### PR TITLE
EDSC 1725: Created filter to remove 'FTP' duplicate links in granule downloads

### DIFF
--- a/app/assets/javascripts/models/data/granule.coffee
+++ b/app/assets/javascripts/models/data/granule.coffee
@@ -26,8 +26,12 @@
 
     download_now_urls: ->
       links = []
+      done = []
       if @links? && @links.length > 0
-        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.inherited != true
+        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('http') != -1 && link.inherited != true
+        done.push(link.rel.replace("https", "ftp").replace(".html", "")) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('http://') != -1 && link.inherited != true
+        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('ftp://') != -1 && done.indexOf(link.rel) == -1
+
       @dataLinks(links)
 
     onThumbError: (granule) ->

--- a/app/assets/javascripts/models/data/granule.coffee
+++ b/app/assets/javascripts/models/data/granule.coffee
@@ -26,11 +26,15 @@
 
     download_now_urls: ->
       links = []
-      done = []
+      filter = []
       if @links? && @links.length > 0
-        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('http') != -1 && link.inherited != true
-        done.push(link.rel.replace("https", "ftp").replace(".html", "")) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('http://') != -1 && link.inherited != true
-        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.rel.indexOf('ftp://') != -1 && done.indexOf(link.rel) == -1
+        # Step one - add all links that are 'http' and are not inherited
+        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.href.indexOf('http') != -1 && link.inherited != true
+        # Step two - create 'filter' array which stores the file names of all previous http links
+        filter.push(link.href.substr(link.href.lastIndexOf('/') + 1).replace(".html", "")) for link in @links when link.rel.indexOf('/data#') != -1 && link.href.indexOf('http') != -1 && link.inherited != true
+        # Step three - add all links that are 'ftp' which call filenames that are *not* in the filter (meaning, have not already
+        # been added with an http link)
+        links.push(link) for link in @links when link.rel.indexOf('/data#') != -1 && link.href.indexOf('ftp://') != -1 && filter.indexOf(link.href.substr(link.href.lastIndexOf('/') + 1)) == -1 && link.inherited != true
 
       @dataLinks(links)
 

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -430,6 +430,21 @@ http_interactions:
   digest: 13d605a9f672361f03e5381042498b50352410e8
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1000000042-LANCEAMSR2&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:36:54 GMT
+  digest: fd2e39c3b95be90aed579909f01820e84dd7ef3d
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1000000300-NSIDC_ECS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -808,6 +823,21 @@ http_interactions:
   digest: e4c527a54dbec0699399034d221d108c55038745
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1444742099-PODAAC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:40:09 GMT
+  digest: da818a5e03375b857555d9d60c14d488eedfcc93
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C14758250-LPDAAC_ECS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -1116,6 +1146,21 @@ http_interactions:
       - edsc
   recorded_at: Mon, 06 Jun 2016 22:08:56 GMT
   digest: 75c38fbfc57d3b3775c8599e9c503661b212711f
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C179003380-ORNL_DAAC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:36:47 GMT
+  digest: 3548062835cfba0aa31b255b218124406576e1ed
 - request:
     method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C179003620-ORNL_DAAC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
@@ -5035,6 +5080,21 @@ http_interactions:
   digest: 755b26e5447705cd259bdb50bfb0e641c6786c40
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000000042-LANCEAMSR2%2A&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:36:56 GMT
+  digest: 88bb6803246fb9b2cd54df6b8f6b08d9f9eb09b5
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000001167-NSIDC_ECS%2A&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -5048,6 +5108,21 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Tue, 22 Aug 2017 23:54:54 GMT
   digest: 03907bb9b728181bdcfe6825550410f811094171
+- request:
+    method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1444742099-PODAAC%2A&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:40:12 GMT
+  digest: 4e1cd378adeb822454605d5aff4fe68b98bcb8b9
 - request:
     method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C14758250-LPDAAC_ECS%2A&include_has_granules=true&include_granule_counts=true

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -5050,6 +5050,21 @@ http_interactions:
   digest: 03907bb9b728181bdcfe6825550410f811094171
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1444742099-PODAAC%2A&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Tue, 30 Jan 2018 21:03:34 GMT
+  digest: 4e1cd378adeb822454605d5aff4fe68b98bcb8b9
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C14758250-LPDAAC_ECS%2A&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -5046,7 +5046,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Wed, 31 Jan 2018 17:15:24 GMT
+  recorded_at: Thu, 01 Feb 2018 05:42:38 GMT
   digest: 88bb6803246fb9b2cd54df6b8f6b08d9f9eb09b5
 - request:
     method: get
@@ -5076,7 +5076,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Tue, 30 Jan 2018 21:03:34 GMT
+  recorded_at: Thu, 01 Feb 2018 05:43:06 GMT
   digest: 4e1cd378adeb822454605d5aff4fe68b98bcb8b9
 - request:
     method: get

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -5035,6 +5035,21 @@ http_interactions:
   digest: 755b26e5447705cd259bdb50bfb0e641c6786c40
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000000042-LANCEAMSR2%2A&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Wed, 31 Jan 2018 17:15:24 GMT
+  digest: 88bb6803246fb9b2cd54df6b8f6b08d9f9eb09b5
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000001167-NSIDC_ECS%2A&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -808,6 +808,21 @@ http_interactions:
   digest: e4c527a54dbec0699399034d221d108c55038745
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1444742099-PODAAC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 17:59:01 GMT
+  digest: da818a5e03375b857555d9d60c14d488eedfcc93
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C14758250-LPDAAC_ECS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -5046,7 +5061,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:42:38 GMT
+  recorded_at: Thu, 01 Feb 2018 18:00:18 GMT
   digest: 88bb6803246fb9b2cd54df6b8f6b08d9f9eb09b5
 - request:
     method: get
@@ -5076,7 +5091,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:43:06 GMT
+  recorded_at: Thu, 01 Feb 2018 17:59:04 GMT
   digest: 4e1cd378adeb822454605d5aff4fe68b98bcb8b9
 - request:
     method: get

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -808,21 +808,6 @@ http_interactions:
   digest: e4c527a54dbec0699399034d221d108c55038745
 - request:
     method: get
-    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1444742099-PODAAC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:59:01 GMT
-  digest: da818a5e03375b857555d9d60c14d488eedfcc93
-- request:
-    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C14758250-LPDAAC_ECS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -5050,21 +5035,6 @@ http_interactions:
   digest: 755b26e5447705cd259bdb50bfb0e641c6786c40
 - request:
     method: get
-    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000000042-LANCEAMSR2%2A&include_has_granules=true&include_granule_counts=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 18:00:18 GMT
-  digest: 88bb6803246fb9b2cd54df6b8f6b08d9f9eb09b5
-- request:
-    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1000001167-NSIDC_ECS%2A&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -5078,21 +5048,6 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Tue, 22 Aug 2017 23:54:54 GMT
   digest: 03907bb9b728181bdcfe6825550410f811094171
