### PR TITLE
EDSC-1504: Fixing Portal Access

### DIFF
--- a/app/assets/javascripts/models/page/search_page.js.coffee
+++ b/app/assets/javascripts/models/page/search_page.js.coffee
@@ -130,7 +130,10 @@ ns.SearchPage = do (ko
 
     showProject: (data, event) =>
       $('#view-project').click()
-
+  
+  loc = window.location.pathname
+  if loc.indexOf("portal") >= 0 && loc.slice(-6) != "search" && loc.slice(-1) != '/'
+    window.location.replace(loc + '/search' + window.location.search);
   current = new SearchPage()
   setCurrent(current)
 


### PR DESCRIPTION
The issue is that the old scheme of /portals/[portal ID] became somewhat broken when we removed the landing page and set '/search' as our new forward page.  The portals functionality mirrors that of general functionality; it, too, must now end in '/search' to function properly.

This patch forwards portal calls without '/search' - as it used to be - to the new route.  