### PR TITLE
Avoid FOIA Redirect Page by Direct Link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,7 @@
           <span class="version">v <strong><%= Rails.configuration.version %></strong></span> •
           <strong>NASA Official:</strong> Andrew Mitchell •
           <span class="nasa-links">
-            <a href="http://www.hq.nasa.gov/office/pao/FOIA/agency/">FOIA</a> •
+            <a href="http://www.nasa.gov/FOIA/index.html">FOIA</a> •
             <a href="http://www.nasa.gov/about/highlights/HP_Privacy.html#.Uu-qOHddVm0">NASA Privacy Policy</a> •
             <a href="http://www.usa.gov">USA.gov</a>
           </span>


### PR DESCRIPTION
The existing FOIA link resolves to a [(presumably) old URL](http://www.hq.nasa.gov/office/pao/FOIA/agency/), one which does a meta redirect to [the new page](http://www.nasa.gov/FOIA/index.html).  Instead of routing FOIA request through the old URL, it is probably better to simply link to the new FOIA page.

This could be classified as a low-impact change, as it only affects one link on the main application layout.