### PR TITLE
EDSC-1165: Added 'find' functionality to arrays where it is not provided by the browser

### DIFF
--- a/app/assets/javascripts/util/array.js.coffee
+++ b/app/assets/javascripts/util/array.js.coffee
@@ -9,3 +9,13 @@
 
   exports =
     pairs: pairs
+
+  if Array::find == undefined
+
+    Array::find = (callback, thisArg) ->
+      i = 0
+      while i < @length
+        if callback.call(thisArg or window, @[i], i, this)
+          return @[i]
+        i++
+      undefined

--- a/app/assets/javascripts/util/array.js.coffee
+++ b/app/assets/javascripts/util/array.js.coffee
@@ -10,12 +10,12 @@
   exports =
     pairs: pairs
 
-  if Array::find == undefined
+if Array::find == undefined
 
-    Array::find = (callback, thisArg) ->
-      i = 0
-      while i < @length
-        if callback.call(thisArg or window, @[i], i, this)
-          return @[i]
-        i++
-      undefined
+  Array::find = (callback, thisArg) ->
+    i = 0
+    while i < @length
+      if callback.call(thisArg or window, @[i], i, this)
+        return @[i]
+      i++
+    undefined


### PR DESCRIPTION
Ticket 1165 describes an issue wherein a page does not load due within IE11.  Investigation revealed use of 'find' function applied to arrays - a function that is (surprisingly) not implemented in all Internet Explorer versions (though it was finally added in Edge).

The answer then was to provide a support function that provides the 'find' capability in the instance that the browser does not naturally provide it.