### PR TITLE
EDSC-1531: Updated preferences to use cookie instead of session object in case of anonymous user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,7 +45,6 @@ class UsersController < ApplicationController
 
   def get_site_preferences
     user_id = get_user_id
-
     if user_id
       user = User.where(echo_id: get_user_id).first
       if user
@@ -54,7 +53,7 @@ class UsersController < ApplicationController
         render json: nil, status: :ok
       end
     else
-      site_preferences = session[:site_preferences]
+      site_preferences = cookies[:site_preferences]
       render json: site_preferences, status: :ok
     end
   end
@@ -67,8 +66,11 @@ class UsersController < ApplicationController
       user.save
       render json: user.site_preferences, status: :ok
     else
-      session[:site_preferences] = params[:site_preferences]
-      render json: session[:site_preferences], status: :ok
+      cookies[:site_preferences] = {
+        value: params[:site_preferences].to_json,
+        expires: 10.years.from_now
+      }
+      render json: cookies[:site_preferences], status: :ok
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
 
   def get_site_preferences
     user_id = get_user_id
+    
     if user_id
       user = User.where(echo_id: get_user_id).first
       if user


### PR DESCRIPTION

The site tour is experiencing an issue wherein an **anonymous** user can select 'Do Not Show Again', close the page, and still see the splash screen when revisiting the site some time later.  This is due to the data being stored in the session object, which expires rather quickly.

This fix updates the anonymous user so that the preferences are stored in a cookie with a ten year expiration date.  