### PR TITLE
EDSC-1352: Initial fix for multiple collections having appropriate options in data access

### DIFF
--- a/app/assets/javascripts/models/data/project.js.coffee
+++ b/app/assets/javascripts/models/data/project.js.coffee
@@ -54,12 +54,11 @@ ns.Project = do (ko,
   ])
 
   class ProjectCollection
-    constructor: (@collection, @meta={}) ->
+    constructor: (@collection, @index, @meta={}) ->
       @collection.reference()
       @meta.color ?= colorPool.next()
-
       @granuleAccessOptions = ko.asyncComputed({}, 100, @_loadGranuleAccessOptions, this)
-      @serviceOptions = new ServiceOptionsModel(@granuleAccessOptions)
+      @serviceOptions = new ServiceOptionsModel(@granuleAccessOptions, @index)
 
     dispose: ->
       colorPool.unuse(@meta.color) if colorPool.has(@meta.color)
@@ -143,7 +142,7 @@ ns.Project = do (ko,
       unless current?.collection == collection
         current?.dispose()
         if collection?
-          projectCollection = new ProjectCollection(collection)
+          projectCollection = new ProjectCollection(collection, Object.keys(@_collectionsById).length)
         observable(projectCollection)
 
     getCollections: ->
@@ -155,7 +154,7 @@ ns.Project = do (ko,
       for ds, i in collections
         id = ds.id
         collectionIds.push(id)
-        collectionsById[id] = @_collectionsById[id] ? new ProjectCollection(ds)
+        collectionsById[id] = @_collectionsById[id] ? new ProjectCollection(ds, Object.keys(collectionIds).length)
       @_collectionsById = collectionsById
       @_collectionIds(collectionIds)
       null
@@ -185,8 +184,7 @@ ns.Project = do (ko,
 
     addCollection: (collection) ->
       id = collection.id
-
-      @_collectionsById[id] ?= new ProjectCollection(collection)
+      @_collectionsById[id] ?= new ProjectCollection(collection, Object.keys(@_collectionsById).length)
       @_collectionIds.remove(id)
       @_collectionIds.push(id)
       null

--- a/app/assets/javascripts/models/data/project.js.coffee
+++ b/app/assets/javascripts/models/data/project.js.coffee
@@ -154,7 +154,7 @@ ns.Project = do (ko,
       for ds, i in collections
         id = ds.id
         collectionIds.push(id)
-        collectionsById[id] = @_collectionsById[id] ? new ProjectCollection(ds, Object.keys(collectionIds).length)
+        collectionsById[id] = @_collectionsById[id] ? new ProjectCollection(ds, Object.keys(@_collectionsById).length)
       @_collectionsById = collectionsById
       @_collectionIds(collectionIds)
       null

--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -32,6 +32,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
     constructor: (method, @availableMethods, @index) ->
       @method = ko.observable(method)
       @isValid = ko.observable(true)
+      
       @loadForm = ko.observable(false)
       @loadingForm = ko.computed (item, e) =>
         if @loadForm()

--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -68,7 +68,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
         clickedMethod = m
         break
 
-      echoformContainer = document.getElementsByClassName('access-form')[@index]
+      echoformContainer = if @index then document.getElementsByClassName('access-form')[@index] else document.getElementsByClassName('access-form')[0]
       if clickedMethod.type == 'service' || clickedMethod.type == 'order'
         @loadForm(true) if clickedMethod.type == 'service'
         setTimeout (=>
@@ -106,7 +106,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
       if jsonObj.type == 'service' || jsonObj.type == 'order'
         echoformContainer = null
         checkExistsTimer = setInterval (=>
-          echoformContainer = document.getElementsByClassName('access-form')[0]
+          echoformContainer = if @index then document.getElementsByClassName('access-form')[@index] else document.getElementsByClassName('access-form')[0]
           if echoformContainer
             clearTimeout checkExistsTimer
             setTimeout (=>

--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -32,7 +32,6 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
     constructor: (method, @availableMethods, @index) ->
       @method = ko.observable(method)
       @isValid = ko.observable(true)
-      
       @loadForm = ko.observable(false)
       @loadingForm = ko.computed (item, e) =>
         if @loadForm()

--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -29,12 +29,11 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
       this
 
   class ServiceOptions
-    constructor: (method, @availableMethods) ->
+    constructor: (method, @availableMethods, @index) ->
       @method = ko.observable(method)
       @isValid = ko.observable(true)
-
+      
       @loadForm = ko.observable(false)
-
       @loadingForm = ko.computed (item, e) =>
         if @loadForm()
           timer = setTimeout((=>
@@ -69,7 +68,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
         clickedMethod = m
         break
 
-      echoformContainer = document.getElementsByClassName('access-form')[0]
+      echoformContainer = document.getElementsByClassName('access-form')[@index]
       if clickedMethod.type == 'service' || clickedMethod.type == 'order'
         @loadForm(true) if clickedMethod.type == 'service'
         setTimeout (=>
@@ -107,7 +106,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
       if jsonObj.type == 'service' || jsonObj.type == 'order'
         echoformContainer = null
         checkExistsTimer = setInterval (=>
-          echoformContainer = document.getElementsByClassName('access-form')[0]
+          echoformContainer = document.getElementsByClassName('access-form')[@index]
           if echoformContainer
             clearTimeout checkExistsTimer
             setTimeout (=>
@@ -126,7 +125,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
       this
 
   class ServiceOptionsModel extends KnockoutModel
-    constructor: (@granuleAccessOptions) ->
+    constructor: (@granuleAccessOptions, @index) ->
       @accessMethod = ko.observableArray()
       @isLoaded = @computed
         read: =>
@@ -136,7 +135,6 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
           @_onAccessOptionsLoad(opts) if result
           result
         deferEvaluation: true
-
       @canAddAccessMethod = ko.observable(false)
       @readyToDownload = @computed(@_computeIsReadyToDownload, this, deferEvaluation: true)
 
@@ -165,8 +163,8 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
         return false if m.loadForm()
       true
 
-    addAccessMethod: =>
-      @accessMethod.push(new ServiceOptions(null, @granuleAccessOptions().methods))
+    addAccessMethod: => 
+      @accessMethod.push(new ServiceOptions(null, @granuleAccessOptions().methods, @index))
 
     removeAccessMethod: (method) =>
       @accessMethod.remove(method)

--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -106,7 +106,7 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
       if jsonObj.type == 'service' || jsonObj.type == 'order'
         echoformContainer = null
         checkExistsTimer = setInterval (=>
-          echoformContainer = document.getElementsByClassName('access-form')[@index]
+          echoformContainer = document.getElementsByClassName('access-form')[0]
           if echoformContainer
             clearTimeout checkExistsTimer
             setTimeout (=>

--- a/spec/features/data_access/data_access_workflow_spec.rb
+++ b/spec/features/data_access/data_access_workflow_spec.rb
@@ -8,6 +8,66 @@ describe "Data Access workflow", reset: false do
   non_downloadable_collection_id = 'C179001887-SEDAC'
   non_downloadable_collection_title = '2000 Pilot Environmental Sustainability Index (ESI)'
 
+  test_collection_1 = 'C90762182-LAADS'
+  test_collection_2 = 'C1000000560-NSIDC_ECS'
+  test_collection_3 = 'C1000000561-NSIDC_ECS'
+
+  let(:echo_id) { "4C0390AF-BEE1-32C0-4606-66CAFDD4131D" }
+
+  context "when a user has three or more collections within a project" do
+    before(:all) do
+      load_page :search, project: [test_collection_1, test_collection_2, test_collection_3], view: :project
+      login
+      click_link "Download project data"
+      wait_for_xhr
+    end
+
+    context "when clicking 'FtpPushPull'on the first collection" do
+      before(:all) do
+        within '.access-item-selection:nth-child(1)' do
+          choose 'FtpPushPull'
+        end
+        wait_for_xhr
+      end
+      it "displays the distribution options for the first collection" do
+        expect(page).to have_text('Distribution Options')
+      end
+      context "and then clicking continue and selecting 'AE_SI12.3 ESI Service' for the second collection" do
+        before(:all) do
+          click_button "Continue"
+          wait_for_xhr
+          # the tooManyGranulesModal is taking its time showing up, and this unfortunate sleep is the only way (so far) to get it behave
+          sleep(1)
+          find_by_id("tooManyGranulesModal").click_link("Continue")
+          wait_for_xhr
+          within '.access-item-selection:nth-child(1)' do
+            choose 'AE_SI12.3 ESI Service'
+          end
+          wait_for_xhr
+        end
+        it "displays the option subsettings for the second collection" do
+          within '.access-form' do
+            expect(page).to have_text('Include Metadata and Processing History')
+          end
+        end
+        context "and then clicking continue and selecting 'AE_SI6.3 ESI Service' for the third collection" do
+          before(:all) do
+            click_button "Continue"
+            wait_for_xhr
+            within '.access-item-selection:nth-child(1)' do
+              choose 'AE_SI6.3 ESI Service'
+            end
+            wait_for_xhr
+          end
+          it "displays the option subsetting for the third collection" do
+            within '.access-form' do
+              expect(page).to have_text('Include Metadata and Processing History')
+            end
+          end
+        end
+      end
+    end
+  end
   context "when a malicious user attempts an XSS attack using the data access back link" do
     before(:all) do
       load_page :root

--- a/spec/features/data_access/ordering_with_many_granules_spec.rb
+++ b/spec/features/data_access/ordering_with_many_granules_spec.rb
@@ -26,6 +26,7 @@ describe 'Access data with more than 2000 granules', reset: false do
       context "and selecting 'ESI service' option" do
         before :all do
           choose 'AE_SI6.3 ESI Service'
+          wait_for_xhr
           fill_in 'Email Address', with: "patrick+edsc@element84.com\t"
           click_on 'Continue'
         end

--- a/spec/features/users/missing_preferences_spec.rb
+++ b/spec/features/users/missing_preferences_spec.rb
@@ -14,6 +14,7 @@ describe "User missing ordering preferences", reset: false do
       click_link "Download project data"
 
       choose "FtpPushPull"
+      wait_for_xhr
       select 'FtpPull', from: 'Distribution Options'
       click_button "Continue"
     end


### PR DESCRIPTION
The issue was that the service options model was hard-coded to use container at index 0 for the suboptions; also, each model had no way of knowing its index within the page.

The answer then was to add a new parameter from the Project Collection perspective and then cascade the index to the suboptions model.