### PR TITLE
EDSC-1722: Updated title hovertip so that it is cleared after method selection

### DIFF
--- a/app/assets/javascripts/models/data/service_options.js.coffee
+++ b/app/assets/javascripts/models/data/service_options.js.coffee
@@ -180,6 +180,8 @@ ns.ServiceOptions = do (ko, edsc = @edsc, KnockoutModel = @edsc.models.KnockoutM
         if @granuleAccessOptions().methods?.length == 1
           m.method(m.availableMethods[0].name)
         result = true if (m.isValid() || !m.loadForm()) && m.method()?
+      if result
+        $('.access-submit').prop('title', "");
       result
 
     addAccessMethod: =>


### PR DESCRIPTION
This PR is an add-on for EDSC-1722: the purpose is to simply clear the 'title' hovertip once a method has been selected.