### PR TITLE
EDSC 1733: Created New Modal for Collections that Might Cause Delays

### DIFF
--- a/app/assets/javascripts/models/ui/project_list.js.coffee
+++ b/app/assets/javascripts/models/ui/project_list.js.coffee
@@ -95,6 +95,8 @@ ns.ProjectList = do (ko
       limit = false
       limit = collection.tags()['edsc.collection_alerts']['data']['limit'] if collection.tags() && collection.tags()['edsc.collection_alerts']
       if limit && collection.granuleCount() > limit
+        message = collection.tags()['edsc.collection_alerts']['data']['message']
+        if message then $("#delayOptionalMessage").text(message) else $("#delayOptionalMessage").text("")
         $("#delayWarningModal").modal('show')
       else
         @project.focus(collection)

--- a/app/assets/javascripts/models/ui/project_list.js.coffee
+++ b/app/assets/javascripts/models/ui/project_list.js.coffee
@@ -96,7 +96,7 @@ ns.ProjectList = do (ko
       limit = collection.tags()['edsc.collection_alerts']['data']['limit'] if collection.tags() && collection.tags()['edsc.collection_alerts']
       if limit && collection.granuleCount() > limit
         message = collection.tags()['edsc.collection_alerts']['data']['message']
-        if message then $("#delayOptionalMessage").text(message) else $("#delayOptionalMessage").text("")
+        if message then $("#delayOptionalMessage").text("Message from data provider: " + message) else $("#delayOptionalMessage").text("")
         $("#delayWarningModal").modal('show')
       else
         @project.focus(collection)

--- a/app/assets/javascripts/models/ui/project_list.js.coffee
+++ b/app/assets/javascripts/models/ui/project_list.js.coffee
@@ -85,22 +85,29 @@ ns.ProjectList = do (ko
         collections.splice(endIndex, 0, collection)
         @project.collections(collections)
 
+    _launchDownload: (collection) =>
+      @project.focus(collection)
+      @configureProject()
+
     awaitingStatus: =>
       @collectionsToDownload().length == 0 && @collectionOnly().length == 0 && @submittedOrders().length == 0 && @submittedServiceOrders().length == 0 && @collectionLinks().length == 0
 
     loginAndDownloadCollection: (collection) =>
       $('#delayOk').on 'click', =>
-        @project.focus(collection)
-        @configureProject()
+        @_launchDownload(collection)
       limit = false
-      limit = collection.tags()['edsc.collection_alerts']['data']['limit'] if collection.tags() && collection.tags()['edsc.collection_alerts']
+      if collection.tags()
+        if collection.tags()['edsc.collection_alerts']
+          limit = collection.tags()['edsc.collection_alerts']['data']['limit']
       if limit && collection.granuleCount() > limit
         message = collection.tags()['edsc.collection_alerts']['data']['message']
-        if message && message.length > 0 then $("#delayOptionalMessage").text("Message from data provider: " + message) else $("#delayOptionalMessage").text("")
+        if message && message.length > 0
+          $("#delayOptionalMessage").text("Message from data provider: " + message) 
+        else 
+          $("#delayOptionalMessage").text("")
         $("#delayWarningModal").modal('show')
       else
-        @project.focus(collection)
-        @configureProject()
+        @_launchDownload(collection)
 
     loginAndDownloadGranule: (collection, granule) =>
       @project.focus(collection)

--- a/app/assets/javascripts/models/ui/project_list.js.coffee
+++ b/app/assets/javascripts/models/ui/project_list.js.coffee
@@ -96,7 +96,7 @@ ns.ProjectList = do (ko
       limit = collection.tags()['edsc.collection_alerts']['data']['limit'] if collection.tags() && collection.tags()['edsc.collection_alerts']
       if limit && collection.granuleCount() > limit
         message = collection.tags()['edsc.collection_alerts']['data']['message']
-        if message then $("#delayOptionalMessage").text("Message from data provider: " + message) else $("#delayOptionalMessage").text("")
+        if message && message.length > 0 then $("#delayOptionalMessage").text("Message from data provider: " + message) else $("#delayOptionalMessage").text("")
         $("#delayWarningModal").modal('show')
       else
         @project.focus(collection)

--- a/app/assets/javascripts/models/ui/project_list.js.coffee
+++ b/app/assets/javascripts/models/ui/project_list.js.coffee
@@ -89,8 +89,16 @@ ns.ProjectList = do (ko
       @collectionsToDownload().length == 0 && @collectionOnly().length == 0 && @submittedOrders().length == 0 && @submittedServiceOrders().length == 0 && @collectionLinks().length == 0
 
     loginAndDownloadCollection: (collection) =>
-      @project.focus(collection)
-      @configureProject()
+      $('#delayOk').on 'click', =>
+        @project.focus(collection)
+        @configureProject()
+      limit = false
+      limit = collection.tags()['edsc.collection_alerts']['data']['limit'] if collection.tags() && collection.tags()['edsc.collection_alerts']
+      if limit && collection.granuleCount() > limit
+        $("#delayWarningModal").modal('show')
+      else
+        @project.focus(collection)
+        @configureProject()
 
     loginAndDownloadGranule: (collection, granule) =>
       @project.focus(collection)

--- a/app/assets/javascripts/models/ui/service_options_list.js.coffee
+++ b/app/assets/javascripts/models/ui/service_options_list.js.coffee
@@ -96,21 +96,14 @@ ns.ServiceOptionsList = do (ko, $=jQuery, config=@edsc.models.data.config) ->
 
 
     submitRequest: =>
-      for accessCollection in @project.accessCollections()
-        # find current collection
-        if accessCollection.collection.id == this.currentCollection().id
-          # number of granules in the order
-          console.error accessCollection.granuleAccessOptions().hits
-          $("#delayWarningModal").modal('show')
-      
-      # $('.access-submit').prop('disabled', true)
-      # if @needsContactInfo() && @accountForm.isEditingNotificationPreference()
-      #  @accountForm.saveAccountEdit =>
-      #    @downloadProject()
-      #  # re-enable button if saveAccountEdit fails
-      #  $('.access-submit').prop('disabled', false)
-      # else
-      #  @downloadProject()
+      $('.access-submit').prop('disabled', true)
+      if @needsContactInfo() && @accountForm.isEditingNotificationPreference()
+        @accountForm.saveAccountEdit =>
+          @downloadProject()
+        # re-enable button if saveAccountEdit fails
+        $('.access-submit').prop('disabled', false)
+      else
+        @downloadProject()
 
     showGranuleList: =>
       @showGranules(true)

--- a/app/assets/javascripts/models/ui/service_options_list.js.coffee
+++ b/app/assets/javascripts/models/ui/service_options_list.js.coffee
@@ -96,14 +96,21 @@ ns.ServiceOptionsList = do (ko, $=jQuery, config=@edsc.models.data.config) ->
 
 
     submitRequest: =>
-      $('.access-submit').prop('disabled', true)
-      if @needsContactInfo() && @accountForm.isEditingNotificationPreference()
-        @accountForm.saveAccountEdit =>
-          @downloadProject()
-        # re-enable button if saveAccountEdit fails
-        $('.access-submit').prop('disabled', false)
-      else
-        @downloadProject()
+      for accessCollection in @project.accessCollections()
+        # find current collection
+        if accessCollection.collection.id == this.currentCollection().id
+          # number of granules in the order
+          console.error accessCollection.granuleAccessOptions().hits
+          $("#delayWarningModal").modal('show')
+      
+      # $('.access-submit').prop('disabled', true)
+      # if @needsContactInfo() && @accountForm.isEditingNotificationPreference()
+      #  @accountForm.saveAccountEdit =>
+      #    @downloadProject()
+      #  # re-enable button if saveAccountEdit fails
+      #  $('.access-submit').prop('disabled', false)
+      # else
+      #  @downloadProject()
 
     showGranuleList: =>
       @showGranules(true)

--- a/app/views/data_access/configure.html.erb
+++ b/app/views/data_access/configure.html.erb
@@ -236,3 +236,25 @@
   </div>
 </div>
 <!--end modal-->
+
+<!--begin modal-->
+<div class="modal fade" id="delayWarningModal" tabindex="-1" role="dialog" aria-labelledby="delayWarningModal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <a href="#" class="close modal-close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+        <h4 class="modal-title" id="delayWarningModalLabel">Possible Delay Ahead</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          This order includes a collection that is known to cause delays.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <a class="button text-button" href="<%= @back_path %>?<%= request.query_string %>"><i class="fa fa-arrow-circle-left"></i> Refine your search</a>
+        <a class="button text-button" data-dismiss="modal" href="#">Cancel</a>
+      </div>
+    </div>
+  </div>
+</div>
+<!--end modal-->

--- a/app/views/data_access/configure.html.erb
+++ b/app/views/data_access/configure.html.erb
@@ -236,25 +236,3 @@
   </div>
 </div>
 <!--end modal-->
-
-<!--begin modal-->
-<div class="modal fade" id="delayWarningModal" tabindex="-1" role="dialog" aria-labelledby="delayWarningModal">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <a href="#" class="close modal-close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
-        <h4 class="modal-title" id="delayWarningModalLabel">Possible Delay Ahead</h4>
-      </div>
-      <div class="modal-body">
-        <p>
-          This order includes a collection that is known to cause delays.
-        </p>
-      </div>
-      <div class="modal-footer">
-        <a class="button text-button" href="<%= @back_path %>?<%= request.query_string %>"><i class="fa fa-arrow-circle-left"></i> Refine your search</a>
-        <a class="button text-button" data-dismiss="modal" href="#">Cancel</a>
-      </div>
-    </div>
-  </div>
-</div>
-<!--end modal-->

--- a/app/views/search/_delay_modal.html.erb
+++ b/app/views/search/_delay_modal.html.erb
@@ -8,7 +8,7 @@
       </div>
       <div class="modal-body">
         <p>
-          This collection is known to cause delays and may take longer to download than expected.
+          The amount of granules requested for download may result in a significant delay. You may wish to further refine your search to limit the size of your download. Are you sure you want to continue?
         </p>
         <p>
           <span id='delayOptionalMessage'></span>

--- a/app/views/search/_delay_modal.html.erb
+++ b/app/views/search/_delay_modal.html.erb
@@ -1,0 +1,21 @@
+<!--begin modal-->
+<div class="modal" id="delayWarningModal" tabindex="-1" role="dialog" aria-labelledby="delayWarningModal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <a href="#" class="close modal-close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+        <h4 class="modal-title" id="delayWarningModalLabel">Possible Delay Ahead</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          This collection is known to cause delays and may take longer to download than expected.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Okay</a>
+        <a class="button text-button" id="delayCancel" data-dismiss="modal" href="#">Cancel</a>
+      </div>
+    </div>
+  </div>
+</div>
+<!--end modal-->

--- a/app/views/search/_delay_modal.html.erb
+++ b/app/views/search/_delay_modal.html.erb
@@ -10,6 +10,9 @@
         <p>
           This collection is known to cause delays and may take longer to download than expected.
         </p>
+        <p>
+          <span id='delayOptionalMessage'></span>
+        </p>
       </div>
       <div class="modal-footer">
         <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Okay</a>

--- a/app/views/search/_delay_modal.html.erb
+++ b/app/views/search/_delay_modal.html.erb
@@ -15,7 +15,7 @@
         </p>
       </div>
       <div class="modal-footer">
-        <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Okay</a>
+        <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Continue</a>
         <a class="button text-button" id="delayCancel" data-dismiss="modal" href="#">Cancel</a>
       </div>
     </div>

--- a/app/views/search/_delay_modal.html.erb
+++ b/app/views/search/_delay_modal.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="modal-footer">
         <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Continue</a>
-        <a class="button text-button" id="delayCancel" data-dismiss="modal" href="#">Cancel</a>
+        <a class="button text-button" id="delayCancel" data-dismiss="modal" href="#">Refine Search</a>
       </div>
     </div>
   </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -334,27 +334,6 @@
   </div>
 </div>
 
-<!--begin modal-->
-<div class="modal" id="delayWarningModal" tabindex="-1" role="dialog" aria-labelledby="delayWarningModal">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <a href="#" class="close modal-close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
-        <h4 class="modal-title" id="delayWarningModalLabel">Possible Delay Ahead</h4>
-      </div>
-      <div class="modal-body">
-        <p>
-          This collection is one that is known to cause delays and may take longer than expected.
-        </p>
-      </div>
-      <div class="modal-footer">
-        <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Got it!</a>
-      </div>
-    </div>
-  </div>
-</div>
-<!--end modal-->
-
 <form id="data-access" method="POST" action="/data/configure" style="display:none;">
   <div>
     <input name="authenticity_token" type="hidden" value="<%= form_authenticity_token %>" />
@@ -371,6 +350,7 @@
 <% content_for :global do %>
   <%= render partial: 'variables_modal' %>
   <%= render partial: 'sitetour_modal' %>
+  <%= render partial: 'delay_modal' %>
   <%= render partial: 'reverb_retirement_modal' %>
   <%= render partial: 'customize_data_modal' %>
   <%= render partial: 'related_urls_modal' %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -334,6 +334,27 @@
   </div>
 </div>
 
+<!--begin modal-->
+<div class="modal" id="delayWarningModal" tabindex="-1" role="dialog" aria-labelledby="delayWarningModal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <a href="#" class="close modal-close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+        <h4 class="modal-title" id="delayWarningModalLabel">Possible Delay Ahead</h4>
+      </div>
+      <div class="modal-body">
+        <p>
+          This collection is one that is known to cause delays and may take longer than expected.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <a class="button text-button" id="delayOk" data-dismiss="modal" href="#">Got it!</a>
+      </div>
+    </div>
+  </div>
+</div>
+<!--end modal-->
+
 <form id="data-access" method="POST" action="/data/configure" style="display:none;">
   <div>
     <input name="authenticity_token" type="hidden" value="<%= form_authenticity_token %>" />

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -6742,6 +6742,21 @@ http_interactions:
   digest: 7a17938e3126aaa7e25d52859e96340ee2272080
 - request:
     method: get
+    uri: https://cmr.sit.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C24931-LAADS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 08 Feb 2018 20:30:59 GMT
+  digest: bbd22eb8078e5494ec1a29daf98ef31f35220e9d
+- request:
+    method: get
     uri: https://cmr.sit.earthdata.nasa.gov/search/collections.json?include_facets=v2&data_center_h%5B%5D=DOE%2FORNL%2FESD%2FCDIAC&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII
@@ -8195,6 +8210,21 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Wed, 09 Aug 2017 17:21:45 GMT
   digest: f6f60b57bbd6ab64be4cbab5ca8b19406abecf7f
+- request:
+    method: get
+    uri: https://cmr.sit.earthdata.nasa.gov/search/collections.json?page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&sort_key%5B%5D=score&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&keyword=C24931-LAADS%2A&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 08 Feb 2018 20:31:01 GMT
+  digest: 3a7bdc8956bae78c13bf2766fb4da6e47aed5219
 - request:
     method: get
     uri: https://cmr.sit.earthdata.nasa.gov/search/collections.json?point=0%2C0&page_size=20&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules&has_granules=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&sort_key%5B%5D=score&echo_collection_id%5B%5D=C1229626387-LANCEMODIS&echo_collection_id%5B%5D=C1219032686-LANCEMODIS&keyword=C1200019403-MMT_2%2A&include_has_granules=true&include_granule_counts=true

--- a/fixtures/cassettes/granules_requests.yml
+++ b/fixtures/cassettes/granules_requests.yml
@@ -4244,4 +4244,21 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Fri, 04 Nov 2016 18:36:41 GMT
   digest: 0a5b93d92fa7fae1ac5dcf11ce7bd0fb4b89c3b5
+- request:
+    method: post
+    uri: https://cmr.sit.earthdata.nasa.gov/search/granules.json
+    body:
+      encoding: US-ASCII
+      string: echo_collection_id=C24931-LAADS&page_num=1&page_size=20&sort_key%5B%5D=-start_date
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 08 Feb 2018 20:31:03 GMT
+  digest: 81b83e9cfc773ccd94f61904da9509a9e640b610
 recorded_with: VCR 2.6.0

--- a/fixtures/cassettes/timeline_requests.yml
+++ b/fixtures/cassettes/timeline_requests.yml
@@ -6873,4 +6873,21 @@ http_interactions:
       - eed-edsc-dev
   recorded_at: Fri, 04 Nov 2016 18:36:43 GMT
   digest: 40aeb9e9068c7af924f875ac30e2b085d2a155ac
+- request:
+    method: post
+    uri: https://cmr.sit.earthdata.nasa.gov/search/granules/timeline.json
+    body:
+      encoding: US-ASCII
+      string: concept_id=C24931-LAADS&end_date=2019-02-02T17%3A31%3A12.000Z&interval=day&start_date=2016-01-31T17%3A31%3A12.000Z
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Thu, 08 Feb 2018 20:31:05 GMT
+  digest: 79a3a79488ba12685b94a83ed49835b584df541a
 recorded_with: VCR 2.6.0

--- a/fixtures/cassettes/timeline_responses.yml
+++ b/fixtures/cassettes/timeline_responses.yml
@@ -9189,3 +9189,27 @@ ef4a818f7f48e160eec387ecc6edfde9d5303d7d:
       encoding: UTF-8
       string: '[{"concept-id":"C1000001002-EDF_OPS","intervals":[[1293840000,1294099200,2]]}]'
     http_version: 
+79a3a79488ba12685b94a83ed49835b584df541a:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cmr-request-id:
+      - d54e9338-95b3-4538-a45a-8e0382ba38cf
+      date:
+      - Thu, 08 Feb 2018 20:31:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      content-length:
+      - '2'
+      connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -322,12 +322,14 @@ describe "Granule list", reset: false do
 
   context "for collections that are known to cause download delays" do
     before :all do
-      visit('/search/granules?p=DELAY_ORDER&tl=1501695072!4!!&q=DELAY_ORDER&ok=DELAY_ORDER')
+      visit('/search/granules?cmr_env=sit&p=C24931-LAADS&tl=1501695072!4!!&q=C24931-LAADS&ok=C24931-LAADS')
       wait_for_xhr
+      Capybara::Screenshot.screenshot_and_save_page
       click_button('Download Data')
     end
     it "shows a modal warning of the delay" do
       expect(page).to have_css('#delayWarningModalLabel')
+      expect(page).to have_text('This is an optional message.')
     end
   end
 end

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -319,4 +319,15 @@ describe "Granule list", reset: false do
       expect(page).not_to have_link("The FTP location for the granule.")
     end
   end
+
+  context "for collections that are known to cause download delays" do
+    before :all do
+      visit('/search/granules?p=DELAY_ORDER&tl=1501695072!4!!&q=DELAY_ORDER&ok=DELAY_ORDER')
+      wait_for_xhr
+      click_button('Download Data')
+    end
+    it "shows a modal warning of the delay" do
+      expect(page).to have_css('#delayWarningModalLabel')
+    end
+  end
 end

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -324,7 +324,6 @@ describe "Granule list", reset: false do
     before :all do
       visit('/search/granules?cmr_env=sit&p=C24931-LAADS&tl=1501695072!4!!&q=C24931-LAADS&ok=C24931-LAADS')
       wait_for_xhr
-      Capybara::Screenshot.screenshot_and_save_page
       click_button('Download Data')
     end
     it "shows a modal warning of the delay" do

--- a/spec/features/granules/granule_list_spec.rb
+++ b/spec/features/granules/granule_list_spec.rb
@@ -328,7 +328,7 @@ describe "Granule list", reset: false do
     end
     it "shows a modal warning of the delay" do
       expect(page).to have_css('#delayWarningModalLabel')
-      expect(page).to have_text('This is an optional message.')
+      expect(page).to have_text('Message from data provider: This is an optional message.')
     end
   end
 end


### PR DESCRIPTION
This new modal will appear based upon the following tagging system:

```
"edsc.collection_alerts": {
 "data": {
 "limit": 10,
 "message": "Optional message to be displayed in the modal"
 }
}
```

When the 'Download Data' button is clicked from the granules page of a collection, a check is made to see if this tag is set for the targeted collection, and if so it checks whether the number of granules is greater than the 'limit'.  If it is - it shows the modal warning the user of the possible delay as well as shows the optional message, if present.

Collection 'C24931-LAADS' on SIT has this flag set and is suitable for testing.