### PR TITLE
EDSC-1235: Removed unnecessary call which was causing the granules table to blink

### DIFF
--- a/edsc/plugins/datasource/cwic/src/js/Granules.jsx
+++ b/edsc/plugins/datasource/cwic/src/js/Granules.jsx
@@ -128,6 +128,7 @@ let CwicGranules = (function() {
       this._loadOsdd(() => this._load(params, current, callback));
       return;
     }
+
     let url = this._urlFor(params);
     this.abort();
     this.isLoading(true);
@@ -173,7 +174,7 @@ let CwicGranules = (function() {
     this.currentRequest = ajax(xhrOpts);
   };
 
-  CwicGranules.prototype._parseOsdd = function (doc) {
+  CwicGranules.prototype._parseOsdd = function (doc, callback) {
 
     let urls = doc.getElementsByTagNameNS(xmlNamespaces.os, 'Url');
     for (let i = 0; i < urls.length; i++) {
@@ -184,6 +185,7 @@ let CwicGranules = (function() {
         };
       }
     }
+    if (callback) callback();
     return null;
   };
 
@@ -196,7 +198,7 @@ let CwicGranules = (function() {
       url: this.osddPath,
       retry: () => this._loadOsdd(callback),
       success: (data, status, xhr) => {
-        this.osdd(this._parseOsdd(data));
+        this.osdd(this._parseOsdd(data, callback));
       },
       complete: () => {
         this.isLoading(!this.currentRequest);

--- a/edsc/plugins/datasource/cwic/src/js/Granules.jsx
+++ b/edsc/plugins/datasource/cwic/src/js/Granules.jsx
@@ -197,7 +197,6 @@ let CwicGranules = (function() {
       retry: () => this._loadOsdd(callback),
       success: (data, status, xhr) => {
         this.osdd(this._parseOsdd(data));
-        if (callback) callback();
       },
       complete: () => {
         this.isLoading(!this.currentRequest);

--- a/edsc/plugins/datasource/cwic/src/js/Granules.jsx
+++ b/edsc/plugins/datasource/cwic/src/js/Granules.jsx
@@ -128,7 +128,6 @@ let CwicGranules = (function() {
       this._loadOsdd(() => this._load(params, current, callback));
       return;
     }
-
     let url = this._urlFor(params);
     this.abort();
     this.isLoading(true);


### PR DESCRIPTION
This is a quick add-on for EDSC-1235.  When a collection is being viewed and the granules are loading, the granules table would 'blink' (as in, appear, disappear, and then re-appear) very rapidly upon loading.  This is only with CWIC collections (so far as is known).

The 'callback' function that was removed from the AJAX success condition stored the function _load - which loads the data again.  Since it is a success callback, it only happens when the data is already successfully loaded!  It appears as if this call was actually causing granule data to load _twice_ within the table, and this was causing the 'blink'.

This particular blink bug is currently on production and so can be viewed by looking up 'USGS_EDC_EO1_ALI' (for convenience: https://search.earthdata.nasa.gov/search/granules?p=C1220566654-USGS_LTA&tl=1463858789!4!!&q=USGS_EDC_EO1_ALI&ok=USGS_EDC_EO1_ALI).  When the collection data is retrieved, watch the table of granules on the left - it will load, blink out of existence, then reappear.  Typically it will still be on 'loading granules' when it first disappears.

Testing seems to show this second '_load' is not necessary - granules appear just fine after its removal.  Local testing was done with CWIC collections USGS_EDC_EO1_ALI (which has many granules) and collection AIRX2RET_NRT (which has 0 granules).  Neither table blinks any longer and app behavior is fine.