### PR TITLE
EDSC-1648: Fixed bug with using 'bash'

### DIFF
--- a/app/views/granules/prepare_script.html.erb
+++ b/app/views/granules/prepare_script.html.erb
@@ -81,9 +81,9 @@ prompt_credentials() {
     read -p "Username (<%= @user %>): " username
     username=${username:-<%= @user %>}
     read -s -p "Password: " password
-    echo "\nmachine urs.earthdata.nasa.gov\tlogin $username\tpassword $password" >> $netrc
+    echo "machine urs.earthdata.nasa.gov login $username password $password" >> $netrc
     <% if @first_link && @first_link.start_with?('ftp') %>
-    echo "\nmachine <%= @first_link[/ftp:\/\/([^\/]*)\/.*/, 1] %>\tlogin $username\tpassword $password" >> $netrc
+    echo "machine <%= @first_link[/ftp:\/\/([^\/]*)\/.*/, 1] %> login $username password $password" >> $netrc
     <% end %>
     echo
 }


### PR DESCRIPTION
If the user attempts to execute a download script using 'bash', then the login was previously failing due to how bash interprets escape characters. Removing them from the script fixed the issue; further, using the other method of 'chmod 777' and then ./download.sh seems unaffected (meaning, works fine either way).

With this patch a user will be able to execute the download script with a simple 'bash download.sh' without setting the chmod first.