### PR TITLE
EDSC-1200: Added Faraday rescue for connection failure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_filter :validate_portal
 
   rescue_from Faraday::Error::TimeoutError, with: :handle_timeout
-  rescue_from Faraday::Error::ConnectionFailed, with: :handle_connectionfailed
+  rescue_from Faraday::Error::ConnectionFailed, with: :handle_connection_failed
 
   def redirect_from_urs
     last_point = session[:last_point]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_filter :validate_portal
 
   rescue_from Faraday::Error::TimeoutError, with: :handle_timeout
+  rescue_from Faraday::Error::ConnectionFailed, with: :handle_connectionfailed
 
   def redirect_from_urs
     last_point = session[:last_point]
@@ -74,6 +75,12 @@ class ApplicationController < ActionController::Base
   def handle_timeout
     if request.xhr?
       render json: {errors: {error: 'The server took too long to complete the request'}}, status: 504
+    end
+  end
+
+  def handle_connectionfailed
+    if request.xhr?
+      render json: {errors: {error: 'SSL Certificate Failed'}}, status: 504
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   before_filter :validate_portal
 
   rescue_from Faraday::Error::TimeoutError, with: :handle_timeout
-  rescue_from Faraday::Error::ConnectionFailed, with: :handle_connectionfailed
 
   def redirect_from_urs
     last_point = session[:last_point]
@@ -76,35 +75,6 @@ class ApplicationController < ActionController::Base
     if request.xhr?
       render json: {errors: {error: 'The server took too long to complete the request'}}, status: 504
     end
-  end
-
-  def handle_connectionfailed
-    if request.xhr?
-      render json: {errors: {error: 'SSL Certificate Failed'}}, status: 504
-    else
-      health = Health.new
-      response = {
-          edsc: nil,
-          background_jobs: {
-              delayed_job: health.delayed_job_status,
-              data_load_tags: health.data_load_tags_status,
-              data_load_echo10: health.data_load_echo10_status,
-              data_load_granules: health.data_load_granules_status,
-              colormaps_load: health.colormap_load_status,
-          },
-          dependencies: {
-              echo: health.echo_status(echo_client),
-              cmr: health.cmr_status(echo_client),
-              cmr_search: health.cmr_search_status(echo_client),
-              opensearch: health.opensearch_status(echo_client),
-              browse_scaler: health.browse_scaler_status(echo_client),
-              urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
-          }
-      }
-      response[:edsc] = health.edsc_status
-      respond_with(response, status: :ok)
-      #
-    end 
   end
 
   def token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,7 +81,30 @@ class ApplicationController < ActionController::Base
   def handle_connectionfailed
     if request.xhr?
       render json: {errors: {error: 'SSL Certificate Failed'}}, status: 504
-    end
+    else
+      health = Health.new
+      response = {
+          edsc: nil,
+          background_jobs: {
+              delayed_job: health.delayed_job_status,
+              data_load_tags: health.data_load_tags_status,
+              data_load_echo10: health.data_load_echo10_status,
+              data_load_granules: health.data_load_granules_status,
+              colormaps_load: health.colormap_load_status,
+          },
+          dependencies: {
+              echo: health.echo_status(echo_client),
+              cmr: health.cmr_status(echo_client),
+              cmr_search: health.cmr_search_status(echo_client),
+              opensearch: health.opensearch_status(echo_client),
+              browse_scaler: health.browse_scaler_status(echo_client),
+              urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
+          }
+      }
+      response[:edsc] = health.edsc_status
+      respond_with(response, status: :ok)
+      #
+    end 
   end
 
   def token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,8 +78,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def handle_connectionfailed
-    render json: {errors: {error: 'Faraday::Error::ConnectionFailed: Likely SSL Certificate Failure'}}, status: 504
+  def handle_connection_failed
+    render json: {errors: {error: 'Faraday::Error::ConnectionFailed: Likely SSL Certificate Failure'}}, status: 500
   end
 
   def token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_filter :validate_portal
 
   rescue_from Faraday::Error::TimeoutError, with: :handle_timeout
+  rescue_from Faraday::Error::ConnectionFailed, with: :handle_connectionfailed
 
   def redirect_from_urs
     last_point = session[:last_point]
@@ -75,6 +76,10 @@ class ApplicationController < ActionController::Base
     if request.xhr?
       render json: {errors: {error: 'The server took too long to complete the request'}}, status: 504
     end
+  end
+
+  def handle_connectionfailed
+    render json: {errors: {error: 'Faraday::Error::ConnectionFailed: Likely SSL Certificate Failure'}}, status: 504
   end
 
   def token

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -18,7 +18,7 @@ class HealthController < ApplicationController
             cmr_search: health.cmr_search_status(echo_client),
             opensearch: health.opensearch_status(echo_client),
             browse_scaler: health.browse_scaler_status(echo_client),
-            urs: health.urs_status(echo_client, params[:urs_test])}
+            urs: health.urs_status(echo_client)}
     }
     response[:edsc] = health.edsc_status
     respond_with(response, status: :ok)

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -25,30 +25,26 @@ class HealthController < ApplicationController
   end
 
   def redoHealthCheck
