### PR TITLE
Freeze a string literal for `self.table_name`

### DIFF
--- a/app/models/collection_extra.rb
+++ b/app/models/collection_extra.rb
@@ -1,5 +1,5 @@
 class CollectionExtra < ActiveRecord::Base
-  self.table_name = 'dataset_extras'
+  self.table_name = 'dataset_extras'.freeze
 
   validates_presence_of :echo_id
   validates_uniqueness_of :echo_id


### PR DESCRIPTION
Do you mind if we freeze strings like this to reduce object allocation? All good if not! Feel free to close!