### PR TITLE
EDSC-1641 Download all #data links in a zip.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ gem 'daemons'
 
 gem 'nokogiri'
 gem 'responders', '~> 2.0'
+gem 'rubyzip', '>= 1.0.0'
 
 # Eventually we'll need these, but there's version conflict when installing
 #gem 'crossroadsjs-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.5.0)
+    rubyzip (1.2.1)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -335,6 +336,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
+  rubyzip (>= 1.0.0)
   sass-rails (~> 4.0.0)
   seed_dump
   sqlite3
@@ -350,4 +352,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/assets/javascripts/config.js.coffee.erb
+++ b/app/assets/javascripts/config.js.coffee.erb
@@ -54,6 +54,7 @@
     asterCollections: limited_collections
     enableEsiOrderChunking: enable_esi_order_chunking
     reverb_url: reverb_url
+    cmr_env: cmr_env
 
   <% elsif Rails.env.development? %>
 
@@ -78,6 +79,7 @@
     asterCollections: limited_collections
     enableEsiOrderChunking: enable_esi_order_chunking
     reverb_url: reverb_url
+    cmr_env: cmr_env
 
   <% else %>
   # Production config
@@ -100,5 +102,6 @@
     asterCollections: limited_collections
     enableEsiOrderChunking: enable_esi_order_chunking
     reverb_url: reverb_url
+    cmr_env: cmr_env
 
   <% end %>

--- a/app/assets/javascripts/models/data/granule.coffee
+++ b/app/assets/javascripts/models/data/granule.coffee
@@ -23,8 +23,7 @@
       null
 
     download_now_url: ->
-      return link.href for link in @links when link.rel.indexOf('/data#') != -1 if @links? && @links.length > 0
-      '#'
+      "/granules/single_download/#{@id}?cmr_env=#{edsc.config.cmr_env}"
 
     onThumbError: (granule) ->
       @browseError(true)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -29,7 +29,7 @@ class CollectionsController < ApplicationController
   def show
     metrics_event('details', {collections: [params[:id]]})
     #TODO make 1_4 configurable (yml + ENV)
-    response = echo_client.get_collection(params[:id], token, 'umm_json_v1_9')
+    response = echo_client.get_concept(params[:id], token, 'umm_json_v1_9')
 
 
     if response.success?

--- a/app/models/opendap_configuration.rb
+++ b/app/models/opendap_configuration.rb
@@ -33,7 +33,7 @@ class OpendapConfiguration
   def self.prototype_ddx(collection_or_id, client, token=nil)
     collection = collection_or_id
     if collection.is_a?(String)
-      collection_response = client.get_collection(collection, token, 'json')
+      collection_response = client.get_concept(collection, token, 'json')
       return nil unless collection_response.success?
       collection = collection_response.body
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ EarthdataSearchClient::Application.routes.draw do
   end
   post 'collections/collection_relevancy' => 'collections#collection_relevancy'
 
+  get 'granules/single_download/:id' => 'granules#single_download'
+
   resources :granules, only: [:create, :show], defaults: {format: 'json'} do
     collection do
       post 'timeline'

--- a/lib/echo/cmr_client.rb
+++ b/lib/echo/cmr_client.rb
@@ -23,7 +23,7 @@ module Echo
       post("/search/collections.#{format}?#{options.to_param}", query.to_json, token_header(token))
     end
 
-    def get_collection(id, token = nil, format = 'echo10')
+    def get_concept(id, token = nil, format = 'echo10')
       get("/search/concepts/#{id}.#{format}", {}, token_header(token))
     end
 

--- a/spec/echo/client_spec.rb
+++ b/spec/echo/client_spec.rb
@@ -53,7 +53,7 @@ describe Echo::Client do
     it 'with valid collection ID' do
       expect(connection).to receive(:get).with(collection_url, {}).and_return(resp)
 
-      response = cmr_client.get_collection('C14758250-LPDAAC_ECS', nil, 'umm_json_v1_9')
+      response = cmr_client.get_concept('C14758250-LPDAAC_ECS', nil, 'umm_json_v1_9')
       expect(response.faraday_response).to eq(resp)
     end
 
@@ -64,7 +64,7 @@ describe Echo::Client do
       expect(body).to receive(:granule_url=).with(granule_url)
       expect(body).to receive(:granule_url).and_return(granule_url)
 
-      response = cmr_client.get_collection('C14758250-LPDAAC_ECS')
+      response = cmr_client.get_concept('C14758250-LPDAAC_ECS')
       expect(response.body[0].granule_url).to_not be_nil
     end
   end

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -36,7 +36,7 @@ describe "Granule list", reset: false do
     it 'provides a button to download single granule' do
       within '#granules-scroll .panel-list-item:nth-child(1)' do
         expect(page).to have_link('Download single granule data')
-        expect(page).to have_css('a[href="https://n5eil01u.ecs.nsidc.org/DP5/MOST/MOD10A1.005/2017.01.01/MOD10A1.A2017001.h34v09.005.2017003060855.hdf"]')
+        expect(page).to have_css('a[href~="/granules/single_download/G1360367376-NSIDC_ECS?cmr_env=prod"]')
       end
     end
 


### PR DESCRIPTION
The example collection in the ticket times out when retrieving its links (firewall issue??). Plus, you may not even be able to see the collection due to ACL setups.

As an alternative, ```C1200237736-MMT_1``` was created in SIT with one granule that has two #data links.

Note that the feature doesn't have a test since we don't have any tests that verify the downloaded content in the past (capybara-webkit won't allow us to. See here: https://forum.shakacode.com/t/how-to-test-file-downloads-with-capybara/347). The existing test that verifies the download link, however, has been updated.