### PR TITLE
EDSC-1648: Removed unnecessary escape characters

### DIFF
--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -81,9 +81,9 @@ prompt_credentials() {
     read -p "Username (<%= @user %>): " username
     username=${username:-<%= @user %>}
     read -s -p "Password: " password
-    echo "\nmachine urs.earthdata.nasa.gov\tlogin $username\tpassword $password" >> $netrc
+    echo "machine urs.earthdata.nasa.gov login $username password $password" >> $netrc
     <% if @first_link && @first_link.start_with?('ftp') %>
-    echo "\nmachine <%= @first_link[/ftp:\/\/([^\/]*)\/.*/, 1] %>\tlogin $username\tpassword $password" >> $netrc
+    echo "machine <%= @first_link[/ftp:\/\/([^\/]*)\/.*/, 1] %> login $username password $password" >> $netrc
     <% end %>
     echo
 }

--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -44,8 +44,11 @@
 <div id="errors"></div>
 <div id="loading">Preparing download script. Fetching downloadable granule links...</div>
 <div id="download-description" style="display: none;">
-  <p>Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a></p>
+  <h2>How to use this script</h2>
+  <p>Linux: You must first make the script an executable by running the line 'chmod 777 download.sh' from the command line.  After that is complete, the file can be executed by typing './download.sh'.</p>
+  <p>Windows: The file can be executed within Windows by first installing a Unix-like command line utility such as <a href='https://www.cygwin.com/'>Cygwin</a>. After installing Cygwin (or a similar utility), run the line 'chmod 777 download.sh' from the utility's command line, and then execute by typing './download.sh'.</p>
   <p>For a detailed walk through of this process, please reference this <a target="_blank" href='https://wiki.earthdata.nasa.gov/display/EDSC/How+To%3A+Use+the+Download+Access+Script'>How To guide</a>.</p>
+  Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a>
 </div>
 <div class="pre-container">
   <pre id="script">

--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -45,9 +45,10 @@
 <div id="loading">Preparing download script. Fetching downloadable granule links...</div>
 <div id="download-description" style="display: none;">
   <h2>How to use this script</h2>
-  <p>Linux: You must first make the script an executable by running the line 'chmod 777 download.sh' from the command line.  After that is complete, the file can be executed by typing './download.sh'.</p>
-  <p>Windows: The file can be executed within Windows by first installing a Unix-like command line utility such as <a href='https://www.cygwin.com/'>Cygwin</a>. After installing Cygwin (or a similar utility), run the line 'chmod 777 download.sh' from the utility's command line, and then execute by typing './download.sh'.</p>
+  <p>Linux: You must first make the script an executable by running the line 'chmod 777 download.sh' from the command line.  After that is complete, the file can be executed by typing './download.sh'.</p> 
   <p>For a detailed walk through of this process, please reference this <a target="_blank" href='https://wiki.earthdata.nasa.gov/display/EDSC/How+To%3A+Use+the+Download+Access+Script'>How To guide</a>.</p>
+  <p>Windows: The file can be executed within Windows by first installing a Unix-like command line utility such as <a href='https://www.cygwin.com/'>Cygwin</a>. After installing Cygwin (or a similar utility), run the line 'chmod 777 download.sh' from the utility's command line, and then execute by typing './download.sh'.</p>
+  
   Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a>
 </div>
 <div class="pre-container">

--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -43,7 +43,12 @@
 <body>
 <div id="errors"></div>
 <div id="loading">Preparing download script. Fetching downloadable granule links...</div>
-<div id="download-description" style="display: none;">Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a></div>
+<div id="download-description" style="display: none;">
+  <h2>How to use this script</h2>
+  <p>Linux: You must first make the script an executable by running the line 'chmod 777 download.sh' from the command line.  After that is complete, the file can be executed by typing './download.sh'.</p>
+  <p>Windows: The file can be executed within Windows by first installing a Unix-like command line utility such as <a href='https://www.cygwin.com/'>Cygwin</a>. After installing Cygwin (or a similar utility), run the line 'chmod 777 download.sh' from the utility's command line, and then execute by typing './download.sh'.</p>
+  Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a>
+</div>
 <div class="pre-container">
   <pre id="script">
 #!/bin/sh
@@ -126,7 +131,7 @@ prompt_credentials
 }
 
 fetch_urls <<'EDSCEOF'
-  </pre>
+</pre>
 </div>
 <ul id="links">
 </ul>
@@ -181,7 +186,7 @@ fetch_urls <<'EDSCEOF'
 
       document.getElementById('loading').style.display = 'none';
       document.getElementById('download-button').style.display = 'inline';
-      document.getElementById('download-description').style.display = 'inline';
+      document.getElementById('download-description').style.display = 'inherit';
     }
 
     function onLoad() {
@@ -191,9 +196,9 @@ fetch_urls <<'EDSCEOF'
       var links = doc.links;
       preContent = document.getElementById('script');
       preContent.innerHTML += links.join("\n");
-      preContent.innerHTML += '\n'
       var next = getNextPageUrl();
       if (next) {
+        preContent.innerHTML += '\n'
         fetchLinks(next);
       }
       else {

--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -44,10 +44,8 @@
 <div id="errors"></div>
 <div id="loading">Preparing download script. Fetching downloadable granule links...</div>
 <div id="download-description" style="display: none;">
-  <h2>How to use this script</h2>
-  <p>Linux: You must first make the script an executable by running the line 'chmod 777 download.sh' from the command line.  After that is complete, the file can be executed by typing './download.sh'.</p>
-  <p>Windows: The file can be executed within Windows by first installing a Unix-like command line utility such as <a href='https://www.cygwin.com/'>Cygwin</a>. After installing Cygwin (or a similar utility), run the line 'chmod 777 download.sh' from the utility's command line, and then execute by typing './download.sh'.</p>
-  Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a>
+  <p>Script preparation completed. Please click the button to download the script. <a href="#" id="download-button">Download Script File</a></p>
+  <p>For a detailed walk through of this process, please reference this <a target="_blank" href='https://wiki.earthdata.nasa.gov/display/EDSC/How+To%3A+Use+the+Download+Access+Script'>How To guide</a>.</p>
 </div>
 <div class="pre-container">
   <pre id="script">

--- a/spec/features/collections/collection_results_spec.rb
+++ b/spec/features/collections/collection_results_spec.rb
@@ -103,7 +103,7 @@ describe "Collection results", reset: false do
   it "doesn't' show version_id for collections that don't have one" do
     fill_in "keywords", with: 'C1214605943-SCIOPS'
     wait_for_xhr
-    expect(page).to have_no_content("vNot provided")
+    expect(page).to have_no_content("Not provided")
   end
 
   it "indicates if a collection's data collection is ongoing" do


### PR DESCRIPTION

If the user attempts to execute a script using 'bash', then the login was previously failing due to how bash interprets escape characters.  Removing them fixed the issue; further, using the other method of 'chmod 777' and then ./download.sh seems unaffected (meaning, works fine).

With this patch a user will be able to execute the download script with a simple 'bash download.sh' without setting the chmod.