### PR TITLE
EDSC-1534: Implemented delayed_job queues and added additional workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./start.sh
-jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 run
+jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 start
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: ./start.sh
-jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 start
+jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 run
+worker: bundle exec rake jobs:work
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 web: ./start.sh
 normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
-priority_jobs: bundle exec bin/delayed_job --pool=NSIDC,LPDAAC:2 run
+priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC run
 worker: bundle exec rake jobs:work
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./start.sh
-jobs: bundle exec bin/delayed_job run
+jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 run
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,6 @@
 web: ./start.sh
-jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 run
+normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
+priority_jobs: bundle exec bin/delayed_job --pool=NSIDC,LPDAAC:2 run
 worker: bundle exec rake jobs:work
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -66,7 +66,7 @@ class DataAccessController < ApplicationController
       end
     end
     new_job = Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
-    Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
+    Rails.logger.info("Delayed Job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end
 

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -66,7 +66,15 @@ class DataAccessController < ApplicationController
       end
     end
     new_job = Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
-    Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
+    if new_job
+      if new_job.queue
+        Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
+      end
+      Rails.logger.info("There was an issue reading the queue from the newest job.")
+    else
+      Rails.logger.info("Retrieval returned an unexpected object when attempting to create a new job.")
+    end
+
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end
 

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -52,7 +52,7 @@ class DataAccessController < ApplicationController
     retrieval.save!
     
     queue = "Default"
-    daacs = ENV["priority_daacs"].split(",")
+    daacs = ENV["priority_daacs"] ? ENV["priority_daacs"].split(",") : []
     collections = JSON.parse(params[:project])['collections']
     daacs.each do |daac|
       collections.each do |collection|

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -65,7 +65,8 @@ class DataAccessController < ApplicationController
         break
       end
     end
-    Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
+    new_job = Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
+    Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end
 

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -66,15 +66,7 @@ class DataAccessController < ApplicationController
       end
     end
     new_job = Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
-    if new_job
-      if new_job.queue
-        Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
-      end
-      Rails.logger.info("There was an issue reading the queue from the newest job.")
-    else
-      Rails.logger.info("Retrieval returned an unexpected object when attempting to create a new job.")
-    end
-
+    Rails.logger.info("Delayed job " + new_job.id.to_s + " has been sent into queue " + new_job.queue.to_s + " with:" + params[:project]) 
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end
 

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -52,7 +52,7 @@ class DataAccessController < ApplicationController
     retrieval.save!
     
     queue = "Default"
-    daacs = ENV["priority_daacs"] ? ENV["priority_daacs"].split(",") : []
+    daacs = ['NSIDC', 'LPDAAC']
     collections = JSON.parse(params[:project])['collections']
     daacs.each do |daac|
       collections.each do |collection|

--- a/app/controllers/data_access_controller.rb
+++ b/app/controllers/data_access_controller.rb
@@ -50,10 +50,22 @@ class DataAccessController < ApplicationController
     retrieval.user = user
     retrieval.project = project
     retrieval.save!
-
-    new_job = Retrieval.delay.process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
-    Rails.logger.info("A new delayed job with ID " + new_job.id.to_s + " has been created: " + params[:project]) 
-
+    
+    queue = "Default"
+    daacs = ENV["priority_daacs"].split(",")
+    collections = JSON.parse(params[:project])['collections']
+    daacs.each do |daac|
+      collections.each do |collection|
+        if collection['id'].include? daac
+          queue = daac
+          break
+        end
+      end
+      if queue != "Default"
+        break
+      end
+    end
+    Retrieval.delay(:queue => queue).process(retrieval.id, token, cmr_env, edsc_path(request.base_url + '/'), session[:access_token])
     redirect_to edsc_path("/data/retrieve/#{retrieval.to_param}")
   end
 

--- a/app/models/retrieval.rb
+++ b/app/models/retrieval.rb
@@ -76,19 +76,19 @@ class Retrieval < ActiveRecord::Base
 
   def self.error(job, exception)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.error "Delayed Job #{job.id} from the #{job.queue } queue has encountered an error during its #{job.attempts + 1} attempt. That error is: #{exception}"
+      logger.error "Delayed Job #{job.id} from the #{job.queue} queue has encountered an error during its #{job.attempts + 1} attempt. That error is: #{exception}"
     end
   end
 
   def self.failure(job)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.error "Delayed Job #{job.id} from the #{job.queue } queue has failed and will not be retried."
+      logger.error "Delayed Job #{job.id} from the #{job.queue} queue has failed and will not be retried."
     end
   end
 
   def self.success(job)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.info "Delayed Job #{job.id} from the #{job.queue } queue has completed processing."
+      logger.info "Delayed Job #{job.id} from the #{job.queue} queue has completed processing."
     end
   end
 

--- a/app/models/retrieval.rb
+++ b/app/models/retrieval.rb
@@ -60,9 +60,9 @@ class Retrieval < ActiveRecord::Base
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
       queued_jobs = DelayedJob.where(failed_at: nil)
       if job.attempts == 0
-        logger.info "Delayed Job #{job.id} is beginning its work - there are #{queued_jobs.size - 1} orders waiting in line behind it."
+        logger.info "Delayed Job #{job.id} from the #{job.queue } queue is beginning its work - there are #{queued_jobs.size - 1} orders waiting in line behind it."
       else
-        logger.info "Delayed Job #{job.id} has begun its work after failing #{job.attempts} time - there are #{queued_jobs.size - 1} orders waiting in line behind it."
+        logger.info "Delayed Job #{job.id} from the #{job.queue } queue has begun its work after failing #{job.attempts} time - there are #{queued_jobs.size - 1} orders waiting in line behind it."
       end
     end
   end
@@ -76,19 +76,19 @@ class Retrieval < ActiveRecord::Base
 
   def self.error(job, exception)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.error "Delayed Job #{job.id} has encountered an error during its #{job.attempts + 1} attempt. That error is: #{exception}"
+      logger.error "Delayed Job #{job.id} from the #{job.queue } queue has encountered an error during its #{job.attempts + 1} attempt. That error is: #{exception}"
     end
   end
 
   def self.failure(job)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.error "Delayed Job #{job.id} has failed and will not be retried."
+      logger.error "Delayed Job #{job.id} from the #{job.queue } queue has failed and will not be retried."
     end
   end
 
   def self.success(job)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
-      logger.info "Delayed Job #{job.id} has completed processing."
+      logger.info "Delayed Job #{job.id} from the #{job.queue } queue has completed processing."
     end
   end
 

--- a/app/models/retrieval.rb
+++ b/app/models/retrieval.rb
@@ -70,7 +70,7 @@ class Retrieval < ActiveRecord::Base
   def self.enqueue(job)
     logger.tagged("delayed_job version: #{Rails.configuration.version}") do
       queued_jobs = DelayedJob.where(failed_at: nil)
-      logger.info "A new delayed job is being enqueued into processing - there are #{queued_jobs.size} orders ahead of this job in the queue."
+      logger.info "A new Delayed Job is being enqueued into processing - there are #{queued_jobs.size} orders ahead of this job in the queue."
     end
   end 
 


### PR DESCRIPTION
The issue this ticket addresses is that job retrieval can become hung up if the single delayed_job worker becomes 'enthralled' with a long standing task, such as those coming from NSIDC.  The current implementation of data retrieval uses only a single lowly worker and one queue.

Edit: An earlier version of this PR required a modification to config/application.yml - this is no longer necessary.

My largest concern is with the instruction:

jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=NSIDC,LPDAAC:2 --pool=*:2 run

I *believe* this will work, however my ability to test this line locally is limited.  It works well enough using 'start' instead of 'run' - when I use 'run', it keeps the process in the foreground (which it is supposed to do) however doesn't seem to start all the workers.  I am very interested to see how this line will behave on SIT.

To explain that line - what that does, is it creates two workers for the 'Default' pool, two workers for the 'NSIDC,LPDAAC' pool, and then two extra workers who will do anything that comes up that needs doing in either queue.