-    if request.xhr?
-      render json: {errors: {error: 'SSL Certificate Failed'}}, status: 504
-    else
-      health = Health.new
-      response = {
-          edsc: nil,
-          background_jobs: {
-              delayed_job: health.delayed_job_status,
-              data_load_tags: health.data_load_tags_status,
-              data_load_echo10: health.data_load_echo10_status,
-              data_load_granules: health.data_load_granules_status,
-              colormaps_load: health.colormap_load_status,
-          },
-          dependencies: {
-              echo: health.echo_status(echo_client),
-              cmr: health.cmr_status(echo_client),
-              cmr_search: health.cmr_search_status(echo_client),
-              opensearch: health.opensearch_status(echo_client),
-              browse_scaler: health.browse_scaler_status(echo_client),
-              urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
-          }
-      }
-      response[:edsc] = health.edsc_status
-      respond_with(response, status: :ok)
-    end 
+    health = Health.new
+    response = {
+        edsc: nil,
+        background_jobs: {
+            delayed_job: health.delayed_job_status,
+            data_load_tags: health.data_load_tags_status,
+            data_load_echo10: health.data_load_echo10_status,
+            data_load_granules: health.data_load_granules_status,
+            colormaps_load: health.colormap_load_status,
+        },
+        dependencies: {
+            echo: health.echo_status(echo_client),
+            cmr: health.cmr_status(echo_client),
+            cmr_search: health.cmr_search_status(echo_client),
+            opensearch: health.opensearch_status(echo_client),
+            browse_scaler: health.browse_scaler_status(echo_client),
+            urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
+        }
+    }
+    response[:edsc] = health.edsc_status
+    respond_with(response, status: :ok)
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,7 @@
 class HealthController < ApplicationController
   respond_to :json
 
-  def index
+  def index 
     health = Health.new
     response = {
         edsc: nil,
@@ -18,7 +18,7 @@ class HealthController < ApplicationController
             cmr_search: health.cmr_search_status(echo_client),
             opensearch: health.opensearch_status(echo_client),
             browse_scaler: health.browse_scaler_status(echo_client),
-            urs: health.urs_status(echo_client)}
+            urs: health.urs_status(echo_client, params[:urs_test])}
     }
     response[:edsc] = health.edsc_status
     respond_with(response, status: :ok)

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 class HealthController < ApplicationController
   respond_to :json
-
+  rescue_from Faraday::Error::ConnectionFailed, with: :redoHealthCheck
   def index
     health = Health.new
     response = {
@@ -22,5 +22,33 @@ class HealthController < ApplicationController
     }
     response[:edsc] = health.edsc_status
     respond_with(response, status: :ok)
+  end
+
+  def redoHealthCheck
+    if request.xhr?
+      render json: {errors: {error: 'SSL Certificate Failed'}}, status: 504
+    else
+      health = Health.new
+      response = {
+          edsc: nil,
+          background_jobs: {
+              delayed_job: health.delayed_job_status,
+              data_load_tags: health.data_load_tags_status,
+              data_load_echo10: health.data_load_echo10_status,
+              data_load_granules: health.data_load_granules_status,
+              colormaps_load: health.colormap_load_status,
+          },
+          dependencies: {
+              echo: health.echo_status(echo_client),
+              cmr: health.cmr_status(echo_client),
+              cmr_search: health.cmr_search_status(echo_client),
+              opensearch: health.opensearch_status(echo_client),
+              browse_scaler: health.browse_scaler_status(echo_client),
+              urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
+          }
+      }
+      response[:edsc] = health.edsc_status
+      respond_with(response, status: :ok)
+    end 
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 class HealthController < ApplicationController
   respond_to :json
-  rescue_from Faraday::Error::ConnectionFailed, with: :redoHealthCheck
+
   def index
     health = Health.new
     response = {
@@ -19,30 +19,6 @@ class HealthController < ApplicationController
             opensearch: health.opensearch_status(echo_client),
             browse_scaler: health.browse_scaler_status(echo_client),
             urs: health.urs_status(echo_client)}
