### PR TITLE
EDSC-1313 Fix text color on data access configure page.

### DIFF
--- a/app/assets/stylesheets/modules/data_access.css.scss
+++ b/app/assets/stylesheets/modules/data_access.css.scss
@@ -249,6 +249,7 @@ section.data-access-next {
 
   &.panel-body {
     padding: 0 0 10px 0;
+    color: #333;
   }
 
   > * {


### PR DESCRIPTION
Go to /data/configure. The text color of access methods is #fff due to the recent facet list css changes.