### PR TITLE
ORNL DAAC Portal: change text in heading

### DIFF
--- a/config/portals.yml
+++ b/config/portals.yml
@@ -29,7 +29,7 @@ portals: &portals
       
   ornldaac:
     org: ORNL DAAC
-    title: ORNL DAAC
+    title: Search
     params:
       data_center:
         - ORNL_DAAC


### PR DESCRIPTION
change text in heading to ORNL DAAC/Search instead of ORNL DAAC/ORNL DAAC
Search is used on main EDSC