### PR TITLE
EDSC-1645: Stripped out occurrences of dx.doi.org stuff in order to make string consistent

### DIFF
--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -49,18 +49,14 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
       doi = doi['DOI']
       # EDSC-1645: This string varies a *lot* - clean up permutations so that we start from the same place...
       doi = doi.gsub(/^https?\:\/\//, '')
-      doi = doi.gsub("dx.dio.org/", '')
-      doi = doi.gsub("dio.org/", '')
-      if doi.match(/^doi:.+/)
-        return {doi_link: "https://dx.doi.org/#{doi.match(/doi:(.+)/)[1]}", doi_text: doi}
-      elsif doi.match(/^[^\s]+(\/[^\s]+){1,}\/?/)
+      doi = doi.gsub("dx.doi.org/", '')
+      doi = doi.gsub("doi.org/", '')
+      if doi.match(/^[^\s]+(\/[^\s]+){1,}\/?/)
         if doi.match('dx.doi.org')
           return {doi_link: "https://#{doi}", doi_text: doi} 
         else
           return {doi_link: "https://dx.doi.org/#{doi}", doi_text: doi}
         end
-      elsif doi.match(/https:\/\/dx\.doi\.org.+/)
-        return {doi_link: doi, doi_text: doi}
       else
         return {doi_text: doi, doi_link: nil}
       end

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -52,8 +52,8 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
       doi = doi.gsub("doi:", '')
       doi = doi.gsub("dx.doi.org/", '')
       doi = doi.gsub("doi.org/", '')
-      if doi.match(/^[^\s]+(\/[^\s]+){1,}\/?/)
-        return {doi_link: "https://#{doi}", doi_text: doi} 
+      if !doi.blank?
+        return {doi_link: "https://dx.doi.org/#{doi}", doi_text: doi} 
       else
         return {doi_text: doi, doi_link: nil}
       end

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -50,6 +50,7 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
       # EDSC-1645: This string varies - clean up permutations so that we start from the same place...
       doi = doi.gsub(/^https?\:\/\//, '')
       doi = doi.gsub("doi:", '')
+      doi = doi.gsub("10.", '')
       doi = doi.gsub("dx.doi.org/", '')
       doi = doi.gsub("doi.org/", '')
       if !doi.blank?

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -50,7 +50,6 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
       # EDSC-1645: This string varies - clean up permutations so that we start from the same place...
       doi = doi.gsub(/^https?\:\/\//, '')
       doi = doi.gsub("doi:", '')
-      doi = doi.gsub("10.", '')
       doi = doi.gsub("dx.doi.org/", '')
       doi = doi.gsub("doi.org/", '')
       if !doi.blank?

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -47,16 +47,13 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
   def doi(doi)
     if doi && doi['DOI']
       doi = doi['DOI']
-      # EDSC-1645: This string varies a *lot* - clean up permutations so that we start from the same place...
+      # EDSC-1645: This string varies - clean up permutations so that we start from the same place...
       doi = doi.gsub(/^https?\:\/\//, '')
+      doi = doi.gsub("doi:", '')
       doi = doi.gsub("dx.doi.org/", '')
       doi = doi.gsub("doi.org/", '')
       if doi.match(/^[^\s]+(\/[^\s]+){1,}\/?/)
-        if doi.match('dx.doi.org')
-          return {doi_link: "https://#{doi}", doi_text: doi} 
-        else
-          return {doi_link: "https://dx.doi.org/#{doi}", doi_text: doi}
-        end
+        return {doi_link: "https://#{doi}", doi_text: doi} 
       else
         return {doi_text: doi, doi_link: nil}
       end

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -47,7 +47,10 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
   def doi(doi)
     if doi && doi['DOI']
       doi = doi['DOI']
+      # EDSC-1645: This string varies a *lot* - clean up permutations so that we start from the same place...
       doi = doi.gsub(/^https?\:\/\//, '')
+      doi = doi.gsub("dx.dio.org/", '')
+      doi = doi.gsub("dio.org/", '')
       if doi.match(/^doi:.+/)
         return {doi_link: "https://dx.doi.org/#{doi.match(/doi:(.+)/)[1]}", doi_text: doi}
       elsif doi.match(/^[^\s]+(\/[^\s]+){1,}\/?/)


### PR DESCRIPTION
The regex based conditionals that originally controlled this string cleansing became unwieldy, and so this patch provides a more direct and simpler solution.  Based upon these values (provided on the ticket):

blank 1 record
doi: 645 records
http://dx.doi.org 122 records
https://doi.org 1 record
10. 2368 records ('10.' is part of the URL and so is 'okay')

The code has been updated to 'clean' the string of these substrings (i.e., 'doi:', 'http://dx.doi.org', 'https://doi.org', ~~and '10.'~~), and then concatenate the remainder with a consistent 'https://dx.doi.org'. 

This has been tested with  'C1200237617-MMT_1' as well as 'C1200230663-MMT_1' (both on SIT).