### PR TITLE
EDSC-1371 Fix polygon around pole issue.

### DIFF
--- a/app/assets/javascripts/modules/map/geoutil.js.coffee
+++ b/app/assets/javascripts/modules/map/geoutil.js.coffee
@@ -123,7 +123,7 @@ ns.geoutil = do (L, Coordinate = ns.Coordinate, Arc = ns.Arc, config = @edsc.con
 
     latlngs = (latLng(latlng) for latlng in latlngs)
 
-    # http://www.element84.com/determining-if-a-spherical-polygon-contains-a-pole.html
+    # http://blog.element84.com/determining-if-a-spherical-polygon-contains-a-pole.html
 
     delta = 0
     len = latlngs.length
@@ -154,7 +154,7 @@ ns.geoutil = do (L, Coordinate = ns.Coordinate, Arc = ns.Arc, config = @edsc.con
 
     if delta < -360 + EPSILON
       NORTH_POLE | SOUTH_POLE
-    else if delta < EPSILON
+    else if delta < 180 + EPSILON
       angles = (latlng.lng for latlng in latlngs)
       dir = _rotationDirection(angles)
 

--- a/app/assets/javascripts/modules/map/geoutil.js.coffee
+++ b/app/assets/javascripts/modules/map/geoutil.js.coffee
@@ -121,9 +121,11 @@ ns.geoutil = do (L, Coordinate = ns.Coordinate, Arc = ns.Arc, config = @edsc.con
   containsPole = (latlngs) ->
     return false if latlngs.length < 3
 
-    latlngs = (latLng(latlng) for latlng in latlngs)
-
     # http://blog.element84.com/determining-if-a-spherical-polygon-contains-a-pole.html
+
+    # Add second point to the end per the algorithm
+    latlngs.push latlngs[1]
+    latlngs = (latLng(latlng) for latlng in latlngs)
 
     delta = 0
     len = latlngs.length
@@ -150,11 +152,14 @@ ns.geoutil = do (L, Coordinate = ns.Coordinate, Arc = ns.Arc, config = @edsc.con
 
       delta += delta0 + delta1
 
+    # clean up the added point after calculating 'delta'
+    latlngs.pop()
+
     delta = delta * RAD_TO_DEG
 
     if delta < -360 + EPSILON
       NORTH_POLE | SOUTH_POLE
-    else if delta < 180 + EPSILON
+    else if delta < EPSILON
       angles = (latlng.lng for latlng in latlngs)
       dir = _rotationDirection(angles)
 


### PR DESCRIPTION
See the article for the detail of the algorithm. ~The polygon that the algorithm applied to in our code is not a closed polygon. So 180 degree is added when comparing to the ```delta```.~ In the algorithm, the second point in the array is used to calculate the last delta, heading, and sum. So ```latlngs[1]``` is ```push```ed to the array for calculation and then is ```pop```ed when ```delta``` is summed up.

In our tests, we only verify the existence of the path on the map. Therefore there is no test added.

~* A closed polygon has the same start and end point. For example: (1, 1), (3, 3), (4, 2), (1, 1).~
