### PR TITLE
EDSC-1717: Sets related_urls to empty if there are no Related URLs

### DIFF
--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -207,10 +207,14 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
       end
     end
 
-    # URLs hsould be listed alphabetically and grouped by Type
+    # URLs should be listed alphabetically and grouped by Type
     related_urls.each do |url_category|
       url_category[:urls].sort_by! {|url| [url['Type'], url['Subtype'], url['URL']]}
     end
+
+    # related_urls should be empty if there are no Related URLs
+    related_urls.each {|x| if !(x[:urls].empty?) then return related_urls end}
+    related_urls = []
 
     related_urls
   end

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -214,9 +214,7 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
 
     # related_urls should be empty if there are no Related URLs
     related_urls.each {|x| if !(x[:urls].empty?) then return related_urls end}
-    related_urls = []
-
-    related_urls
+    []
   end
 
   def format_url(url)

--- a/app/presenters/collection_details_presenter_umm_json.rb
+++ b/app/presenters/collection_details_presenter_umm_json.rb
@@ -213,7 +213,7 @@ class CollectionDetailsPresenterUmmJson < DetailsPresenterUmmJson
     end
 
     # related_urls should be empty if there are no Related URLs
-    related_urls.each {|x| if !(x[:urls].empty?) then return related_urls end}
+    related_urls.each {|x| if (x[:urls].any?) then return related_urls end}
     []
   end
 

--- a/fixtures/cassettes/collections_requests.yml
+++ b/fixtures/cassettes/collections_requests.yml
@@ -402,6 +402,21 @@ http_interactions:
   digest: 772abdc4d5bd7e55274f6b4d96b6c166afb8f34c
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1297504182-LARC&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules_or_cwic&has_granules_or_cwic=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Mon, 12 Mar 2018 14:43:59 GMT
+  digest: 00fa35331bd9024276eb71007699e846c58e3f70
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/collections.json?echo_collection_id%5B%5D=C1353062857-NSIDC_ECS&page_num=1&include_tags=edsc.%2A%2Corg.ceos.wgiss.cwic.granules.prod&sort_key%5B%5D=has_granules_or_cwic&has_granules_or_cwic=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&include_has_granules=true&include_granule_counts=true
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/concepts_requests.yml
+++ b/fixtures/cassettes/concepts_requests.yml
@@ -209,6 +209,21 @@ http_interactions:
   digest: 2cc5633aa91d0d85904d4c8539c96cd4e7e946da
 - request:
     method: get
+    uri: https://cmr.earthdata.nasa.gov/search/concepts/C1297504182-LARC.umm_json_v1_9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      Client-Id:
+      - eed-edsc-dev
+      Echo-ClientId:
+      - eed-edsc-dev
+  recorded_at: Mon, 12 Mar 2018 14:44:01 GMT
+  digest: 15aec1b6194aeff77e4bb8da9a61d5be5965c825
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/search/concepts/C1358859924-ORNL_DAAC.json
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/concepts_responses.yml
+++ b/fixtures/cassettes/concepts_responses.yml
@@ -1032,6 +1032,68 @@ d7fb0692d7fe1bfad11ee1e7f524d798474029db:
         Satellite Facility"},{"Roles":["ARCHIVER"],"ShortName":"Alaska Satellite Facility"},{"Roles":["ARCHIVER"],"ShortName":"Not
         provided","ContactInformation":{"ContactMechanisms":[{"Type":"Primary","Value":"907-474-5041"},{"Type":"Email","Value":"uso@asf.alaska.edu"}]}}]}'
     http_version: 
