### PR TITLE
EDSC-1482 Hide token from collection detail source code.

### DIFF
--- a/app/assets/javascripts/models/data/collection.js.coffee
+++ b/app/assets/javascripts/models/data/collection.js.coffee
@@ -291,6 +291,10 @@ ns.Collection = do (ko
       else
         @archive_center
 
+    metadata_url: (collection, e) ->
+      win = window.open(@details()["#{e.target.text.toLowerCase()}_url"], '_blank')
+      win.focus()
+
     fromJson: (jsonObj) ->
       @json = jsonObj
 

--- a/app/views/search/_collection_details.html.erb
+++ b/app/views/search/_collection_details.html.erb
@@ -59,15 +59,15 @@
             <a href="#" data-toggle="dropdown" class="button dropdown-button" aria-expanded="false">Metadata Formats <i class="fa fa-caret-down"></i></a>
             <ul class="dropdown-menu">
               <!-- ko with: $root.ui.collectionsList.selected() -->
-              <li><a class="dropdown-link" data-bind="click: metadata_url">HTML</a></li>
-              <li><a class="dropdown-link" data-bind="click: metadata_url">Native</a></li>
-              <li><a class="dropdown-link" data-bind="click: metadata_url">ATOM</a></li>
-              <li><a class="dropdown-link" data-bind="click: metadata_url">ECHO10</a></li>
-              <li><a class="dropdown-link" data-bind="click: metadata_url">ISO19115</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">HTML</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">Native</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">ATOM</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">ECHO10</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">ISO19115</a></li>
               <!-- ko if: $data.smap_iso_url -->
-              <li><a class="dropdown-link" data-bind="click: metadata_url">SMAP ISO</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">SMAP ISO</a></li>
               <!-- /ko -->
-              <li><a class="dropdown-link" data-bind="click: metadata_url">DIF</a></li>
+              <li><a href='#' class="dropdown-link" data-bind="click: metadata_url">DIF</a></li>
               <!--/ko-->
             </ul>
           </div>

--- a/app/views/search/_collection_details.html.erb
+++ b/app/views/search/_collection_details.html.erb
@@ -58,15 +58,17 @@
           <div class="dropdown detail-dropdown">
             <a href="#" data-toggle="dropdown" class="button dropdown-button" aria-expanded="false">Metadata Formats <i class="fa fa-caret-down"></i></a>
             <ul class="dropdown-menu">
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.html_url }">HTML</a></li>
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.native_url }">Native</a></li>
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.atom_url }">ATOM</a></li>
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.echo10_url }">ECHO10</a></li>
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.iso19115_url }">ISO19115</a></li>
+              <!-- ko with: $root.ui.collectionsList.selected() -->
+              <li><a class="dropdown-link" data-bind="click: metadata_url">HTML</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">Native</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">ATOM</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">ECHO10</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">ISO19115</a></li>
               <!-- ko if: $data.smap_iso_url -->
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.smap_iso_url }">SMAP ISO</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">SMAP ISO</a></li>
               <!-- /ko -->
-              <li><a class="dropdown-link" data-bind="attr: { href: $data.dif_url }">DIF</a></li>
+              <li><a class="dropdown-link" data-bind="click: metadata_url">DIF</a></li>
+              <!--/ko-->
             </ul>
           </div>
           <div class="dropdown detail-dropdown">

--- a/spec/features/collections/collection_metadata_spec.rb
+++ b/spec/features/collections/collection_metadata_spec.rb
@@ -10,12 +10,12 @@ describe 'Collection metadata', reset: false do
   end
 
   it 'provides metadata in multiple formats' do
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.html"]')
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.native"]')
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.atom"]')
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.echo10"]')
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.iso19115"]')
-    expect(page).to have_selector('a[href="https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.dif"]')
+    expect(page).to have_link('HTML')
+    expect(page).to have_link('Native')
+    expect(page).to have_link('ATOM')
+    expect(page).to have_link('ECHO10')
+    expect(page).to have_link('ISO19115')
+    expect(page).to have_link('DIF')
   end
 
   context 'when a logged in user views collection metadata' do
@@ -25,13 +25,12 @@ describe 'Collection metadata', reset: false do
       click_link 'Metadata Formats'
     end
 
-    it 'provides metadata in multiple formats with user tokens' do
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.html?token=")]')
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.native?token=")]')
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.atom?token=")]')
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.echo10?token=")]')
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.iso19115?token=")]')
-      expect(page).to have_xpath('//a[contains(@href, "https://cmr.earthdata.nasa.gov/search/concepts/C179460405-LPDAAC_ECS.dif?token=")]')
+    it 'provides metadata in multiple formats without user tokens' do
+      expect(page).not_to have_xpath('//a[contains(@href, ".html?token=")]')
+      expect(page).not_to have_xpath('//a[contains(@href, ".atom?token=")]')
+      expect(page).not_to have_xpath('//a[contains(@href, ".echo10?token=")]')
+      expect(page).not_to have_xpath('//a[contains(@href, ".iso19115?token=")]')
+      expect(page).not_to have_xpath('//a[contains(@href, ".dif?token=")]')
     end
   end
 end


### PR DESCRIPTION
Find a collection that is visible after logging in. Open collection details page and the metadata dropdown. Mouseover or take a look at the html source, no token should appear.