### PR TITLE
EDSC-1448: Updated dropdown and datepicker behaviors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,3 +345,9 @@ DEPENDENCIES
   unicorn
   vcr
   whenever
+
+RUBY VERSION
+   ruby 2.2.2p95
+
+BUNDLED WITH
+   1.15.3

--- a/app/assets/javascripts/models/page/search_page.js.coffee
+++ b/app/assets/javascripts/models/page/search_page.js.coffee
@@ -89,6 +89,8 @@ ns.SearchPage = do (ko
         @_focus.notifyRenderers('startSearchFocus')
 
     clearFilters: =>
+      # EDSC-1448: The temporal dropdown is 'special' and needs to be programmatically closed...
+      $('#temporal-dropdown.open').removeClass('open');
       @query.clearFilters()
       @ui.spatialType.selectNone()
       @ui.spatialType.clearManualEntry()

--- a/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
+++ b/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
@@ -58,7 +58,7 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
     onChangeDateTime = (dp, $input) ->
       $input.trigger('change')
 
-    root.find('.temporal-range-picker').datepicker
+    root.find('.temporal-range-picker').datepicker(
       format: "yyyy-mm-dd"
       startDate: "1960-01-01"
       endDate: new Date()
@@ -69,6 +69,10 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
       todayHighlight: true
       forceParse: false
       keyboardNavigation: false
+      ).on 'click', (e) ->
+        $('.temporal-filter').click (e) ->
+          e.stopPropagation()
+          return
 
     root.find('.temporal-recurring-picker').datepicker(
       format: "mm-dd"
@@ -83,6 +87,10 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
       keyboardNavigation: false
       ).on 'show', ->
         $(this).data('datepicker').picker.addClass('datepicker-temporal-recurring')
+      ).on 'click', (e) ->
+        $('.temporal-filter').click (e) ->
+          e.stopPropagation()
+          return  
 
     # Set end time to 23:59:59
     DatePickerProto = Object.getPrototypeOf($('.temporal').data('datepicker'))
@@ -156,8 +164,22 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
     $('.temporal-range-stop').datepicker('update')
 
   $(document).ready ->
-    $(".temporal-dropdown-button").on 'click', ->
-      $(this).parents('.dropdown').toggleClass('open')
+    # EDSC-1448: If the spatial dropdown is opened, then the temporal dropdown - if open - should close itself...
+    $("#spatial-dropdown").on 'click', (e) ->
+      $('#temporal-dropdown.open').removeClass('open');
+
+    # EDSC-1448: .keep-open is a special class for the temporal dropdown - the presence of a datepicker
+    # within a dropdown can cause the dropdown to erroneously close when a date is picked.  This prevents that issue.
+
+    $(".dropdown.keep-open").on 'shown.bs.dropdown', (e) ->
+      this.closable = false
+
+    $(".dropdown.keep-open").on 'click', (e) ->
+      this.closable = true
+
+    $(".dropdown.keep-open").on 'hide.bs.dropdown', (e) ->
+      return this.closable
+ 
     $('.collection-temporal-filter').temporalSelectors({
       uiModel: temporalModel,
       modelPath: "query.temporal.pending",

--- a/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
+++ b/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
@@ -87,7 +87,7 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
       keyboardNavigation: false
       ).on 'show', ->
         $(this).data('datepicker').picker.addClass('datepicker-temporal-recurring')
-      ).on 'click', (e) ->
+      .on 'click', (e) ->
         $('.temporal-filter').click (e) ->
           e.stopPropagation()
           return  

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -24,8 +24,8 @@
                  autofocus>
         </p>
       <% end %>
-      <div class="dropdown" id="temporal-dropdown">
-        <a href="#" class="button temporal-dropdown-button dropdown-button" title="Temporal">
+      <div class="dropdown keep-open" id="temporal-dropdown">
+        <a href="#" class="button temporal-dropdown-button dropdown-button" data-toggle="dropdown" title="Temporal">
           <i class="fa fa-clock-o"></i>
           <i class="fa fa-caret-down"></i>
         </a>
@@ -38,7 +38,7 @@
         </ul>
       </div>
 
-      <div class="dropdown" data-bind="with: ui.spatialType">
+      <div class="dropdown" data-bind="with: ui.spatialType" id="spatial-dropdown">
         <a href="#" data-toggle="dropdown" class="button dropdown-button spatial-dropdown-button" title="Spatial"><i class="fa fa-fw" data-bind="css: icon"></i><i class="fa fa-caret-down"></i></a>
         <ul class="dropdown-menu spatial-selection">
           <li><a href="#" class="dropdown-link select-polygon" data-bind="click: selectPolygon" title="Select Polygon"><i class="edsc-icon-poly-open edsc-icon-fw"></i> Polygon</a></li>

--- a/spec/features/temporal/temporal_selection_spec.rb
+++ b/spec/features/temporal/temporal_selection_spec.rb
@@ -12,6 +12,17 @@ describe "Temporal" do
     reset_search
   end
 
+  context 'When opening the temporal dropdown, and then opening the spatial dropdown' do
+    before :all do
+      click_link "Temporal"
+      click_link "Spatial"
+    end
+
+    it 'closes the temporal dropdown' do
+      expect(page).to have_no_content("Start")
+    end
+  end
+
   context "range selection" do
     it "allows the user to search from a start date time to the present" do
       click_link "Temporal"

--- a/spec/features/temporal/temporal_selection_spec.rb
+++ b/spec/features/temporal/temporal_selection_spec.rb
@@ -15,6 +15,7 @@ describe "Temporal" do
   context 'When opening the temporal dropdown, and then opening the spatial dropdown' do
     before :all do
       click_link "Temporal"
+      expect(page).to have_content("Start")
       click_link "Spatial"
     end
 


### PR DESCRIPTION
The issue is that the temporal dropdown is remaining open when the user selects the spatial dropdown or 'clear filters'; this is unexpected behavior for the user.

It's a tricky issue as the dropdown has to have special code to keep it open, as the datepicker within the temporal dropdown will close it unexpectedly when a date is choosen; this special code is what is erroneously keeping the dropdown open when the user clicks the spatial dropdown or 'clear filters'.

The fix was to modify how the dropdown stays open and coordinates with the datepicker, as well as new code triggered by the spatial dropdown and 'clear filters' that programmatically closes the temporal dropdown in the case it is still open.