### PR TITLE
EDSC-2084: Added capability to use shapefile from search in esi order

### DIFF
--- a/app/jobs/process_retrieval_job.rb
+++ b/app/jobs/process_retrieval_job.rb
@@ -64,6 +64,12 @@ class ProcessRetrievalJob < ActiveJob::Base
           )
         elsif method['type'] == 'service'
           # `Customize` Access Method
+
+          source = Rack::Utils.parse_nested_query(retrieval.project['source'])
+          if source.key?('sf')
+            params['sf'] = source['sf']
+          end
+
           catalog_rest_order = CatalogRestOrder.create(
             retrieval_collection: retrieval_collection,
             search_params: params

--- a/app/jobs/submit_catalog_rest_job.rb
+++ b/app/jobs/submit_catalog_rest_job.rb
@@ -7,7 +7,7 @@ class SubmitCatalogRestJob < ActiveJob::Base
     request_url = "#{base_url}/data/retrieve/#{order.retrieval_collection.retrieval.to_param}"
     shapefile = nil
 
-    if order.search_params.key?('sf') and not order.search_params['sf'].blank?
+    if order.search_params.key?('sf') && !order.search_params['sf'].blank?
       shapefile = Shapefile.find(order.search_params['sf'].to_i)
       shapefile = shapefile.nil? ? nil : shapefile.file
       order.search_params.delete('sf')

--- a/app/services/esi_client.rb
+++ b/app/services/esi_client.rb
@@ -16,7 +16,6 @@ class ESIClient
   def submit_esi_request(retrieval_collection, granule_params, request_url, token, shapefile = nil)
     service_url = get_service_url(retrieval_collection.collection_id, retrieval_collection.client, token)
     options = {}
-    @shapefile = shapefile
 
     begin
       # Fetch the granules the user is requesting from CRM
@@ -40,7 +39,7 @@ class ESIClient
       e.backtrace.each { |line| Rails.logger.error "\t#{line}" }
     end
 
-    options.merge!(build_params)
+    options.merge!(build_params(shapefile))
 
     Rails.logger.info " service_url: #{service_url}"
     Rails.logger.info " options:     #{options.inspect}"
@@ -99,7 +98,7 @@ class ESIClient
     @esi_fields ||= {}
   end
 
-  def build_params
+  def build_params(shapefile = nil)
     add_top_level_fields
 
     add_switch_field(:INCLUDE_META)
@@ -109,7 +108,7 @@ class ESIClient
 
     add_subset_data_layers
     add_bounding_box
-    add_shapefile
+    add_shapefile(shapefile)
 
     add_parameter(:EMAIL, find_field_element("email").text.strip)
 
@@ -234,9 +233,9 @@ class ESIClient
   end
 
 
-  def add_shapefile()
+  def add_shapefile(shapefile)
 
-    unless @shapefile.nil?
+    unless shapefile.nil?
       use_shapefile = false
 
       find_by_xpath("//ecs:spatial_subset_shapefile_flag").map{|spatial_subset_shapefile_flag|
@@ -246,7 +245,7 @@ class ESIClient
       }
 
       if use_shapefile
-        add_parameter(:BoundingShape, @shapefile.to_json)
+        add_parameter(:BoundingShape, shapefile.to_json)
       end
     end
   end

--- a/spec/features/data_access/esi_order_spec.rb
+++ b/spec/features/data_access/esi_order_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'ESI Orders' do
+  before :all do
+    # Don't process retrievals
+    Delayed::Worker.delay_jobs = true
+  end
+
+  after :all do
+    Delayed::Worker.delay_jobs = false
+  end
+
+  context 'when submitting an order with a shapefile' do
+    before :all do
+
+      ## load_page :projects_page, project: ['C1200341690-EDF_DEV02'], temporal: ['1970-01-01T00:00:00Z', '2019-03-01T23:59:59Z'], authenticate: 'edsc', env: :sit
+      # load_page :search, env: :sit, authenticate: 'edsc', q: 'C1200341690-EDF_DEV02'
+      # wait_for_xhr
+      # upload_shapefile('doc/example-data/shapefiles/single_shp.shp')
+      # wait_for_xhr
+      # collection_card = find('.project-list-item', match: :first)
+      # collection_card.find('.project-list-item-action-edit-options').click
+      # wait_for_xhr
+      # click_on 'Edit Delivery Method'
+      # choose('Customize & Download')
+      # check 'Use Shapefile from Search'
+      # find('.button-download-data').click
+
+      # TODO Above not working, no results for collection concept id
+
+      retrieval = Retrieval.last
+    end
+
+  end
+end


### PR DESCRIPTION
Caveats:
* A polygon with many points ( like state/country boundaries found on the Internet ) will cause errors in the icesat2 subsetter
* Some KML/Shapefiles when converted to geojson have some characters that ESI complains about.
Will have to work with SDPS team to add more stability to these cases.