-- request:
-    method: get
-    uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C1444742099-PODAAC%2A&include_has_granules=true&include_granule_counts=true
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:59:04 GMT
-  digest: 4e1cd378adeb822454605d5aff4fe68b98bcb8b9
 - request:
     method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C14758250-LPDAAC_ECS%2A&include_has_granules=true&include_granule_counts=true

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -921,7 +921,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:42:42 GMT
+  recorded_at: Thu, 01 Feb 2018 18:00:21 GMT
   digest: 9d6e3a66c1b5c3ee5ed79224835853d2eefcafcd
 - request:
     method: post
@@ -1912,7 +1912,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:43:11 GMT
+  recorded_at: Thu, 01 Feb 2018 17:59:07 GMT
   digest: e8a8de140d4b5d054e59442714194333d684d846
 - request:
     method: post

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -921,7 +921,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Wed, 31 Jan 2018 17:15:26 GMT
+  recorded_at: Thu, 01 Feb 2018 05:42:42 GMT
   digest: 9d6e3a66c1b5c3ee5ed79224835853d2eefcafcd
 - request:
     method: post
@@ -1912,7 +1912,7 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Tue, 30 Jan 2018 21:03:40 GMT
+  recorded_at: Thu, 01 Feb 2018 05:43:11 GMT
   digest: e8a8de140d4b5d054e59442714194333d684d846
 - request:
     method: post

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -911,23 +911,6 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules.json
     body:
       encoding: US-ASCII
-      string: echo_collection_id=C1000000042-LANCEAMSR2&page_num=1&page_size=20&sort_key%5B%5D=-start_date
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 18:00:21 GMT
-  digest: 9d6e3a66c1b5c3ee5ed79224835853d2eefcafcd
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules.json
-    body:
-      encoding: US-ASCII
       string: echo_collection_id=C1000000062-NSIDC_ECS&page_num=1&page_size=20&project=2009_AN_NASA&sort_key%5B%5D=-start_date
     headers:
       User-Agent:
@@ -1897,23 +1880,6 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:49 GMT
   digest: cd7dd03a6200ba6fd79cd1865341a88b35708db0
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules.json
-    body:
-      encoding: US-ASCII
-      string: echo_collection_id=C1444742099-PODAAC&page_num=1&page_size=20&sort_key%5B%5D=-start_date
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:59:07 GMT
-  digest: e8a8de140d4b5d054e59442714194333d684d846
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules.json

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -1885,6 +1885,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules.json
     body:
       encoding: US-ASCII
+      string: echo_collection_id=C1444742099-PODAAC&page_num=1&page_size=20&sort_key%5B%5D=-start_date
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Tue, 30 Jan 2018 21:03:40 GMT
+  digest: e8a8de140d4b5d054e59442714194333d684d846
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules.json
+    body:
+      encoding: US-ASCII
       string: echo_collection_id=C14758250-LPDAAC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1005442453-LPDAAC_ECS&page_num=2&page_size=19&sort_key%5B%5D=-start_date&temporal=1999-12-01T00%3A00%3A00.000Z%2C2015-01-01T00%3A00%3A00.000Z
     headers:
       User-Agent:

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -911,6 +911,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules.json
     body:
       encoding: US-ASCII
+      string: echo_collection_id=C1000000042-LANCEAMSR2&page_num=1&page_size=20&sort_key%5B%5D=-start_date
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:36:58 GMT
+  digest: 9d6e3a66c1b5c3ee5ed79224835853d2eefcafcd
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules.json
+    body:
+      encoding: US-ASCII
       string: echo_collection_id=C1000000062-NSIDC_ECS&page_num=1&page_size=20&project=2009_AN_NASA&sort_key%5B%5D=-start_date
     headers:
       User-Agent:
@@ -1880,6 +1897,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:49 GMT
   digest: cd7dd03a6200ba6fd79cd1865341a88b35708db0
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules.json
+    body:
+      encoding: US-ASCII
+      string: echo_collection_id=C1444742099-PODAAC&page_num=1&page_size=20&sort_key%5B%5D=-start_date
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:40:15 GMT
+  digest: e8a8de140d4b5d054e59442714194333d684d846
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules.json

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -911,6 +911,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules.json
     body:
       encoding: US-ASCII
+      string: echo_collection_id=C1000000042-LANCEAMSR2&page_num=1&page_size=20&sort_key%5B%5D=-start_date
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Wed, 31 Jan 2018 17:15:26 GMT
+  digest: 9d6e3a66c1b5c3ee5ed79224835853d2eefcafcd
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules.json
+    body:
+      encoding: US-ASCII
       string: echo_collection_id=C1000000062-NSIDC_ECS&page_num=1&page_size=20&project=2009_AN_NASA&sort_key%5B%5D=-start_date
     headers:
       User-Agent:

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -1759,19 +1759,8 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.8.8
-  recorded_at: Thu, 01 Feb 2018 05:42:36 GMT
+  recorded_at: Thu, 01 Feb 2018 18:00:17 GMT
   digest: eae9c5fb737dc40c673dbd2ee98bf23fa437c205
-- request:
-    method: get
-    uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C1444742099-PODAAC
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-  recorded_at: Thu, 01 Feb 2018 05:43:05 GMT
-  digest: 9c6a00b2f66edd5e7257dbc75abd0487796df269
 - request:
     method: get
     uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C179002107-SEDAC

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -1752,17 +1752,6 @@ http_interactions:
   digest: 186ad8f8d0bf8d82cb805125293cbf363e157bfc
 - request:
     method: get
-    uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C1000000042-LANCEAMSR2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-  recorded_at: Thu, 01 Feb 2018 18:00:17 GMT
-  digest: eae9c5fb737dc40c673dbd2ee98bf23fa437c205
-- request:
-    method: get
     uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C179002107-SEDAC
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -1752,6 +1752,17 @@ http_interactions:
   digest: 186ad8f8d0bf8d82cb805125293cbf363e157bfc
 - request:
     method: get
+    uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C1444742099-PODAAC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Tue, 30 Jan 2018 21:03:33 GMT
+  digest: 9c6a00b2f66edd5e7257dbc75abd0487796df269
+- request:
+    method: get
     uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C179002107-SEDAC
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -1759,7 +1759,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.8.8
-  recorded_at: Wed, 31 Jan 2018 17:15:23 GMT
+  recorded_at: Thu, 01 Feb 2018 05:42:36 GMT
   digest: eae9c5fb737dc40c673dbd2ee98bf23fa437c205
 - request:
     method: get
@@ -1770,7 +1770,7 @@ http_interactions:
     headers:
       User-Agent:
       - Faraday v0.8.8
