### PR TITLE
use portal org for site_name

### DIFF
--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -22,7 +22,7 @@ module PortalHelper
 
   def site_name
     if portal?
-      "#{portal['title'] || portal_id.titleize} Portal"
+      "#{portal['org'] || portal_id.titleize} Portal"
     else
       "Earthdata Search"
     end

--- a/app/helpers/portal_helper.rb
+++ b/app/helpers/portal_helper.rb
@@ -20,6 +20,14 @@ module PortalHelper
     end
   end
 
+  def site_org
+    if portal?
+      "#{portal['org'] || portal_id.titleize}"
+    else
+      "Earthdata Search"
+    end
+  end
+
   def site_name
     if portal?
       "#{portal['org'] || portal_id.titleize} Portal"

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -141,7 +141,7 @@
             <% if portal? %>
             <p class="portal-escape" data-bind="visible: !collections.isLoading()">
               Looking for more collections?
-              <a href="#" data-bind="click: ui.collectionsList.escapePortal" class="portal-escape-link">Leave the <%= site_name %></a>
+              <a href="#" data-bind="click: ui.collectionsList.escapePortal" class="portal-escape-link">Leave <%= site_org %>'s <%= site_name %></a>
             </p>
             <% end %>
           </div>

--- a/spec/features/portals/portal_escape_link_spec.rb
+++ b/spec/features/portals/portal_escape_link_spec.rb
@@ -7,10 +7,10 @@ describe "Portal escape link", reset: false do
     end
 
     it "provides an obvious link to the non-portal view of Earthdata Search which preserves the current filters", acceptance: true do
-      expect(page).to have_link('Leave the Simple Portal')
-      expect(page).to have_text('Looking for more collections? Leave the Simple Portal')
+      expect(page).to have_link("Leave Simple's Simple Portal")
+      expect(page).to have_text("Looking for more collections? Leave Simple's Simple Portal")
 
-      click_link 'Leave the Simple Portal'
+      click_link "Leave Simple's Simple Portal"
       expect(page).to have_no_path_prefix("/portal")
       wait_for_xhr
       expect(page.find_field('keywords').value).to eql('modis')


### PR DESCRIPTION
Action: Updating site_name to use portal org defined in config/portals.yml instead of portal title.

Reasoning: The link at the bottom of portal search results allows a user to escape the portal to the full earthdata-search. This text must get it's wording from the portal title. The text is "Looking for more collections? Leave the Search Portal". This is ambiguous. Preferred is 'Leave the ORNL DAAC Portal'.

To consider: Other uses of 'site_name' seem to make more sense with the updated site_name, although I may have missed something. Here's the list of 'site_name' locations I found:
./node_modules/jodid25519/jsdoc.json
./app/views/data_access/retrieval.html.erb
./app/views/search/index.html.erb
./app/helpers/portal_helper.rb (changed file)