### PR TITLE
EDSC-1683: Setting X-Frame-Options to 'Deny'

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module EarthdataSearchClient
     config.autoload_paths += Dir["#{config.root}/app/services", "#{config.root}/app/services/**/"]
     config.eager_load_paths += Dir["#{config.root}/app/services", "#{config.root}/app/services/**/"]
 
-    config.action_dispatch.default_headers['X-Frame-Options'] = "ALLOW-FROM https://[scriptdomain]"
+    config.action_dispatch.default_headers['X-Frame-Options'] = "DENY"
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module EarthdataSearchClient
     config.autoload_paths += Dir["#{config.root}/app/services", "#{config.root}/app/services/**/"]
     config.eager_load_paths += Dir["#{config.root}/app/services", "#{config.root}/app/services/**/"]
 
+    config.action_dispatch.default_headers['X-Frame-Options'] = "ALLOW-FROM https://[scriptdomain]"
+
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]


### PR DESCRIPTION
This PR sets the x-frame-options to 'DENY' in an effort to pass certain security script checks.