### PR TITLE
EDSC-1599: Added additional logging during data retrieval

### DIFF
--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -51,8 +51,8 @@ class DataAccessController < ApplicationController
     retrieval.project = project
     retrieval.save!
 
-    Rails.logger.info("The following task is being submitted to delayed_job: " + params[:project]) 
-    Retrieval.delay.process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
+    new_job = Retrieval.delay.process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
+    Rails.logger.info("A new delayed job with ID " + new_job.id.to_s + " has been created: " + params[:project]) 
 
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -51,6 +51,7 @@ class DataAccessController < ApplicationController
     retrieval.project = project
     retrieval.save!
 
+    Rails.logger.info("The following task is being submitted to delayed_job: " + params[:project]) 
     Retrieval.delay.process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
 
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")


### PR DESCRIPTION
This additional logging will output the data request object when the 'Submit' button is clicked as per the following:

The following task is being submitted to delayed_job: {"query":"p=C179003620-ORNL_DAAC","collections":[{"id":"C179003620-ORNL_DAAC","params":"echo_collection_id=C179003620-ORNL_DAAC&sort_key%5B%5D=-start_date&page_size=20","serviceOptions":{"accessMethod":[{"method":"Order","type":"order","id":null}]},"form_hashes":[{"id":"order","form_hash":null}]}],"source":"p=C179003620-ORNL_DAAC&tl=1503944607!4!!&back=%2Fsearch%2Fgranules"}

It's worth noting that a test to check for this logging isn't available - I do not believe our test suites check logging (or are even able to).

