### PR TITLE
EDSC-1482: Backing out of initial solution for hiding user tokens

### DIFF
--- a/app/presenters/collection_details_presenter_echo10.rb
+++ b/app/presenters/collection_details_presenter_echo10.rb
@@ -46,15 +46,16 @@ class CollectionDetailsPresenterEcho10 < DetailsPresenterEcho10
     @collection.associated_difs = associated_difs(collection.associated_difs)
 
     metadata_url = "#{Rails.configuration.services['earthdata'][env]['cmr_root']}/search/concepts/#{@collection.id}"
-    @collection.html_url = "#{metadata_url}.html"
-    @collection.native_url = "#{metadata_url}.native"
-    @collection.atom_url = "#{metadata_url}.atom"
-    @collection.echo10_url = "#{metadata_url}.echo10"
-    @collection.iso19115_url = "#{metadata_url}.iso19115"
-    @collection.dif_url = "#{metadata_url}.dif"
+    url_token = "?token=#{token}:#{client_id(env)}" if token
+    @collection.html_url = "#{metadata_url}.html#{url_token}"
+    @collection.native_url = "#{metadata_url}.native#{url_token}"
+    @collection.atom_url = "#{metadata_url}.atom#{url_token}"
+    @collection.echo10_url = "#{metadata_url}.echo10#{url_token}"
+    @collection.iso19115_url = "#{metadata_url}.iso19115#{url_token}"
+    @collection.dif_url = "#{metadata_url}.dif#{url_token}"
     @collection.smap_iso_url = nil #"#{metadata_url}.smap_iso"
     opensearch_url = "#{Rails.configuration.services['earthdata'][env]['opensearch_root']}/granules/descriptor_document.xml"
-    @collection.osdd_url = "#{opensearch_url}?utf8=%E2%9C%93&clientId=#{Rails.configuration.cmr_client_id}&shortName=#{URI.encode_www_form_component(@collection.short_name)}&versionId=#{@collection.version_id}&dataCenter=#{URI.encode_www_form_component(data_center)}&commit=Generate"
+    @collection.osdd_url = "#{opensearch_url}?utf8=%E2%9C%93&clientId=#{Rails.configuration.cmr_client_id}&shortName=#{URI.encode_www_form_component(@collection.short_name)}&versionId=#{@collection.version_id}&dataCenter=#{URI.encode_www_form_component(data_center)}&commit=Generate#{url_token}"
 
     # Set description to URL if URLDescription doesn't exist
     @collection.online_access_urls = [] if @collection.online_access_urls.nil?

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -32,17 +32,18 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
     @collection[:granule_url] = "#{Rails.configuration.services['earthdata'][env]['cmr_root']}/search/granules.json"
 
     metadata_url = "#{Rails.configuration.services['earthdata'][env]['cmr_root']}/search/concepts/#{@collection[:id]}"
-    @collection[:html_url] = "#{metadata_url}.html"
-    @collection[:native_url] = "#{metadata_url}.native"
-    @collection[:atom_url] = "#{metadata_url}.atom"
-    @collection[:echo10_url] = "#{metadata_url}.echo10"
-    @collection[:iso19115_url] = "#{metadata_url}.iso19115"
-    @collection[:dif_url] = "#{metadata_url}.dif"
+    url_token = "?token=#{token}:#{client_id(env)}" if token
+    @collection[:html_url] = "#{metadata_url}.html#{url_token}"
+    @collection[:native_url] = "#{metadata_url}.native#{url_token}"
+    @collection[:atom_url] = "#{metadata_url}.atom#{url_token}"
+    @collection[:echo10_url] = "#{metadata_url}.echo10#{url_token}"
+    @collection[:iso19115_url] = "#{metadata_url}.iso19115#{url_token}"
+    @collection[:dif_url] = "#{metadata_url}.dif#{url_token}"
     @collection[:smap_iso_url] = nil # "#{metadata_url}.smap_iso"
     opensearch_url = "#{Rails.configuration.services['earthdata'][env]['opensearch_root']}/granules/descriptor_document.xml"
     data_center = ''
     data_center = collection_id.split('-').last if collection_id.is_a?(String)