+15aec1b6194aeff77e4bb8da9a61d5be5965c825:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-origin:
+      - "*"
+      access-control-expose-headers:
+      - CMR-Hits, CMR-Request-Id
+      cmr-request-id:
+      - b435bb78-a780-4bef-b0db-8a424ba6568f
+      content-type:
+      - application/vnd.nasa.cmr.umm+json;version=1.9; charset=utf-8
+      date:
+      - Mon, 12 Mar 2018 14:43:56 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains;
+      vary:
+      - Accept-Encoding, User-Agent
+      content-length:
+      - '1933'
+      connection:
+      - Close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"MetadataDates":[{"Date":"2016-06-03T00:00:00.000Z","Type":"UPDATE"}],"VersionDescription":"Gridded
+        joint TIR/NIR-based CO retrievals based on MERRA 2 meteorological fields,
+        time-varying N2O and updated HITRAN data","ShortName":"MOP03J","Abstract":"The
+        MOPITT L3 files contain daily and monthly mean gridded versions of the daily
+        L2 CO profile and total column retrievals. The averaging kernels associated
+        with each retrieval are also gridded and included in the L3 files. For a description
+        of the file contents, refer to the File Spec Document. Please see the MOPITT
+        L2 Data Quality Statement for additional information about the quality and
+        the limitations of the retrievals. [From the MOPITT V3 Level 3 Data Quality
+        Summary] Measurements Of Pollution In The Troposphere (MOPITT) was successfully
+        launched into sun-synchronous polar orbit aboard Terra, NASA''s first Earth
+        Observing System spacecraft on December 18, 1999. The MOPITT instrument was
+        constructed by a consortium of Canadian companies and funded by the Space
+        Science Division of the Canadian Space Agency.","DataDates":[{"Date":"2016-06-15T13:49:31.944Z","Type":"CREATE"},{"Date":"2016-07-05T11:36:30.766Z","Type":"UPDATE"}],"SpatialExtent":{"SpatialCoverageType":"HORIZ&VERT","HorizontalSpatialDomain":{"Geometry":{"CoordinateSystem":"CARTESIAN","BoundingRectangles":[{"WestBoundingCoordinate":-180.0,"NorthBoundingCoordinate":90.0,"EastBoundingCoordinate":180.0,"SouthBoundingCoordinate":-90.0}]}},"GranuleSpatialRepresentation":"CARTESIAN"},"AdditionalAttributes":[{"Value":"10.5067/TERRA/MOPITT/MOP03J_L3.007","Name":"identifier_product_doi","Description":"Digital
+        object identifier that uniquely identifies this data product","DataType":"STRING"},{"Value":"http://dx.doi.org","Name":"identifier_product_doi_authority","Description":"URL
+        of the digital object identifier resolving authority","DataType":"STRING"}],"ScienceKeywords":[{"Category":"EARTH
+        SCIENCE","Topic":"ATMOSPHERE","Term":"ATMOSPHERIC CHEMISTRY/CARBON AND HYDROCARBON
+        COMPOUNDS","VariableLevel1":"CARBON MONOXIDE"},{"Category":"EARTH SCIENCE","Topic":"ATMOSPHERE","Term":"AIR
+        QUALITY","VariableLevel1":"CARBON MONOXIDE"}],"EntryTitle":"MOPITT CO gridded
+        daily means (Near and Thermal Infrared Radiances) V007","CollectionProgress":"IN
+        WORK","TemporalKeywords":["daily"],"ProcessingLevel":{"ProcessingLevelDescription":"GRID","Id":"3"},"Platforms":[{"Type":"Spacecraft","ShortName":"TERRA","LongName":"Earth
+        Observing System, TERRA (AM-1)","Instruments":[{"ShortName":"MOPITT","LongName":"Measurements
+        of Pollution In The Troposphere","Technique":"Correlation Radiometry","ComposedOf":[{"ShortName":"2.3um
+        Radiometer","LongName":"Correlation Radiometer at 2.3 um","Technique":"Correlation
+        Radiometry"},{"ShortName":"2.4um Radiometer","LongName":"Correlation Radiometer
+        at 2.4 um","Technique":"Correlation Radiometry"},{"ShortName":"4.7um Radiometer","LongName":"Correlation
+        Radiometer at 4.7 um","Technique":"Correlation Radiometry"}]}]}],"Version":"007","TemporalExtents":[{"PrecisionOfSeconds":6,"EndsAtPresentFlag":true,"RangeDateTimes":[{"BeginningDateTime":"2000-03-03T00:00:00.000Z"}]}],"DataCenters":[{"Roles":["PROCESSOR"],"ShortName":"LaRC"},{"Roles":["ARCHIVER"],"ShortName":"LaRC"},{"Roles":["ARCHIVER"],"ShortName":"Not
+        provided","ContactPersons":[{"Roles":["Technical Contact"],"FirstName":"Helen","LastName":"Worden"}],"ContactInformation":{"ContactInstruction":"None","ContactMechanisms":[{"Type":"Telephone","Value":"303-497-2912"},{"Type":"Telephone","Value":"303-497-1400"},{"Type":"Email","Value":"hmw@ucar.edu"}],"Addresses":[{"StreetAddresses":["Atmospheric
+        Chemistry Observations & Modeling (ACOM) Laboratory, National Center for Atmospheric
+        Research, P.O. Box 3000"],"City":"Boulder","StateProvince":"Colorado","Country":"USA","PostalCode":"80307"}]}},{"Roles":["ARCHIVER"],"ShortName":"NASA
+        Langley ASDC User Services","ContactInformation":{"ServiceHours":"8:00 A.M.
+        to 4:30 P.M., U.S. Eastern Time, Monday through Friday, excluding U.S. holidays.","ContactInstruction":"None","ContactMechanisms":[{"Type":"Telephone","Value":"757-864-8656"},{"Type":"Fax","Value":"757-864-8807"},{"Type":"Email","Value":"support-asdc@earthdata.nasa.gov"}],"Addresses":[{"StreetAddresses":["NASA
+        Langley Research Center, Mail Stop 157D"],"City":"Hampton","StateProvince":"Virginia","Country":"USA","PostalCode":"23681-2199"}]}}]}'
+    http_version: 
 d0f614e05eeabbbd562460b9013bbdcf9dce6515:
   response:
     status:

