### PR TITLE
EDSC-1826: Updates Procfile configuration for Delayed Jobs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,5 @@
 web: ./start.sh
 normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
 priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC run
-worker: bundle exec rake jobs:work
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,6 @@
 web: ./start.sh
-normal_jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=*:2 run
-priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC --pool=*:2 run
+normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
+nsidc_jobs: bundle exec bin/delayed_job --pool=NSIDC run
+lpdaac_jobs: bundle exec bin/delayed_job --pool=LPDAAC run
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: ./start.sh
-normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
-priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC run
+normal_jobs: bundle exec bin/delayed_job --pool=Default:2 --pool=*:2 run
+priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC --pool=*:2 run
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,5 @@
 web: ./start.sh
-normal_jobs: bundle exec bin/delayed_job --pool=Default:2 run
-nsidc_jobs: bundle exec bin/delayed_job --pool=NSIDC run
-lpdaac_jobs: bundle exec bin/delayed_job --pool=LPDAAC run
+normal_jobs: bundle exec bin/delayed_job --pool=Default --pool=*:2 start
+priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC  start
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,7 @@
 web: ./start.sh
-normal_jobs: bundle exec bin/delayed_job --pool=Default --pool=*:2 start
-priority_jobs: bundle exec bin/delayed_job --pool=NSIDC --pool=LPDAAC  start
+normal_jobs: bundle exec bin/delayed_job --pool=Default run
+nsidc_jobs: bundle exec bin/delayed_job --pool=NSIDC run
+lpdaac_jobs: bundle exec bin/delayed_job --pool=LPDAAC run
+worker: bundle exec rake jobs:work
 cron: ./cron.sh
 on_build: bundle exec rake deploy:pre


### PR DESCRIPTION
This PR updates the Procfile to use the following delayed jobs configuration:

normal_jobs: bundle exec bin/delayed_job --pool=Default run
nsidc_jobs: bundle exec bin/delayed_job --pool=NSIDC run
lpdaac_jobs: bundle exec bin/delayed_job --pool=LPDAAC run
worker: bundle exec rake jobs:work