### PR TITLE
EDSC-1488: Adjusted fix for updating datepicker and dropdown behavior

### DIFF
--- a/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
+++ b/app/assets/javascripts/modules/temporal/temporal_range_selection.js.coffee
@@ -58,7 +58,7 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
     onChangeDateTime = (dp, $input) ->
       $input.trigger('change')
 
-    root.find('.temporal-range-picker').datepicker(
+    root.find('.temporal-range-picker').datepicker
       format: "yyyy-mm-dd"
       startDate: "1960-01-01"
       endDate: new Date()
@@ -69,10 +69,6 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
       todayHighlight: true
       forceParse: false
       keyboardNavigation: false
-      ).on 'click', (e) ->
-        $('.temporal-filter').click (e) ->
-          e.stopPropagation()
-          return
 
     root.find('.temporal-recurring-picker').datepicker(
       format: "mm-dd"
@@ -87,10 +83,7 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
       keyboardNavigation: false
       ).on 'show', ->
         $(this).data('datepicker').picker.addClass('datepicker-temporal-recurring')
-      .on 'click', (e) ->
-        $('.temporal-filter').click (e) ->
-          e.stopPropagation()
-          return  
+      
 
     # Set end time to 23:59:59
     DatePickerProto = Object.getPrototypeOf($('.temporal').data('datepicker'))
@@ -167,6 +160,10 @@ do (document, $=jQuery, edsc_date=@edsc.util.date, temporalModel=@edsc.page.quer
     # EDSC-1448: If the spatial dropdown is opened, then the temporal dropdown - if open - should close itself...
     $("#spatial-dropdown").on 'click', (e) ->
       $('#temporal-dropdown.open').removeClass('open');
+
+    $('.temporal-filter').on 'click', (e) ->
+      e.stopPropagation()
+      return  
 
     # EDSC-1448: .keep-open is a special class for the temporal dropdown - the presence of a datepicker
     # within a dropdown can cause the dropdown to erroneously close when a date is picked.  This prevents that issue.

--- a/spec/features/temporal/temporal_selection_spec.rb
+++ b/spec/features/temporal/temporal_selection_spec.rb
@@ -14,6 +14,7 @@ describe "Temporal" do
 
   context 'When opening the temporal dropdown, and then opening the spatial dropdown' do
     before :all do
+      load_page :search
       click_link "Temporal"
       expect(page).to have_content("Start")
       click_link "Spatial"


### PR DESCRIPTION
This fix moves the 'stopPropagation' routine out from the datepicker declarations in order to allow it to trigger in all applicable cases.  

This update was necessary as, within the previous PR, the stopPropagation routine was not firing in all cases - just  most of them.  This update should fix that issue.