### PR TITLE
EDSC-1531: Implemented deferred method to load site tour in order to remove potential race condition

### DIFF
--- a/app/assets/javascripts/models/data/preferences.js.coffee
+++ b/app/assets/javascripts/models/data/preferences.js.coffee
@@ -13,10 +13,11 @@ ns.Preferences = do (ko
       @showTour = ko.observable(true)
       @doNotShowTourAgain = ko.observable('false')
       @isLoaded = ko.observable(false)
-
       @load()
 
     load: ->
+      readyDeferred = new $.Deferred()
+      this.ready = readyDeferred
       data = window.edscprefs
       window.edscprefs = null
 
@@ -28,6 +29,7 @@ ns.Preferences = do (ko
           console.log "Loaded site preferences, #{JSON.stringify(data)}"
           @fromJson(data)
           @isLoaded(true)
+          readyDeferred.resolve()
       null
 
     onload: (fn) ->

--- a/app/assets/javascripts/models/page/search_page.js.coffee
+++ b/app/assets/javascripts/models/page/search_page.js.coffee
@@ -39,7 +39,7 @@ ns.SearchPage = do (ko
   sitetour = new SiteTourModel();
 
   initModal = () ->
-    $('#sitetourModal').modal('show') if sitetour.safePath() && (preferences.doNotShowTourAgain() == 'false' ||  window.location.href.indexOf('?tour=true') != -1)
+    $('#sitetourModal').modal('show') if sitetour.safePath() && (preferences.doNotShowTourAgain() == 'false' || window.location.href.indexOf('?tour=true') != -1)
 
   $(document).ready ->
     current.map = map = new window.edsc.map.Map(document.getElementById('map'), 'geo')
@@ -50,7 +50,7 @@ ns.SearchPage = do (ko
     $('.launch-customize-modal').click ->
       $('#customizeDataModal').modal('show')
 
-    setTimeout initModal, 2000 if !window.edscportal
+    preferences.ready.done(-> initModal()) if !window.edscportal
 
   class SearchPage
     constructor: ->


### PR DESCRIPTION

The site tour can potentially load despite being set to 'not show' due to a potential race condition involving a timer.  This new method of loading the site tour uses a 'deferred method' approach - this method adds precision to how the site tour must load after the user's preferences are fetched, and effectively removes the race condition. 