-  recorded_at: Tue, 30 Jan 2018 21:03:33 GMT
+  recorded_at: Thu, 01 Feb 2018 05:43:05 GMT
   digest: 9c6a00b2f66edd5e7257dbc75abd0487796df269
 - request:
     method: get

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -1752,6 +1752,17 @@ http_interactions:
   digest: 186ad8f8d0bf8d82cb805125293cbf363e157bfc
 - request:
     method: get
+    uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C1000000042-LANCEAMSR2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Wed, 31 Jan 2018 17:15:23 GMT
+  digest: eae9c5fb737dc40c673dbd2ee98bf23fa437c205
+- request:
+    method: get
     uri: https://edsc-nlp.ngap.earthdata.nasa.gov/nlp?text=C1444742099-PODAAC
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -4493,6 +4493,30 @@ d63cb049375aff72da5b367d65d787ce978ec49f:
       encoding: UTF-8
       string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"trigger500"}'
     http_version: 
+9c6a00b2f66edd5e7257dbc75abd0487796df269:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Jan 2018 21:03:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '71'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1444742099-PODAAC"}'
+    http_version: 
 3ef62e8415dbc5c2c1a0ba09d54309fdc1505b9a:
   response:
     status:

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -4502,7 +4502,7 @@ eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
       content-type:
       - application/json
       date:
-      - Wed, 31 Jan 2018 17:14:52 GMT
+      - Thu, 01 Feb 2018 05:42:49 GMT
       server:
       - nginx
       strict-transport-security:
@@ -4526,7 +4526,7 @@ eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
       content-type:
       - application/json
       date:
-      - Tue, 30 Jan 2018 21:03:04 GMT
+      - Thu, 01 Feb 2018 05:43:18 GMT
       server:
       - nginx
       strict-transport-security:

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -4493,30 +4493,6 @@ d63cb049375aff72da5b367d65d787ce978ec49f:
       encoding: UTF-8
       string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"trigger500"}'
     http_version: 
-eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      content-type:
-      - application/json
-      date:
-      - Thu, 01 Feb 2018 17:59:38 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      vary:
-      - Accept-Encoding
-      content-length:
-      - '75'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1000000042-LANCEAMSR2"}'
-    http_version: 
 3ef62e8415dbc5c2c1a0ba09d54309fdc1505b9a:
   response:
     status:

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -4502,7 +4502,7 @@ eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
       content-type:
       - application/json
       date:
-      - Thu, 01 Feb 2018 05:42:49 GMT
+      - Thu, 01 Feb 2018 17:59:38 GMT
       server:
       - nginx
       strict-transport-security:
@@ -4516,30 +4516,6 @@ eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
     body:
       encoding: UTF-8
       string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1000000042-LANCEAMSR2"}'
-    http_version: 
-9c6a00b2f66edd5e7257dbc75abd0487796df269:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      content-type:
-      - application/json
-      date:
-      - Thu, 01 Feb 2018 05:43:18 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      vary:
-      - Accept-Encoding
-      content-length:
-      - '71'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1444742099-PODAAC"}'
     http_version: 
 3ef62e8415dbc5c2c1a0ba09d54309fdc1505b9a:
   response:

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -4493,6 +4493,30 @@ d63cb049375aff72da5b367d65d787ce978ec49f:
       encoding: UTF-8
       string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"trigger500"}'
     http_version: 
+eae9c5fb737dc40c673dbd2ee98bf23fa437c205:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      content-type:
+      - application/json
+      date:
+      - Wed, 31 Jan 2018 17:14:52 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '75'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1000000042-LANCEAMSR2"}'
+    http_version: 
 9c6a00b2f66edd5e7257dbc75abd0487796df269:
   response:
     status:

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -655,6 +655,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: browse_only=true&concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:23 GMT
+  digest: aae51c774d53af6af38e7827687102eca077eda2
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: cloud_cover=%2C5.0&concept_id=C14758250-LPDAAC_ECS&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -786,6 +803,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 26 May 2016 21:28:41 GMT
   digest: a08acca69f95ed3209679bf691c963a42b32711d
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:01 GMT
+  digest: fa5afb45a53c22f594722936316b225edfd58c33
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
@@ -1298,6 +1332,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:50 GMT
   digest: f5801e117ff4523a275fccd3ef6ed5ca040c1e7a
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C1444742099-PODAAC&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:40:19 GMT
+  digest: c03050d4ab85544fb5ebd2b246e2b05e48cc159d
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
@@ -3790,6 +3841,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 19:09:52 GMT
   digest: 411ef6378d79b0839172fea6a3d9f7c1f324345f
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C179003380-ORNL_DAAC&end_date=2011-01-01T23%3A59%3A59.000Z&interval=day&start_date=2007-12-30T23%3A59%3A59.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:36:52 GMT
+  digest: e41480ffaf1a19861a77d5e08a9e924c79098082
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
@@ -6380,6 +6448,380 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 08 Sep 2016 19:42:02 GMT
   digest: 3d16ca76035b153e58e3a8b9f7bc4a7987e0358e
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366863-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366867-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366946-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366892-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366930-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:38:00 GMT
+  digest: 1182c03256b397eb26882e5ec2fdbf03f5f7cd93
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366863-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366867-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366946-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366892-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:57 GMT
+  digest: 633e5defc9eded420269f23bb061d21021d63f7a
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366863-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366867-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366946-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:56 GMT
+  digest: c5790ad005a532e35b7b09fd8dbbe7ccbe6d536f
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366863-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366867-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:54 GMT
+  digest: 17c5f001347049f432a2206455972b5d2d9cf0b3
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366863-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:52 GMT
+  digest: 86f573fe0751095adba00f92f2b5b9034285b97e
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367715-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:50 GMT
+  digest: fd609ce960944754d3496b6cd6615fc1775607b9
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367354-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:49 GMT
+  digest: 9dc1924f14897b8ec443ab345405e7600c218bb9
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366421-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:47 GMT
+  digest: 44d5dbf4c595fc8543433a4a45e3f8a87e28a902
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367431-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:45 GMT
+  digest: fb47ca63120e551478d525d78b5ceb68399c5c1b
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367393-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:43 GMT
+  digest: e0c1d042f05daaf7152c15106ef1e57c339097c5
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366879-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:42 GMT
+  digest: 6809ea0c3d8d7b826c7132a6cd9742fa70842626
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366864-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:40 GMT
+  digest: 81b651b8d1eb23df3c6ef53744ff5531dfb69462
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367747-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:38 GMT
+  digest: 58d75d8cda674ed6f9662860251e0aa137d0c795
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367405-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:36 GMT
+  digest: b2e2ef37198f70a1423736aa1c6b7c164cd9a503
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366399-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:34 GMT
+  digest: f3f22b22df3346216cbba5fc3ee9e9dbc00db610
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367468-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:33 GMT
+  digest: 67fff40d280707ba739ab9802a9333189e027f8d
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367446-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:31 GMT
+  digest: ac8806fc8104cb4f7347b2f293d1db0ddbe57915
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360366932-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:29 GMT
+  digest: dfac9225095f0bdb08439c217a88062dce875aa5
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&exclude%5Becho_granule_id%5D%5B%5D=G1360367334-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:27 GMT
+  digest: ef4a818f7f48e160eec387ecc6edfde9d5303d7d
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&exclude%5Becho_granule_id%5D%5B%5D=G1360367376-NSIDC_ECS&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:21 GMT
+  digest: 815c7a7ba5fa4d8fdbbe069969e75ad7a4c5df1e
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&options%5Breadable_granule_name%5D%5Bpattern%5D=true&readable_granule_name%5B%5D=MOD10A1.A2016001.h31v13.005.2016006204744.hdf&readable_granule_name%5B%5D=MOD10A1.A2016001.h31v12%2A&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:47:00 GMT
+  digest: 7de31f7f7cb5966707f84c047636ec732ca7ea39
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C92711294-NSIDC_ECS&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 19:37:03 GMT
+  digest: 7cf20186fa682de16f0e8de0fbf440a4a67aba29
 - request:
     method: post
     uri: https://cmr.sit.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -791,7 +791,7 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
