### PR TITLE
EDSC-1652: Direct Download GA Event

### DIFF
--- a/app/assets/javascripts/models/ui/granules_list.js.coffee
+++ b/app/assets/javascripts/models/ui/granules_list.js.coffee
@@ -57,6 +57,16 @@ ns.GranulesList = do ($=jQuery, config = @edsc.config)->
         # click's mousedown.  Ugh.
         setTimeout((=> @_hasFocus(true)), 500)
 
+      # Track single granule direct downloads
+      $(document).on 'click', 'a.direct-download', ->
+        options = [
+          {"accessMethod": [{
+            "method": "Download",
+            "type": "direct_download"}]
+          }
+        ]
+        $(document).trigger('dataaccessevent', [@collection, options])
+
       @_setupSwipeEvents($granuleList)
       map.focusCollection(@collection)
 

--- a/app/assets/javascripts/models/ui/granules_list.js.coffee
+++ b/app/assets/javascripts/models/ui/granules_list.js.coffee
@@ -61,8 +61,7 @@ ns.GranulesList = do ($=jQuery, config = @edsc.config)->
       $(document).on 'click', 'a.direct-download', ->
         options = [
           {"accessMethod": [{
-            "method": "Download",
-            "type": "direct_download"}]
+            "method": "Single Granule Download"}]
           }
         ]
         $(document).trigger('dataaccessevent', [@collection, options])

--- a/app/views/search/_granule_list.html.erb
+++ b/app/views/search/_granule_list.html.erb
@@ -100,7 +100,7 @@ Delimiters: Separate multiple granule IDs by space, comma, or new line."/>
                 <a href="#" class="button icon-button master-overlay-forward" data-master-overlay-forward="Granules" data-bind="click: $parent.showGranuleDetails" title="View granule details">
                   <i class="fa fa-info-circle"></i>
                 </a>
-                <a class="button icon-button" title="Download single granule data" target="_blank" data-bind="visible: !$parent.collection.cwic() && online_access_flag, attr: {href: download_now_url()}">
+                <a class="button icon-button direct-download" title="Download single granule data" target="_blank" data-bind="visible: !$parent.collection.cwic() && online_access_flag, attr: {href: download_now_url()}">
                   <i class="fa fa-download"></i>
                 </a>
                 <a href="#" class="button icon-button" title="Configure and download single granule data"  data-bind="click: $root.ui.projectList.loginAndDownloadGranule.bind($data, $parent.collection)">


### PR DESCRIPTION
I'd like someone to review this to see if I'm on the right track. I added a click event to the download button and had that trigger a `dataaccessevent` with a new Download method type called "direct_download." This should still populate the data access metric, but now we'll have a breakdown under download for this type.

I'm about 90% sure I've used the right methods from the other metrics calls, but I'd like someone with more experience on the GA side to take a look.