-    @collection[:osdd_url] = "#{opensearch_url}?utf8=%E2%9C%93&clientId=#{Rails.configuration.cmr_client_id}&shortName=#{URI.encode_www_form_component(@collection[:short_name])}&versionId=#{@collection[:version_id]}&dataCenter=#{URI.encode_www_form_component(data_center)}&commit=Generate"
+    @collection[:osdd_url] = "#{opensearch_url}?utf8=%E2%9C%93&clientId=#{Rails.configuration.cmr_client_id}&shortName=#{URI.encode_www_form_component(@collection[:short_name])}&versionId=#{@collection[:version_id]}&dataCenter=#{URI.encode_www_form_component(data_center)}&commit=Generate#{url_token}"
   end
 
   def data_center(data_centers, type)

--- a/app/presenters/granule_details_presenter_echo10.rb
+++ b/app/presenters/granule_details_presenter_echo10.rb
@@ -4,10 +4,11 @@ class GranuleDetailsPresenterEcho10 < DetailsPresenterEcho10
     @granule.id = granule_id
 
     metadata_url = "#{Rails.configuration.services['earthdata'][env]['cmr_root']}/search/concepts/#{@granule.id}"
-    @granule.native_url = "#{metadata_url}"
-    @granule.atom_url = "#{metadata_url}.atom"
-    @granule.echo10_url = "#{metadata_url}.echo10"
-    @granule.iso19115_url = "#{metadata_url}.iso19115"
+    url_token = "?token=#{token}:#{client_id(env)}" if token
+    @granule.native_url = "#{metadata_url}#{url_token}"
+    @granule.atom_url = "#{metadata_url}.atom#{url_token}"
+    @granule.echo10_url = "#{metadata_url}.echo10#{url_token}"
+    @granule.iso19115_url = "#{metadata_url}.iso19115#{url_token}"
 
     xml = @granule.xml.to_xml(:root => 'Granule', :skip_instruct => true, :indent => 2)
     xml.gsub!("<Granule>\n", '') # Remove top level element

--- a/spec/features/collections/collection_metadata_spec.rb
+++ b/spec/features/collections/collection_metadata_spec.rb
@@ -18,21 +18,20 @@ describe 'Collection metadata', reset: false do
     expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.dif"]')
   end
 
-  # EDSC-1482 requires tokens are not included as part of viewable URLs - this test is no longer appropriate
-  #context 'when a logged in user views collection metadata' do
-  #  before do
-  #    login
-  #    wait_for_xhr
-  #    click_link 'Metadata Formats'
-  #  end
+  context 'when a logged in user views collection metadata' do
+    before do
+      login
+      wait_for_xhr
+      click_link 'Metadata Formats'
+    end
 
-  #  it 'provides metadata in multiple formats with user tokens' do
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.html?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.native?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.atom?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.echo10?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.iso19115?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.dif?token=")]')
-  #  end
-  #end
+    it 'provides metadata in multiple formats with user tokens' do
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.html?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.native?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.atom?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.echo10?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.iso19115?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.dif?token=")]')
+    end
+  end
 end

--- a/spec/features/granules/granule_metadata_spec.rb
+++ b/spec/features/granules/granule_metadata_spec.rb
@@ -23,19 +23,18 @@ describe 'Granule metadata' do
     expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.iso19115"]')
   end
 
-  # EDSC-1482 requires tokens are not included as part of viewable URLs - this test is no longer appropriate
-  #context 'when a logged in user views granule metadata' do
-  #  before do
-  #    login
-  #    wait_for_xhr
-  #    click_link 'Metadata'
-  #  end
+  context 'when a logged in user views granule metadata' do
+    before do
+      login
+      wait_for_xhr
+      click_link 'Metadata'
+    end
 
-  #  it 'provides metadata in multiple formats with user tokens' do
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.atom?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.echo10?token=")]')
-  #    expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.iso19115?token=")]')
-  #  end
-  # end
+    it 'provides metadata in multiple formats with user tokens' do
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.atom?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.echo10?token=")]')
+      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/G179111301-ORNL_DAAC.iso19115?token=")]')
+    end
+   end
 end


### PR DESCRIPTION

The solution of simply removing the tokens from the URLs had unintended side effects - this PR backs those changes out so that we can consider alternatives.