### PR TITLE
EDSC-1361: Updated search page object to properly grab URL parameters…

### DIFF
--- a/app/assets/javascripts/models/page/search_page.js.coffee
+++ b/app/assets/javascripts/models/page/search_page.js.coffee
@@ -20,6 +20,7 @@ ns = models.page
 ns.SearchPage = do (ko
                     ajax = @edsc.util.xhr.ajax
                     setCurrent = ns.setCurrent
+                    urlUtil = @edsc.util.url
                     QueryModel = data.query.CollectionQuery
                     CollectionsModel = data.Collections
                     ProjectModel = data.Project
@@ -56,7 +57,7 @@ ns.SearchPage = do (ko
         projectList: new ProjectListModel(@project, @collections)
         isLandingPage: ko.observable(null) # Used by modules/landing
         feedback: new FeedbackModel()
-
+      @project.serialized(urlUtil.currentParams())
       @bindingsLoaded = ko.observable(false)
       @labs = ko.observable(false)
 
@@ -71,7 +72,6 @@ ns.SearchPage = do (ko
 
       @outputFileFormats = ko.observableArray([])
       @chosenOutputFileFormat = ko.observable(@query.outputFormat())
-
       @reprojectionOptions = ko.observableArray([])
       @chosenReprojectionOption = ko.observable(@query.reprojectionOption())
 
@@ -80,7 +80,6 @@ ns.SearchPage = do (ko
 
       @interpolationMethods = ko.observableArray([])
       @chosenInterpolationMethod = ko.observable(@query.interpolationMethod())
-
       @chosenMeasurement = ko.observable()
       @checkedVariables = ko.observableArray([])
 
@@ -201,6 +200,7 @@ ns.SearchPage = do (ko
           $('#variables-modal').modal('show') unless $('#variables-modal').is(':visible')
 
     getCustomizeOptions: =>
+
       ajax
         dataType: 'json'
         url: "/customize_options"


### PR DESCRIPTION
… within constructor

The issue was that the new label showing 'custom data' format was not being populated when the page was reloaded, or when the output_format was included in the URL.

I found that it did not appear the parameters were being read within the search page constructor; once that was done, the label and drop down began to work as expected.