### PR TITLE
EDSC-1214: Removed granule filter from href

### DIFF
--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -25,6 +25,13 @@ class DataAccessController < ApplicationController
     if !@back_path || ! %r{^/[\w/]*$}.match(@back_path)
       @back_path = '/search/collections'
     end
+
+    #This block removes the granule filter per EDSC-1214
+    @paramsWithoutGranuleFilter = request.query_string
+    params = CGI.parse(@paramsWithoutGranuleFilter) 
+    params.delete('sgd')
+    @paramsWithoutGranuleFilter = URI.encode_www_form(params).to_s
+    @paramsWithoutGranuleFilter = URI.unescape(@paramsWithoutGranuleFilter)
   end
 
   def retrieve

--- a/app/views/data_access/configure.html.erb
+++ b/app/views/data_access/configure.html.erb
@@ -9,7 +9,7 @@
 
 <div class="data-access">
   <nav class="data-access-nav">
-    <a href="<%= @back_path %>?<%= request.query_string %>">
+    <a href="<%= @back_path %>?<%= @paramsWithoutGranuleFilter %>">
       <i class="fa fa-arrow-circle-o-left"></i> Back to Search Session
     </a>
   </nav>

--- a/spec/features/data_access/single_granule_access_spec.rb
+++ b/spec/features/data_access/single_granule_access_spec.rb
@@ -36,6 +36,10 @@ describe 'Single Granule Data Access', reset: false do
       expect(page).to have_content "1 Granule"
     end
 
+    it 'does not have granule filter in back url' do
+      expect(find_link('Back to Search Session')[:href]).not_to include("&sgd=")
+    end
+
     it 'limits the data access to only the selected granule' do
       click_link 'Expand List'
       expect(page).to have_content 'FIFE_RAIN_30M.72981621.r30'


### PR DESCRIPTION
Added code to remove the granule filter from the link returning to collection results.