### PR TITLE
Fix granule paging.

### DIFF
--- a/edsc/plugins/datasource/cwic/src/js/Granules.jsx
+++ b/edsc/plugins/datasource/cwic/src/js/Granules.jsx
@@ -124,7 +124,15 @@ let CwicGranules = (function() {
 
   CwicGranules.prototype._responseHasNextPage = function(xhr, data, results) {
     let hits = this._responseHits(xhr, data);
-    return parseInt(data.feed.Query.startPage, 10) * parseInt(data.feed.Query.count, 10) < hits;
+    if (data.feed.Query.startPage) {
+      return parseInt(data.feed.Query.startPage, 10) * parseInt(data.feed.Query.count, 10) < hits;
+    }
+    else if (data.feed.Query.startIndex) {
+      return parseInt(data.feed.Query.startIndex, 10) + parseInt(data.feed.Query.count, 10) < hits;
+    }
+    else {
+      return false
+    }
   };
 
   CwicGranules.prototype.loadNextPage = function(params, callback) {


### PR DESCRIPTION
I used the UAT CWIC collection and noticed that the granule paging was broken.
It turns out that for this collection, CWIC responses ```startIndex``` instead of ```startPage```. Hence the ```hasNextPage``` is false.