-      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
     headers:
       User-Agent:
       - Faraday v0.8.8
@@ -801,42 +801,8 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Wed, 31 Jan 2018 17:15:29 GMT
-  digest: c386fcf88b55ef4db90c0c3ad89c3adb93760a31
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-26T00%3A00%3A00.000Z&interval=day&start_date=1985-10-24T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 00:05:21 GMT
-  digest: eafcb86252a713db71ea6a0a920c0e93eab75aa2
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1000000042-LANCEAMSR2&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 01:18:57 GMT
-  digest: bfae0b93752577cb9f6e9a267c4a5aab993ca479
+  recorded_at: Thu, 01 Feb 2018 05:42:41 GMT
+  digest: bac2ff02e5a753bd278ed3fef8fd6672b4284b91
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
@@ -1354,23 +1320,6 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
-      string: concept_id=C1444742099-PODAAC&end_date=1988-10-26T00%3A00%3A00.000Z&interval=day&start_date=1985-10-24T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 00:04:47 GMT
-  digest: 2405d4bdf152df74fab947aa956b3a85e32bd7cb
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
       string: concept_id=C1444742099-PODAAC&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -1381,25 +1330,8 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Wed, 31 Jan 2018 17:14:30 GMT
+  recorded_at: Thu, 01 Feb 2018 05:43:09 GMT
   digest: 93f859cc16e28a28924c0465ac0e41de6ff5eb8a
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1444742099-PODAAC&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Tue, 30 Jan 2018 21:03:37 GMT
-  digest: bfa2c73867d1fb977c53c76dd3648b7881163272
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -1303,6 +1303,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: concept_id=C1444742099-PODAAC&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Tue, 30 Jan 2018 21:03:37 GMT
+  digest: bfa2c73867d1fb977c53c76dd3648b7881163272
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: concept_id=C14758250-LPDAAC_ECS&day_night_flag=BOTH&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -791,6 +791,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 17:24:50 GMT
+  digest: c386fcf88b55ef4db90c0c3ad89c3adb93760a31
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: concept_id=C1000000042-LANCEAMSR2&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -1315,6 +1332,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:50 GMT
   digest: f5801e117ff4523a275fccd3ef6ed5ca040c1e7a
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C1444742099-PODAAC&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 17:24:16 GMT
+  digest: cf1b074df74936e4fee5e385d8a0fb398deee714
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -791,6 +791,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Wed, 31 Jan 2018 17:15:29 GMT
+  digest: c386fcf88b55ef4db90c0c3ad89c3adb93760a31
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: concept_id=C1000000062-NSIDC_ECS&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&project=2009_AN_NASA&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -1298,6 +1315,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:50 GMT
   digest: f5801e117ff4523a275fccd3ef6ed5ca040c1e7a
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C1444742099-PODAAC&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Wed, 31 Jan 2018 17:14:30 GMT
+  digest: 93f859cc16e28a28924c0465ac0e41de6ff5eb8a
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -808,6 +808,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-26T00%3A00%3A00.000Z&interval=day&start_date=1985-10-24T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 00:05:21 GMT
+  digest: eafcb86252a713db71ea6a0a920c0e93eab75aa2
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: concept_id=C1000000062-NSIDC_ECS&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&project=2009_AN_NASA&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -1315,6 +1332,23 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:50 GMT
   digest: f5801e117ff4523a275fccd3ef6ed5ca040c1e7a
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C1444742099-PODAAC&end_date=1988-10-26T00%3A00%3A00.000Z&interval=day&start_date=1985-10-24T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 00:04:47 GMT
+  digest: 2405d4bdf152df74fab947aa956b3a85e32bd7cb
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -801,25 +801,8 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:24:50 GMT
+  recorded_at: Thu, 01 Feb 2018 18:00:23 GMT
   digest: c386fcf88b55ef4db90c0c3ad89c3adb93760a31
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1000000042-LANCEAMSR2&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:42:41 GMT
-  digest: bac2ff02e5a753bd278ed3fef8fd6672b4284b91
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
@@ -1337,7 +1320,7 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
-      string: concept_id=C1444742099-PODAAC&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
+      string: concept_id=C1444742099-PODAAC&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
     headers:
       User-Agent:
       - Faraday v0.8.8
@@ -1347,25 +1330,8 @@ http_interactions:
       - eed-edsc-dev
       Echo-ClientId:
       - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:24:16 GMT
-  digest: cf1b074df74936e4fee5e385d8a0fb398deee714
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1444742099-PODAAC&end_date=2011-01-01T00%3A00%3A00.000Z&interval=day&start_date=2007-12-30T00%3A00%3A00.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 05:43:09 GMT
-  digest: 93f859cc16e28a28924c0465ac0e41de6ff5eb8a
+  recorded_at: Thu, 01 Feb 2018 17:59:06 GMT
+  digest: c03050d4ab85544fb5ebd2b246e2b05e48cc159d
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -791,23 +791,6 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
-      string: concept_id=C1000000042-LANCEAMSR2&end_date=1988-10-25T23%3A59%3A59.999Z&interval=day&start_date=1985-10-23T23%3A59%3A59.999Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 18:00:23 GMT
-  digest: c386fcf88b55ef4db90c0c3ad89c3adb93760a31
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
       string: concept_id=C1000000062-NSIDC_ECS&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&project=2009_AN_NASA&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:
@@ -1315,23 +1298,6 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Thu, 19 May 2016 16:17:50 GMT
   digest: f5801e117ff4523a275fccd3ef6ed5ca040c1e7a