-    }
-    response[:edsc] = health.edsc_status
-    respond_with(response, status: :ok)
-  end
-
-  def redoHealthCheck
-    health = Health.new
-    response = {
-        edsc: nil,
-        background_jobs: {
-            delayed_job: health.delayed_job_status,
-            data_load_tags: health.data_load_tags_status,
-            data_load_echo10: health.data_load_echo10_status,
-            data_load_granules: health.data_load_granules_status,
-            colormaps_load: health.colormap_load_status,
-        },
-        dependencies: {
-            echo: health.echo_status(echo_client),
-            cmr: health.cmr_status(echo_client),
-            cmr_search: health.cmr_search_status(echo_client),
-            opensearch: health.opensearch_status(echo_client),
-            browse_scaler: health.browse_scaler_status(echo_client),
-            urs: {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
-        }
     }
     response[:edsc] = health.edsc_status
     respond_with(response, status: :ok)

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,7 @@
 class HealthController < ApplicationController
   respond_to :json
 
-  def index 
+  def index
     health = Health.new
     response = {
         edsc: nil,

--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -75,8 +75,8 @@ class Health
     ok? res, res.body.present? && !res.body.downcase.include?("down")
   end
 
-  def urs_status(echo_client, urs_test = false)
-    res = echo_client.get_urs_availability(urs_test)
+  def urs_status(echo_client)
+    res = echo_client.get_urs_availability()
     (res.respond_to? :success? ) ? (ok? res) : res
   end
 

--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -76,8 +76,8 @@ class Health
   end
 
   def urs_status(echo_client)
-    # check login page
-    ok? echo_client.get_urs_availability
+    res = echo_client.get_urs_availability
+    (res.respond_to? :success? ) ? (ok? res) : res
   end
 
   private

--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -75,8 +75,8 @@ class Health
     ok? res, res.body.present? && !res.body.downcase.include?("down")
   end
 
-  def urs_status(echo_client)
-    res = echo_client.get_urs_availability
+  def urs_status(echo_client, urs_test = false)
+    res = echo_client.get_urs_availability(urs_test)
     (res.respond_to? :success? ) ? (ok? res) : res
   end
 

--- a/lib/echo/urs_client.rb
+++ b/lib/echo/urs_client.rb
@@ -1,7 +1,10 @@
 module Echo
+  
   class UrsClient < BaseClient
     def get_urs_availability
       connection.get("/")
+    rescue Faraday::Error::ConnectionFailed
+      {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
     end
 
     def urs_login_path(callback_url=ENV['urs_callback_url'])

--- a/lib/echo/urs_client.rb
+++ b/lib/echo/urs_client.rb
@@ -1,8 +1,12 @@
 module Echo
   
   class UrsClient < BaseClient
-    def get_urs_availability
-      connection.get("/")
+    def get_urs_availability(urs_test = false)
+      if urs_test == "true"
+        connection.get("https://expired.badssl.com")
+      else
+        connection.get("/") 
+      end
     rescue Faraday::Error::ConnectionFailed
       {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
     end

--- a/lib/echo/urs_client.rb
+++ b/lib/echo/urs_client.rb
@@ -1,12 +1,8 @@
 module Echo
   
   class UrsClient < BaseClient
-    def get_urs_availability(urs_test = false)
-      if urs_test == "true"
-        connection.get("https://expired.badssl.com")
-      else
-        connection.get("/") 
-      end
+    def get_urs_availability
+      connection.get("/") 
     rescue Faraday::Error::ConnectionFailed
       {'ok?' => false, 'error' => 'Faraday::Error::ConnectionFailed (SSL Certificate Failed)'}
     end

--- a/spec/controllers/health_spec.rb
+++ b/spec/controllers/health_spec.rb
@@ -71,10 +71,11 @@ describe HealthController, type: :controller do
         CronJobHistory.delete_all
       end
 
+      
+
       it "returns a json response indicating edsc is not ok" do
         mock_client = Object.new
         allow(Echo::Client).to receive(:client_for_environment).and_return(mock_client)
-
         res = MockResponse.edsc_dependency({"availability"=>"NO"})
         expect(mock_client).to receive(:get_echo_availability).and_return(res)
         res = MockResponse.edsc_dependency({"ok?"=>true})
@@ -100,6 +101,14 @@ describe HealthController, type: :controller do
         expect(json['background_jobs']['data_load_granules']).to eq({"ok?"=>true})
         expect(json['background_jobs']['data_load_tags']).to eq({"ok?"=>true})
         expect(json['background_jobs']['colormaps_load']).to eq({"ok?"=>true})
+      end
+    end
+
+    context "when the SSL Certificate held by URS fails" do
+      it "recovers from the exception and reports the failure" do
+        get :index, urs_test: "true", format: 'json'
+        json = JSON.parse response.body
+        expect(json['dependencies']['urs']).to eq({"ok?"=>false, "error"=>"Faraday::Error::ConnectionFailed (SSL Certificate Failed)"})
       end
     end
 

--- a/spec/controllers/health_spec.rb
+++ b/spec/controllers/health_spec.rb
@@ -71,8 +71,6 @@ describe HealthController, type: :controller do
         CronJobHistory.delete_all
       end
 
-      
-
       it "returns a json response indicating edsc is not ok" do
         mock_client = Object.new
         allow(Echo::Client).to receive(:client_for_environment).and_return(mock_client)

--- a/spec/helpers/mock_response.rb
+++ b/spec/helpers/mock_response.rb
@@ -13,6 +13,10 @@ class MockResponse
     MockResponse.new(body, {}, 200)
   end
 
+  def self.connection_failed(body)
+    MockResponse.new(body, {}, 500)
+  end
+
   def self.connection_timeout(body)
     MockResponse.new(body, {}, 503)
   end


### PR DESCRIPTION
A rescue method has been added to urs_client which will recover from a Faraday::Error::ConnectionFailed exception and will return the appropriate error.

To convenience testing, a parameter hook has been provided that can be used to trigger this error.  This technique uses the external site https://expired.badssl.com to throw the exception.  To trigger the error in the health check, try: http://edsc.dev/health?urs_test=true

