### PR TITLE
EDSC-1898: Moving granules link to a new location on projects page

### DIFF
--- a/app/assets/stylesheets/modules/projects.css.scss
+++ b/app/assets/stylesheets/modules/projects.css.scss
@@ -140,7 +140,7 @@ $card-background: rgba(235,235,235,1);
       vertical-align: middle;
     }
 
-    h2, ul {
+    .project-panel {
       margin: 0;
       background: #fff;
       padding: 20px;
@@ -186,12 +186,13 @@ $card-background: rgba(235,235,235,1);
           margin-top: 15px;
 
           .label-primary {
+            display: inline;
             font-size: 1.6em;
             font-weight: bold;
-            display: inline;
           }
 
           .label-secondary {
+            margin: 0;
             font-size: .9em;
             color: #a1a1a1;
           }

--- a/app/assets/stylesheets/modules/typography.css.scss
+++ b/app/assets/stylesheets/modules/typography.css.scss
@@ -18,6 +18,21 @@ a:link, a:visited {
     color: #444;
   }
 
+  &.clean {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  &.underline {
+    text-decoration: underline;
+  }
+
+  &.subtle {
+    &:hover {
+      color: #333
+    }
+  }
+
   &.ext {
 
     &:after {
@@ -133,6 +148,20 @@ ul {
   // Expect many more lists without bullets than lists with
   list-style: none;
   padding: 0;
+}
+
+.list-inline {
+  li {
+   display: inline-block;
+  }
+}
+
+.list-divided {
+  li:not(:first-child) {
+    margin-left: 0.425em;
+    padding-left: 0.85em;
+    border-left: 1px solid #a1a1a1;
+  }
 }
 
 // Image replacement

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -57,11 +57,11 @@
   </section>
   <section class="project-collections">
     <div class="project-title-container">
-      <h2><!-- ko text: workspaceName() ? workspaceName() : 'Untitled Project' --><!-- /ko --></h2>
+      <h2 class="project-panel"><!-- ko text: workspaceName() ? workspaceName() : 'Untitled Project' --><!-- /ko --></h2>
       <%= render partial: 'shared/workspace_name' %>
     </div>
     <div class="project-stats">
-      <ul data-bind="fadeVisible: isLoaded">
+      <ul class="project-panel" data-bind="fadeVisible: isLoaded">
         <!-- ko if: project.collections().length > 0 -->
         <li class="granule-count">
           <span class="value" data-bind="text: projectSummary() ? projectSummary()['projectGranules'] : 'Loading'"></span>
@@ -92,7 +92,9 @@
           <div class="collection-card-content">
             <h3 data-bind="text: collection.truncatedTitle, attr: {title: collection.title}"></h3>
             <div class="collection-extra" data-bind="fadeVisible: $root.isLoaded">
-              <div class="label-primary"><span data-bind="text: collection.granule_hits"></span> <!--ko text: collection.granule_hits != 1 ? 'Granules' : 'Granule' --><!--/ko --></div>
+              <div class="label-primary">
+                <span data-bind="text: collection.granule_hits"></span> <!--ko text: collection.granule_hits != 1 ? 'Granules' : 'Granule' --><!--/ko --></span>
+              </div>
               <div class="collection-capability">
                 <!-- ko if: collection.has_spatial_subsetting() -->
                 <span data-bind="css: {enabled: spatialSubsettingEnabled()}">
@@ -118,16 +120,18 @@
                   <i class="fa fa-check" aria-hidden="true" data-tooltip="true" data-placement="bottom" data-title="Collection is ready to download"></i>
                 </span> -->
               </div>
-              <div class="label-secondary" data-bind="fadeVisible: $root.isLoaded">
-                <span>Estimated Size: </span><!-- ko text: collection.total_size() + ' ' + collection.unit() --><!--/ko-->
-              </div>
+              <ul class="label-secondary list-inline list-divided" data-bind="fadeVisible: $root.isLoaded">
+                <li>
+                  <span>Estimated Size: </span><!-- ko text: collection.total_size() + ' ' + collection.unit() --><!--/ko-->
+                </li>
+                <li>
+                  <a class="clean underline subtle" href="#" data-toggle="modal" data-bind="attr: {'data-target': '#' + collection.id + '-modal'}">View Granules</a>
+                </li>
+              </ul>
             </div>
           </div>
           <div class="action-container">
             <a class="action-button customize" data-toggle="modal" data-bind="click: launchCustomizationModal, css: {enabled: !loadingServiceType()}"><i class="fa fa-spinner fa-spin fa-fw" data-bind="visible: loadingServiceType()"></i><span data-bind="text: customizeButtonText(), visible: !loadingServiceType()"></span></a>
-
-            <a class="action-button details" data-toggle="modal" data-bind="attr: {'data-target': '#' + collection.id + '-modal'}">Details</a>
-
             <a class="action-button remove" title="Remove collection from the current project" data-bind="click: $root.removeProjectCollection"><i class="fa fa-minus"></i></a>
           </div>
           <%= render partial: 'collection_customization_modal' %>

--- a/spec/features/projects/viewing_project_spec.rb
+++ b/spec/features/projects/viewing_project_spec.rb
@@ -497,15 +497,15 @@ describe 'Viewing Single Project', reset: false do
       end
     end
 
-    it 'shows details button' do
-      within '.collection-card:first-child .action-container' do
-        expect(page).to have_content('Details')
+    it 'shows view granules link' do
+      within '.collection-card:first-child .collection-extra .label-secondary' do
+        expect(page).to have_content('View Granules')
       end
     end
 
     context 'when granules detail modal is opened' do
       before :all do
-        within '.collection-card:first-child .action-container' do
+        within '.collection-card:first-child .collection-card-content' do
           find('a[data-target="#C14758250-LPDAAC_ECS-modal"]').click
         end
       end


### PR DESCRIPTION
This one moves the replaces the Details button on the collection card in the project view. The collection details modal is now triggered by a View Granules link in the card. 