-- request:
-    method: post
-    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
-    body:
-      encoding: US-ASCII
-      string: concept_id=C1444742099-PODAAC&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
-    headers:
-      User-Agent:
-      - Faraday v0.8.8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Client-Id:
-      - eed-edsc-dev
-      Echo-ClientId:
-      - eed-edsc-dev
-  recorded_at: Thu, 01 Feb 2018 17:59:06 GMT
-  digest: c03050d4ab85544fb5ebd2b246e2b05e48cc159d
 - request:
     method: post
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -825,6 +825,23 @@ http_interactions:
     uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
     body:
       encoding: US-ASCII
+      string: concept_id=C1000000042-LANCEAMSR2&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&start_date=2012-02-28T00%3A00%3A00.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 01 Feb 2018 01:18:57 GMT
+  digest: bfae0b93752577cb9f6e9a267c4a5aab993ca479
+- request:
+    method: post
+    uri: https://cmr.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
       string: concept_id=C1000000062-NSIDC_ECS&end_date=2015-03-02T00%3A00%3A00.000Z&interval=day&project=2009_AN_NASA&start_date=2012-02-28T00%3A00%3A00.000Z
     headers:
       User-Agent:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -869,6 +869,30 @@ c083851dcdda0ca2b9828db0b3f9ede74a2da8fb:
       encoding: UTF-8
       string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1330387200,1425254400,334427]]}]'
     http_version: 
+aae51c774d53af6af38e7827687102eca077eda2:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 32fe1b43-8979-48c5-a71c-bc83743a7d28
+      date:
+      - Thu, 01 Feb 2018 19:37:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94016]]}]'
+    http_version: 
 e3e45f47bb2285d98a4e45ca07857ecf8b0cb005:
   response:
     status:
@@ -1048,6 +1072,30 @@ a08acca69f95ed3209679bf691c963a42b32711d:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C1000000000-ORNL_DAAC","intervals":[[1330387200,1338595200,3]]}]'
+    http_version: 
+fa5afb45a53c22f594722936316b225edfd58c33:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 6bb6d5a2-8344-4677-b9fe-bb3c426ef8b6
+      date:
+      - Thu, 01 Feb 2018 19:37:12 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '82'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C1000000042-LANCEAMSR2","intervals":[[1516233600,1517529600,15]]}]'
     http_version: 
 3ebf746fb5ece902493d10c05cea7a0e0039707c:
   response:
@@ -1740,6 +1788,30 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
+    http_version: 
+c03050d4ab85544fb5ebd2b246e2b05e48cc159d:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 97a22387-d490-487d-b977-6db73410f1c9
+      date:
+      - Thu, 01 Feb 2018 19:40:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '160'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C1444742099-PODAAC","intervals":[[1489795200,1495584000,67],[1496275200,1499817600,41],[1500768000,1510358400,111],[1511568000,1513296000,20]]}]'
     http_version: 
 cf8b100bff82fcafbe5253fb00ca0c0394c23a8d:
   response:
@@ -5016,6 +5088,30 @@ e20bcf54c88b17a8b417d1a569f061cd7e4a1dfd:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C179003380-ORNL_DAAC","intervals":[[1198972800,1262304000,2]]}]'
+    http_version: 
+e41480ffaf1a19861a77d5e08a9e924c79098082:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 0406389d-5458-46f6-8519-437bf79df138
+      date:
+      - Thu, 01 Feb 2018 19:37:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '79'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C179003380-ORNL_DAAC","intervals":[[1199059199,1262304000,2]]}]'
     http_version: 
 a905390c02b03cf176121940af34a64612e0adc8:
   response:
@@ -8498,6 +8594,534 @@ c95e719b96d6b41bdc80e42a00f785a8bb9dfd36:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1330387200,1425254400,334427]]}]'
+    http_version: 
+1182c03256b397eb26882e5ec2fdbf03f5f7cd93:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 9bf6369f-633b-497a-a4b6-bdfd7d22232d
+      date:
+      - Thu, 01 Feb 2018 19:38:42 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,93998]]}]'
+    http_version: 
+633e5defc9eded420269f23bb061d21021d63f7a:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 472542c7-0af3-4fef-a340-16a2c314670b
+      date:
+      - Thu, 01 Feb 2018 19:37:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,93999]]}]'
+    http_version: 
+c5790ad005a532e35b7b09fd8dbbe7ccbe6d536f:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 591f3222-583c-4744-a700-6c13095cd3a0
+      date:
+      - Thu, 01 Feb 2018 19:37:59 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94000]]}]'
+    http_version: 
+17c5f001347049f432a2206455972b5d2d9cf0b3:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 21b4204b-c8ed-4435-aa40-6dc3aa794b45
+      date:
+      - Thu, 01 Feb 2018 19:38:37 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94001]]}]'
+    http_version: 
+86f573fe0751095adba00f92f2b5b9034285b97e:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 2d983719-6571-4c3c-92f7-66d905744738
+      date:
+      - Thu, 01 Feb 2018 19:37:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94002]]}]'
+    http_version: 
+fd609ce960944754d3496b6cd6615fc1775607b9:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - c2c26fe4-bbb4-4109-a4de-42585b0af140
+      date:
+      - Thu, 01 Feb 2018 19:38:02 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94003]]}]'
+    http_version: 
+9dc1924f14897b8ec443ab345405e7600c218bb9:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 2e2a2b1c-5d1d-460f-b9ad-35971ea92d0b
+      date:
+      - Thu, 01 Feb 2018 19:37:52 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94004]]}]'
+    http_version: 
+44d5dbf4c595fc8543433a4a45e3f8a87e28a902:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - bb3276c2-effb-41f1-8e0e-c5a922f53724
+      date:
+      - Thu, 01 Feb 2018 19:37:07 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94005]]}]'
+    http_version: 
+fb47ca63120e551478d525d78b5ceb68399c5c1b:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 813c6bd8-53c5-4f18-8a3b-6960be5f2b6c
+      date:
+      - Thu, 01 Feb 2018 19:37:48 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94006]]}]'
+    http_version: 
+e0c1d042f05daaf7152c15106ef1e57c339097c5:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 405b11d5-d5a1-4016-aa70-822cee470e31
+      date:
+      - Thu, 01 Feb 2018 19:37:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94007]]}]'
+    http_version: 
+6809ea0c3d8d7b826c7132a6cd9742fa70842626:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - a376d3b7-157d-45a2-94a2-00cd87f29585
+      date:
+      - Thu, 01 Feb 2018 19:38:25 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94008]]}]'
+    http_version: 
+81b651b8d1eb23df3c6ef53744ff5531dfb69462:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - a69f5d80-1ccc-46a2-8c2e-d5409e36907c
+      date:
+      - Thu, 01 Feb 2018 19:37:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94009]]}]'
+    http_version: 
+58d75d8cda674ed6f9662860251e0aa137d0c795:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - bea4f53f-df18-44ab-a9cb-4e127fce8693
+      date:
+      - Thu, 01 Feb 2018 19:37:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94010]]}]'
+    http_version: 
+b2e2ef37198f70a1423736aa1c6b7c164cd9a503:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 863532e0-aff7-4580-b17c-0700f82ffae2
+      date:
+      - Thu, 01 Feb 2018 19:37:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94011]]}]'
+    http_version: 
+f3f22b22df3346216cbba5fc3ee9e9dbc00db610:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 06939d68-5225-4095-b84e-09ffcbc3714b
+      date:
+      - Thu, 01 Feb 2018 19:37:32 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94012]]}]'
+    http_version: 
+67fff40d280707ba739ab9802a9333189e027f8d:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - efa87f5e-d74c-423c-9080-427b39823af6
+      date:
+      - Thu, 01 Feb 2018 19:38:16 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94013]]}]'
+    http_version: 
+ac8806fc8104cb4f7347b2f293d1db0ddbe57915:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 29ec20ec-bc19-48e2-81e5-cb86e509c0e3
+      date:
+      - Thu, 01 Feb 2018 19:38:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94014]]}]'
+    http_version: 
+dfac9225095f0bdb08439c217a88062dce875aa5:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - ca6ea4fd-d3d0-4307-a02a-f9af08dd94a2
+      date:
+      - Thu, 01 Feb 2018 19:37:27 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94015]]}]'
+    http_version: 
+ef4a818f7f48e160eec387ecc6edfde9d5303d7d:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 8e99d3b3-9c22-44d9-85e3-52566e6a7683
+      date:
+      - Thu, 01 Feb 2018 19:37:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94016]]}]'
+    http_version: 
+815c7a7ba5fa4d8fdbbe069969e75ad7a4c5df1e:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - b9fd749d-237d-4c1f-96d7-5ff1206d42c4
+      date:
+      - Thu, 01 Feb 2018 19:36:41 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94017]]}]'
+    http_version: 
+7de31f7f7cb5966707f84c047636ec732ca7ea39:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 4ed9f51a-2644-45fb-881b-71129919136a
+      date:
+      - Thu, 01 Feb 2018 19:47:43 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+7cf20186fa682de16f0e8de0fbf440a4a67aba29:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 7b43c6da-d651-4268-8303-a3e4deb10126
+      date:
+      - Thu, 01 Feb 2018 19:37:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '111'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"concept-id":"C92711294-NSIDC_ECS","intervals":[[1454261472,1455753600,5395],[1456617600,1483401600,94018]]}]'
     http_version: 
 1da38b4dee99d98441d839d3aba9cbafbe84c823:
   response:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1073,6 +1073,30 @@ c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
       encoding: UTF-8
       string: "[]"
     http_version: 
