### PR TITLE
EDSC-1068: Notify users when an order or service submission fails

### DIFF
--- a/app/assets/javascripts/models/ui/feedback.coffee
+++ b/app/assets/javascripts/models/ui/feedback.coffee
@@ -12,5 +12,7 @@ ns.Feedback = do (urlUtil = @edsc.util.url
       else
         feedback.showForm({subject: "[Metadata][#{area}]"})
       false
+    submitError: (area, code) =>
+      feedback.showForm({subject: "[Error][#{area}] #{code}"})
 
   exports = Feedback

--- a/app/assets/stylesheets/modules/data_access.css.scss
+++ b/app/assets/stylesheets/modules/data_access.css.scss
@@ -344,11 +344,11 @@ section.data-access-next {
   color: #fff;
   text-transform: capitalize;
 
-  &.processing, &.validated, &.quoted {
+  &.closed, &.complete {
     background: #27ae60;
   }
 
-  &.canceled, &.cancelling, &.submit_rejected, &.submit_failed, &.quote_rejected, &.quote_failed, &.not_validated {
+  &.failed, &.canceled, &.cancelling, &.submit_rejected, &.submit_failed, &.quote_rejected, &.quote_failed, &.not_validated {
     background: #e74c3c;
   }
 }

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -77,21 +77,21 @@ class DataAccessController < ApplicationController
             order['order_status'] = echo_order['state']
           else
             # echo order_id doesn't exist yet
-            order['order_status'] = 'creating'
+            order['order_status'] ||= 'creating'
           end
         end
       end
       # if no order numbers exist yet
       if order_response.nil?
         orders.each do |order|
-          order['order_status'] = 'creating'
+          order['order_status'] ||= 'creating'
         end
       end
     end
 
     if service_orders.size > 0
       service_orders.each do |s|
-        s['order_status'] = 'submitting'
+        s['order_status'] = 'creating'
         s['service_options'] = {}
 
         if !s['error_code'].blank?

--- a/app/views/data_access/_access_error.html.erb
+++ b/app/views/data_access/_access_error.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <p><strong>Error: </strong> <span data-bind="text: error_code"></span></p>
+  <p><strong>Message: </strong> <span data-bind="text: error_message"></span></p>
+  <% if Rails.configuration.feedback_url.present? %>
+    <p>
+      <a href="#" data-bind="click: $root.ui.feedback.submitError.bind($data, 'Data Access', $data.error_code)" class="button feedback-button">
+        <i class="fa fa-exclamation-circle"></i>
+        Report this error
+      </a>
+    </p>
+  <% end %>
+</div>

--- a/app/views/data_access/retrieval.html.erb
+++ b/app/views/data_access/retrieval.html.erb
@@ -65,6 +65,9 @@
             <span class="order-state" data-bind="css: order_status, text: order_status"></span>
             <!-- /ko -->
           </p>
+          <!-- ko if: order_status == 'failed' -->
+          <%= render partial: 'access_error' %>
+          <!-- /ko -->
           <div class="data-access-collection-actions">
             <!-- ko if: downloadBrowseUrl -->
             <a class="button text-button" href="#" target="_blank" data-bind="attr: {href: downloadBrowseUrl}">View Browse Image Links</a>
@@ -119,19 +122,7 @@
             </div>
             <!-- /ko -->
             <!-- ko if: order_status == 'failed' -->
-            <div>
-              <p><strong>Error: </strong> <span data-bind="text: error_code"></span></p>
-              <p><strong>Message: </strong> <span data-bind="text: error_message"></span></p>
-              <% if Rails.configuration.feedback_url.present? %>
-                <p>Please
-                  <a href="#" data-bind="click: $root.ui.feedback.showFeedback.bind($data, 'Data Access', dataset_id)" class="button feedback-button">
-                    <i class="fa fa-exclamation-circle"></i>
-                    report a problem
-                  </a>
-                  with a short description on how to trigger this error. We will get back to you as soon as possible.
-                 </p>
-              <% end %>
-            </div>
+            <%= render partial: 'access_error' %>
             <!-- /ko -->
             <!-- ko if: is_in_progress -->
             <div>

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -4091,6 +4091,36 @@ http_interactions:
   digest: dbc9515a3f2f90c7c5fdd43e7f27bcf4c974fc71
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=-114.0556640625%2C37.08984375%2C-114.0380859375%2C41.994140625%2C-119.9970703125%2C41.994140625%2C-119.9970703125%2C38.9970703125%2C-118.5732421875%2C38.00390625%2C-117.1318359375%2C36.94921875%2C-115.8486328125%2C35.9736328125%2C-114.6357421875%2C34.998046875%2C-114.6005859375%2C35.0771484375%2C-114.64453125%2C35.103515625%2C-114.57421875%2C35.138671875%2C-114.5654296875%2C35.1826171875%2C-114.6005859375%2C35.349609375%2C-114.6796875%2C35.4990234375%2C-114.6533203125%2C35.595703125%2C-114.7060546875%2C35.7099609375%2C-114.7060546875%2C35.8154296875%2C-114.6796875%2C35.8857421875%2C-114.732421875%2C35.9384765625%2C-114.732421875%2C36.052734375%2C-114.7587890625%2C36.0791015625%2C-114.6357421875%2C36.140625%2C-114.4423828125%2C36.123046875%2C-114.4072265625%2C36.1494140625%2C-114.328125%2C36.10546875%2C-114.2666015625%2C36.0263671875%2C-114.15234375%2C36.0263671875%2C-114.046875%2C36.193359375%2C-114.046875%2C37.001953125%2C-114.0556640625%2C37.08984375&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:05 GMT
+  digest: 366bc39fd2bb1b40da71c61f5eb12e92adb7a523
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=-114.0556640625%2C37.08984375%2C-114.0380859375%2C41.994140625%2C-119.9970703125%2C41.994140625%2C-119.9970703125%2C38.9970703125%2C-118.5732421875%2C38.00390625%2C-117.1318359375%2C36.94921875%2C-115.8486328125%2C35.9736328125%2C-114.6357421875%2C34.998046875%2C-114.6005859375%2C35.0771484375%2C-114.64453125%2C35.103515625%2C-114.57421875%2C35.138671875%2C-114.5654296875%2C35.1826171875%2C-114.6005859375%2C35.349609375%2C-114.6796875%2C35.4990234375%2C-114.6533203125%2C35.595703125%2C-114.7060546875%2C35.7099609375%2C-114.7060546875%2C35.8154296875%2C-114.6796875%2C35.8857421875%2C-114.732421875%2C35.9384765625%2C-114.732421875%2C36.052734375%2C-114.7587890625%2C36.0791015625%2C-114.6357421875%2C36.140625%2C-114.4423828125%2C36.123046875%2C-114.4072265625%2C36.1494140625%2C-114.328125%2C36.10546875%2C-114.2666015625%2C36.0263671875%2C-114.15234375%2C36.0263671875%2C-114.046875%2C36.193359375%2C-114.046875%2C37.001953125%2C-114.0556640625%2C37.08984375&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:02 GMT
+  digest: 363d76c1b8660107f8bcffc88aefaffc0b20b572
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=-165%2C77%2C-173%2C72%2C-168%2C67%2C-159%2C69%2C-165%2C77&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -4149,6 +4179,36 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 26 May 2016 13:15:22 GMT
   digest: 8b755589f5fec2d2193d658ec105325019d3b9e3
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=-54.79606867946356%2C54.394109717072354%2C-29.255528115136542%2C54.394109717072354%2C-30.648648509554363%2C72.50467484450424%2C-46.90171977776248%2C74.36216870372802%2C-59.43980332752301%2C68.32531366125072%2C-54.79606867946356%2C54.394109717072354&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:09 GMT
+  digest: 3f15a7745092c56e74f5066d3df48c0ed7d3d102
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=-54.79606867946356%2C54.394109717072354%2C-29.255528115136542%2C54.394109717072354%2C-30.648648509554363%2C72.50467484450424%2C-46.90171977776248%2C74.36216870372802%2C-59.43980332752301%2C68.32531366125072%2C-54.79606867946356%2C54.394109717072354&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:08 GMT
+  digest: 0a58c6d9d6357eeb24cdca836d217c26abcfbfc0
 - request:
     method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=10%2C10%2C-10%2C-10%2C-10%2C10%2C10%2C-10%2C10%2C10&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&include_has_granules=true&include_granule_counts=true
@@ -4254,6 +4314,36 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 26 May 2016 13:23:21 GMT
   digest: c64abe156e361eabc68778c97a66d269b08ac4db
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=100%2C0%2C101%2C0%2C101%2C1%2C100%2C1%2C100%2C0&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:15 GMT
+  digest: 0e0b742ebf02e2c627f721be27ddaed3d5cd2336
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?polygon=100%2C0%2C101%2C0%2C101%2C1%2C100%2C1%2C100%2C0&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:17:13 GMT
+  digest: 547d9410786ec3128cdab9f0abc42e7ebd2fae2f
 - request:
     method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?temporal=%2C1970-12-01T00%3A00%3A00.000Z&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=entry_title&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&include_has_granules=true&include_granule_counts=true

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -281,6 +281,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: browse_only=true&concept_id=C179003030-ORNL_DAAC&end_date=1988-10-26T00%3A00%3A00.000Z&exclude%5Becho_granule_id%5D%5B%5D=G179111301-ORNL_DAAC&interval=day&start_date=1985-10-24T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Fri, 03 Jun 2016 18:20:47 GMT
+  digest: e3ae73f0a97dcd0656ff2993f479ce4d570f9bd8
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: browse_only=true&concept_id=C179003030-ORNL_DAAC&end_date=1989-03-05T00%3A00%3A00.000Z&exclude%5Becho_granule_id%5D%5B%5D=G179111301-ORNL_DAAC&interval=day&start_date=1986-03-03T00%3A00%3A00.000Z
     headers:
       User-Agent:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -351,6 +351,28 @@ abe1485607c534520cc458d534217ecfdd354174:
       encoding: UTF-8
       string: '[{"concept-id":"C14758250-LPDAAC_ECS","intervals":[[1330387200,1383004800,317111],[1383091200,1383609600,2678],[1383696000,1425254400,246920]]}]'
     http_version: 
+e3ae73f0a97dcd0656ff2993f479ce4d570f9bd8:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Fri, 03 Jun 2016 18:20:47 GMT
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 7b761e32-9f9d-4507-8946-970d55ed2982
+      content-length:
+      - '2'
+      connection:
+      - close
+      server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 2aff1aee74489afdecc2923c97463686d0e64367:
   response:
     status:

--- a/spec/features/data_access/data_download_spec.rb
+++ b/spec/features/data_access/data_download_spec.rb
@@ -47,7 +47,6 @@ describe "Data download page", reset: false do
       click_on 'Continue'
       choose 'Download'
       click_on 'Submit'
-      wait_for_xhr
     end
 
     it "displays a section for additional resources and documentation", intermittent: 1 do
@@ -276,7 +275,6 @@ describe "Data download page", reset: false do
 
       # Confirm address
       click_on 'Submit'
-      wait_for_xhr
     end
 
     it "displays no information on direct downloads" do
@@ -330,7 +328,6 @@ describe "Data download page", reset: false do
 
       choose 'Download'
       click_on 'Submit'
-      wait_for_xhr
     end
 
     it "displays no information on direct downloads" do


### PR DESCRIPTION
Some notes:

The notification is presented on the page, rather than via email, since I'd expect it to appear within a few seconds of the page loading. It comes with an error code that gets printed out for ops to reference in the logs.

All errors from submission get logged with patterns that make them easy to find via splunk. It could, in theory, be possible for an error to occur outside of the try/catch bounds we use to present error messages to the user, but it'd have to come from something obscure and global, like a coding error or database failure. Those would not be displayed to the user (because in that scope, there's no object to attach them to) but they'd still get logged.