### PR TITLE
EDSC-1352: Updated migration file to convert value from string to tex…

### DIFF
--- a/db/migrate/20160422011745_add_echoform_digest_to_access_configuration.rb
+++ b/db/migrate/20160422011745_add_echoform_digest_to_access_configuration.rb
@@ -1,5 +1,5 @@
 class AddEchoformDigestToAccessConfiguration < ActiveRecord::Migration
   def change
-    add_column :access_configurations, :echoform_digest, :string
+    add_column :access_configurations, :echoform_digest, :text
   end
 end

--- a/db/migrate/20160422011745_add_echoform_digest_to_access_configuration.rb
+++ b/db/migrate/20160422011745_add_echoform_digest_to_access_configuration.rb
@@ -1,5 +1,5 @@
 class AddEchoformDigestToAccessConfiguration < ActiveRecord::Migration
   def change
-    add_column :access_configurations, :echoform_digest, :text
+    add_column :access_configurations, :echoform_digest, :string
   end
 end

--- a/db/migrate/20170316054224_change_echoform_digest_to_text.rb
+++ b/db/migrate/20170316054224_change_echoform_digest_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeEchoformDigestToText < ActiveRecord::Migration
+  def change
+  	change_column :access_configurations, :echoform_digest, :text
+  end
+end


### PR DESCRIPTION
EDSC-1352 fixes a bug with the 'Add Access Option' feature in project retrievals; previously, only one form would be shown at a time.  Adding a new access option wrote over the previous form, which meant the user could only see the form for the most recent access option - this was confusing.

The fix for this ticket included code so as adding additional access options created a whole new form without writing over the previous one.

However, a bug has arisen in SIT where a 500 error is being thrown due to a field (I believe it's echoform_digest) being longer than expected.  It bursts the limit of :string, which is 255, and so updating the migration file to :text - which is more open length - may fix the error (or it may reveal a second bug hidden behind this bug).