+eafcb86252a713db71ea6a0a920c0e93eab75aa2:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 9c251463-cba0-4a4b-936b-d7bea65db794
+      date:
+      - Thu, 01 Feb 2018 00:05:24 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 3ebf746fb5ece902493d10c05cea7a0e0039707c:
   response:
     status:
@@ -1764,6 +1788,30 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
+    http_version: 
+2405d4bdf152df74fab947aa956b3a85e32bd7cb:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - cc8ce05f-6789-41ad-aff5-0deebcb4c571
+      date:
+      - Thu, 01 Feb 2018 00:04:51 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
     http_version: 
 93f859cc16e28a28924c0465ac0e41de6ff5eb8a:
   response:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1049,6 +1049,30 @@ a08acca69f95ed3209679bf691c963a42b32711d:
       encoding: UTF-8
       string: '[{"concept-id":"C1000000000-ORNL_DAAC","intervals":[[1330387200,1338595200,3]]}]'
     http_version: 
+c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 858fbb54-bc09-45bd-81b7-686f2b425a49
+      date:
+      - Wed, 31 Jan 2018 17:14:59 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 3ebf746fb5ece902493d10c05cea7a0e0039707c:
   response:
     status:
@@ -1740,6 +1764,30 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
+    http_version: 
+93f859cc16e28a28924c0465ac0e41de6ff5eb8a:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - ba26094f-7394-443b-be49-ff51c8c7e509
+      date:
+      - Wed, 31 Jan 2018 17:14:38 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
     http_version: 
 bfa2c73867d1fb977c53c76dd3648b7881163272:
   response:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1741,6 +1741,30 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
     http_version: 
+bfa2c73867d1fb977c53c76dd3648b7881163272:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 374ea067-edab-4458-9810-7e5f3e1a3b81
+      date:
+      - Tue, 30 Jan 2018 21:03:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 cf8b100bff82fcafbe5253fb00ca0c0394c23a8d:
   response:
     status:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1049,30 +1049,6 @@ a08acca69f95ed3209679bf691c963a42b32711d:
       encoding: UTF-8
       string: '[{"concept-id":"C1000000000-ORNL_DAAC","intervals":[[1330387200,1338595200,3]]}]'
     http_version: 
-c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - 6616045c-6621-4fd6-b3f4-f448746fa96a
-      date:
-      - Thu, 01 Feb 2018 18:01:07 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
 3ebf746fb5ece902493d10c05cea7a0e0039707c:
   response:
     status:
@@ -1764,30 +1740,6 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
-    http_version: 
-c03050d4ab85544fb5ebd2b246e2b05e48cc159d:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - b6bb7f98-12bc-4ad2-bcf2-348a1a0eaf8a
-      date:
-      - Thu, 01 Feb 2018 17:59:18 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '160'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: '[{"concept-id":"C1444742099-PODAAC","intervals":[[1489795200,1495584000,67],[1496275200,1499817600,41],[1500768000,1510358400,111],[1511568000,1513296000,20]]}]'
     http_version: 
 cf8b100bff82fcafbe5253fb00ca0c0394c23a8d:
   response:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1058,33 +1058,9 @@ c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
       access-control-allow-origin:
       - "*"
       cmr-request-id:
-      - 96a724d9-c470-4c1b-b5f9-558321c8883c
+      - 6616045c-6621-4fd6-b3f4-f448746fa96a
       date:
-      - Thu, 01 Feb 2018 17:24:48 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-bac2ff02e5a753bd278ed3fef8fd6672b4284b91:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - 6cabcf1c-2656-45e4-b827-e3772ff99e0f
-      date:
-      - Thu, 01 Feb 2018 05:42:45 GMT
+      - Thu, 01 Feb 2018 18:01:07 GMT
       server:
       - nginx
       strict-transport-security:
@@ -1789,7 +1765,7 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
     http_version: 
-cf1b074df74936e4fee5e385d8a0fb398deee714:
+c03050d4ab85544fb5ebd2b246e2b05e48cc159d:
   response:
     status:
       code: 200
@@ -1798,44 +1774,20 @@ cf1b074df74936e4fee5e385d8a0fb398deee714:
       access-control-allow-origin:
       - "*"
       cmr-request-id:
-      - dbedab43-a3a5-420f-a96f-f0eb1022837c
+      - b6bb7f98-12bc-4ad2-bcf2-348a1a0eaf8a
       date:
