### PR TITLE
added js to ORNLDAAC portal

### DIFF
--- a/edsc/portals/ornl/src/js/edsc-portal.ornl.jsx
+++ b/edsc/portals/ornl/src/js/edsc-portal.ornl.jsx
@@ -8,4 +8,14 @@ $(document).ready(function() {
   // Pre-load logo hover image
   image = new Image();
   image.src = '/images/portals/ornl/ornl-daac-logo-color.png';
+
+  // Include collections that have no granules
+  $("p.collection-filters").hide();
+  // Not using JQuery check functionality for this part because it interferes with knockout.
+  if ($("input#hasNonEOSDIS").is(':checked') == false) {
+      $("input#hasNonEOSDIS").trigger('click')
+  }
+  if ($("input#has-granules").is(':checked') == true) {
+      $("input#has-granules").trigger('click')
+  }
 });


### PR DESCRIPTION
portal now includes collections without granules by default
ORNL DAAC has several service collections (MODIS subsetting)
  that have no ganules

Reattempting pull request after failed checks last time (#620)