--- a/fixtures/cassettes/services_requests.yml
+++ b/fixtures/cassettes/services_requests.yml
@@ -200,6 +200,50 @@ http_interactions:
   digest: 74e6b08ac41f7484f5a30df1ade39fdad7f542fc
 - request:
     method: get
+    uri: http://localhost:15400/nlp?text=AST_L1AE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Tue, 13 Mar 2018 15:57:05 GMT
+  digest: ca3d7345f2c73b6b210b399ad385d7c40837679d
+- request:
+    method: get
+    uri: http://localhost:15400/nlp?text=C1216393716-EDF_OPS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Tue, 13 Mar 2018 15:57:11 GMT
+  digest: 4e64915e87d6ec1c80802e36d6a3ddc6df5911bb
+- request:
+    method: get
+    uri: http://localhost:15400/nlp?text=C1386246913-NSIDCV0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Tue, 13 Mar 2018 15:56:57 GMT
+  digest: 8b849487174c138af0b2fb703a4b0ddba8ae1015
+- request:
+    method: get
+    uri: http://localhost:15400/nlp?text=C179002945-ORNL_DAAC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+  recorded_at: Tue, 13 Mar 2018 15:56:59 GMT
+  digest: 4123138ffb200cdffd193eb8e246ac15b38b6c2d
+- request:
+    method: get
     uri: https://cmr.earthdata.nasa.gov/browse-scaler/availability
     body:
       encoding: US-ASCII

--- a/fixtures/cassettes/services_responses.yml
+++ b/fixtures/cassettes/services_responses.yml
@@ -823,6 +823,86 @@ a694fc934ae2c7c76bae650117b25206bc043d7a:
         cGxldGVkIGluIDBtcy4gLS0+PC9mZWVkPjwhLS0gT3BlblNlYXJjaCByZXNw
         b25zZSBjb21wbGV0ZWQgaW4gMTQxOG1zLiAtLT4K
     http_version: 
+ca3d7345f2c73b6b210b399ad385d7c40837679d:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 13 Mar 2018 15:57:05 GMT
+      content-type:
+      - application/json
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '61'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"AST_L1AE"}'
+    http_version: 
+4e64915e87d6ec1c80802e36d6a3ddc6df5911bb:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 13 Mar 2018 15:57:10 GMT
+      content-type:
+      - application/json
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '72'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1216393716-EDF_OPS"}'
+    http_version: 
+8b849487174c138af0b2fb703a4b0ddba8ae1015:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 13 Mar 2018 15:56:57 GMT
+      content-type:
+      - application/json
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '72'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C1386246913-NSIDCV0"}'
+    http_version: 
+4123138ffb200cdffd193eb8e246ac15b38b6c2d:
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 13 Mar 2018 15:56:59 GMT
+      content-type:
+      - application/json
+      vary:
+      - Accept-Encoding
+      content-length:
+      - '73'
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"edscSpatial":null,"edscTemporal":null,"keyword":"C179002945-ORNL_DAAC"}'
+    http_version: 
 a3c67c46886a10f55957a8abd1ff34d4c66514be:
   response:
     status:

--- a/spec/features/collections/collection_details_spec.rb
+++ b/spec/features/collections/collection_details_spec.rb
@@ -310,6 +310,17 @@ describe 'Collection details', reset: false do
     end
   end
 
+  context 'when selecting a collection without related urls' do
+    before do
+      load_page '/search/collection-details', focus: 'C1297504182-LARC'
+    end
+
+    it 'does not display option to view all related urls' do
+      expect(collection_details).not_to have_content 'Related URLs:'
+      expect(collection_details).not_to have_content 'View All Related URLs'
+    end
+  end
+
   context 'when selecting a collection with polygon spatial' do
     before :all do
       load_page '/search/collection-details', focus: 'C1267337984-ASF'


### PR DESCRIPTION
https://bugs.earthdata.nasa.gov/browse/EDSC-1717

There already existed a check (in _collection_details.html.erb) intended to make sure `related_urls` was not empty before displaying "Related URLs: View All Related URLs" on the collection details page. However, even if there were no Related URLs present in a collection, `related_urls` would never itself be an empty array - it was made up of objects to represent Collection URLs, Distribution URLs, Publication URLs, etc...  

The solution in this PR is to leave the check for an empty `related_urls` the same, and to set `related_urls` to actually be empty in the case where there are no Related URLs.