-      - Thu, 01 Feb 2018 17:23:37 GMT
+      - Thu, 01 Feb 2018 17:59:18 GMT
       server:
       - nginx
       strict-transport-security:
       - max-age=31536000; includeSubDomains;
       content-length:
-      - '2'
+      - '160'
       connection:
       - Close
     body:
       encoding: UTF-8
-      string: "[]"
-    http_version: 
-93f859cc16e28a28924c0465ac0e41de6ff5eb8a:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - 449090ac-dd6f-476d-927c-b16e78f20435
-      date:
-      - Thu, 01 Feb 2018 05:42:33 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
+      string: '[{"concept-id":"C1444742099-PODAAC","intervals":[[1489795200,1495584000,67],[1496275200,1499817600,41],[1500768000,1510358400,111],[1511568000,1513296000,20]]}]'
     http_version: 
 cf8b100bff82fcafbe5253fb00ca0c0394c23a8d:
   response:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1097,6 +1097,30 @@ eafcb86252a713db71ea6a0a920c0e93eab75aa2:
       encoding: UTF-8
       string: "[]"
     http_version: 
+bfae0b93752577cb9f6e9a267c4a5aab993ca479:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - d9972eef-04ca-4283-9eb8-67ad5dcfbfdf
+      date:
+      - Thu, 01 Feb 2018 01:19:43 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 3ebf746fb5ece902493d10c05cea7a0e0039707c:
   response:
     status:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1049,7 +1049,7 @@ a08acca69f95ed3209679bf691c963a42b32711d:
       encoding: UTF-8
       string: '[{"concept-id":"C1000000000-ORNL_DAAC","intervals":[[1330387200,1338595200,3]]}]'
     http_version: 
-c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
+bac2ff02e5a753bd278ed3fef8fd6672b4284b91:
   response:
     status:
       code: 200
@@ -1058,57 +1058,9 @@ c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
       access-control-allow-origin:
       - "*"
       cmr-request-id:
-      - 858fbb54-bc09-45bd-81b7-686f2b425a49
+      - 6cabcf1c-2656-45e4-b827-e3772ff99e0f
       date:
-      - Wed, 31 Jan 2018 17:14:59 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-eafcb86252a713db71ea6a0a920c0e93eab75aa2:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - 9c251463-cba0-4a4b-936b-d7bea65db794
-      date:
-      - Thu, 01 Feb 2018 00:05:24 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-bfae0b93752577cb9f6e9a267c4a5aab993ca479:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - d9972eef-04ca-4283-9eb8-67ad5dcfbfdf
-      date:
-      - Thu, 01 Feb 2018 01:19:43 GMT
+      - Thu, 01 Feb 2018 05:42:45 GMT
       server:
       - nginx
       strict-transport-security:
@@ -1813,30 +1765,6 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
     http_version: 
-2405d4bdf152df74fab947aa956b3a85e32bd7cb:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - cc8ce05f-6789-41ad-aff5-0deebcb4c571
-      date:
-      - Thu, 01 Feb 2018 00:04:51 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
 93f859cc16e28a28924c0465ac0e41de6ff5eb8a:
   response:
     status:
@@ -1846,33 +1774,9 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
       access-control-allow-origin:
       - "*"
       cmr-request-id:
-      - ba26094f-7394-443b-be49-ff51c8c7e509
+      - 449090ac-dd6f-476d-927c-b16e78f20435
       date:
-      - Wed, 31 Jan 2018 17:14:38 GMT
-      server:
-      - nginx
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains;
-      content-length:
-      - '2'
-      connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: "[]"
-    http_version: 
-bfa2c73867d1fb977c53c76dd3648b7881163272:
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      access-control-allow-origin:
-      - "*"
-      cmr-request-id:
-      - 374ea067-edab-4458-9810-7e5f3e1a3b81
-      date:
-      - Tue, 30 Jan 2018 21:03:45 GMT
+      - Thu, 01 Feb 2018 05:42:33 GMT
       server:
       - nginx
       strict-transport-security:

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -1049,6 +1049,30 @@ a08acca69f95ed3209679bf691c963a42b32711d:
       encoding: UTF-8
       string: '[{"concept-id":"C1000000000-ORNL_DAAC","intervals":[[1330387200,1338595200,3]]}]'
     http_version: 
+c386fcf88b55ef4db90c0c3ad89c3adb93760a31:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - 96a724d9-c470-4c1b-b5f9-558321c8883c
+      date:
+      - Thu, 01 Feb 2018 17:24:48 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
 bac2ff02e5a753bd278ed3fef8fd6672b4284b91:
   response:
     status:
@@ -1764,6 +1788,30 @@ f5801e117ff4523a275fccd3ef6ed5ca040c1e7a:
     body:
       encoding: UTF-8
       string: '[{"concept-id":"C128599377-NSIDC_ECS","intervals":[[1254466308,1265155200,3584],[1265328000,1317686400,17633]]}]'
+    http_version: 
+cf1b074df74936e4fee5e385d8a0fb398deee714:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - dbedab43-a3a5-420f-a96f-f0eb1022837c
+      date:
+      - Thu, 01 Feb 2018 17:23:37 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
     http_version: 
 93f859cc16e28a28924c0465ac0e41de6ff5eb8a:
   response:

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -271,8 +271,8 @@ describe "Granule list", reset: false do
   end
 
   context 'for collections whose granules have more than one downloadable links' do
-    use_collection 'C204690560-LAADS', 'MODIS/Aqua Aerosol 5-Min L2 Swath 3km V006'
-    hook_granule_results('MODIS/Aqua Aerosol 5-Min L2 Swath 3km V006')
+    use_collection 'C1000000042-LANCEAMSR2', 'NRT AMSR2 DAILY L3 12.5 KM TB AND SEA ICE CONCENTRATION POLAR GRIDS V0'
+    hook_granule_results('NRT AMSR2 DAILY L3 12.5 KM TB AND SEA ICE CONCENTRATION POLAR GRIDS V0')
 
     context 'clicking on the single granule download button' do
       before :all do
@@ -289,8 +289,8 @@ describe "Granule list", reset: false do
 
       it 'shows a dropdown with all the downloadable granules' do
         within '#granules-scroll .panel-list-item:nth-child(1)' do
-          expect(page).to have_content('Download Link 1')
-          expect(page).to have_content('Download Link 2')
+          expect(page).to have_content('Online access to AMSR-2 Near-Real-Time LANCE Products (primary)')
+          expect(page).to have_content('Online access to AMSR-2 Near-Real-Time LANCE Products (backup)')
         end
       end
     end

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -295,4 +295,22 @@ describe "Granule list", reset: false do
       end
     end
   end
+
+  context 'for collections whose granules have duplicate downloadable links, with one pointing to https and the other ftp' do
+    # A collection known to have duplicate downloadable links
+    use_collection 'C1444742099-PODAAC', 'PODAAC-CYGNS-L3X20'
+    hook_granule_results('PODAAC-CYGNS-L3X20')
+    before :all do
+      within '#granules-scroll .panel-list-item:nth-child(1)' do
+        # If the test works, this dropdown won't even exist...
+        if page.has_css?('a[data-toggle="dropdown"]')
+          find('a[data-toggle="dropdown"]').click 
+        end
+      end
+    end
+    
+    it 'only shows the http link' do
+      expect(page).not_to have_link("The FTP location for the granule.")
+    end
+  end
 end

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -297,10 +297,10 @@ describe "Granule list", reset: false do
   end
 
   context 'for collections whose granules have duplicate downloadable links, with one pointing to https and the other ftp' do
-    # A collection known to have duplicate downloadable links
-    use_collection 'C1444742099-PODAAC', 'PODAAC-CYGNS-L3X20'
-    hook_granule_results('PODAAC-CYGNS-L3X20')
     before :all do
+      # A collection known to have duplicate downloadable links
+      visit('/search/granules?p=C1444742099-PODAAC&tl=1501695072!4!!&q=C1444742099-PODAAC&ok=C1444742099-PODAAC')
+      wait_for_xhr
       within '#granules-scroll .panel-list-item:nth-child(1)' do
         # If the test works, this dropdown won't even exist...
         if page.has_css?('a[data-toggle="dropdown"]')

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -14,9 +14,10 @@ describe "Granule list", reset: false do
   end
 
   context "for all collections with granules" do
-    use_collection 'C92711294-NSIDC_ECS', 'MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid V005'
-    hook_granule_results('MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid V005')
-
+    before :all do
+      visit('/search/granules?p=C92711294-NSIDC_ECS&tl=1501695072!4!!&q=C92711294-NSIDC_ECS&ok=C92711294-NSIDC_ECS')
+      wait_for_xhr
+    end
     it 'provides a text field to search for single or multiple granules by granule IDs' do
       expect(page).to have_selector('#granule-ids')
     end
@@ -220,10 +221,11 @@ describe "Granule list", reset: false do
   end
 
   context "for collections with many granule results" do
-    use_collection 'C179002914-ORNL_DAAC', '30 Minute Rainfall Data (FIFE)'
-
+    before :all do
+      visit('/search/granules?p=C179002914-ORNL_DAAC&tl=1501695072!4!!&q=C179002914-ORNL_DAAC&ok=C179002914-ORNL_DAAC')
+      wait_for_xhr
+    end
     context "clicking on a collection result" do
-      hook_granule_results('30 Minute Rainfall Data (FIFE)', :each)
 
       it "displays the first granule results in a list that pages by 20" do
         expect(page).to have_css('#granule-list .panel-list-item', count: 20)
@@ -235,10 +237,12 @@ describe "Granule list", reset: false do
   end
 
   context "for collections with few granule results" do
-    use_collection 'C179003380-ORNL_DAAC', 'A Global Database of Carbon and Nutrient Concentrations of Green and Senesced Leaves'
+    before :all do
+      visit('/search/granules?p=C179003380-ORNL_DAAC&tl=1501695072!4!!&q=C179003380-ORNL_DAAC&ok=C179003380-ORNL_DAAC')
+      wait_for_xhr
+    end
 
     context "clicking on a collection result" do
-      hook_granule_results('A Global Database of Carbon and Nutrient Concentrations of Green and Senesced Leaves')
 
       it "displays all available granule results" do
         expect(page).to have_css('#granule-list .panel-list-item', count: 2)
@@ -251,10 +255,12 @@ describe "Granule list", reset: false do
   end
 
   context "for collections without granules" do
-    use_collection 'C179002107-SEDAC', 'Anthropogenic Biomes of the World, Version 1'
 
     context "clicking on a collection result" do
       before :all do
+        visit('/search?q=C179002107-SEDAC&ok=C179002107-SEDAC')
+        wait_for_xhr
+        dismiss_banner
         expect(page).to have_visible_collection_results
         first_collection_result.click
         wait_for_xhr
@@ -271,11 +277,11 @@ describe "Granule list", reset: false do
   end
 
   context 'for collections whose granules have more than one downloadable links' do
-    use_collection 'C1000000042-LANCEAMSR2', 'NRT AMSR2 DAILY L3 12.5 KM TB AND SEA ICE CONCENTRATION POLAR GRIDS V0'
-    hook_granule_results('NRT AMSR2 DAILY L3 12.5 KM TB AND SEA ICE CONCENTRATION POLAR GRIDS V0')
 
     context 'clicking on the single granule download button' do
       before :all do
+        visit('/search/granules?p=C1000000042-LANCEAMSR2&tl=1501695072!4!!&q=C1000000042-LANCEAMSR2&ok=C1000000042-LANCEAMSR2')
+        wait_for_xhr
         within '#granules-scroll .panel-list-item:nth-child(1)' do
           find('a[data-toggle="dropdown"]').click
         end

--- a/spec/helpers/page_helpers.rb
+++ b/spec/helpers/page_helpers.rb
@@ -95,7 +95,7 @@ module Helpers
       # Let's get the tour modal while we're at it...
       page.execute_script("$('#closeInitialTourModal').trigger('click')")
       # Now the banner...
-      while page.has_css?('.banner-close') do
+      if page.has_css?('a[class="banner-close"]')
         find('a[class="banner-close"]').click
         wait_for_xhr
       end

--- a/spec/helpers/page_helpers.rb
+++ b/spec/helpers/page_helpers.rb
@@ -91,11 +91,13 @@ module Helpers
     end
 
     def dismiss_banner
+      wait_for_xhr
       # Let's get the tour modal while we're at it...
       page.execute_script("$('#closeInitialTourModal').trigger('click')")
       # Now the banner...
-      if page.has_css?('a[class="banner-close"]')
+      while page.has_css?('.banner-close') do
         find('a[class="banner-close"]').click
+        wait_for_xhr
       end
     end
 

--- a/spec/helpers/page_helpers.rb
+++ b/spec/helpers/page_helpers.rb
@@ -91,13 +91,11 @@ module Helpers
     end
 
     def dismiss_banner
-      wait_for_xhr
       # Let's get the tour modal while we're at it...
       page.execute_script("$('#closeInitialTourModal').trigger('click')")
       # Now the banner...
       if page.has_css?('a[class="banner-close"]')
         find('a[class="banner-close"]').click
-        wait_for_xhr
       end
     end
 


### PR DESCRIPTION
The issue is that a granule may have duplicate links towards the same file, with one using FTP and the other HTML.  This PR adds a filter mechanism to check and will suppress any FTP file links that already have HTML links present.

Collection 'C1444742099-PODAAC' was the one flagged in the ticket and is suitable for testing - check out the single granule 'dropdown' on production and see that there are two links - one to FTP and the other to HTML, which reference the same file name.  Contrast with this PR and see that it sends the user only to the HTML link and suppresses the FTP reference.