### PR TITLE
EDSC-2479: Update tooltips and labels.

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatusItemBody.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItemBody.js
@@ -96,7 +96,7 @@ export class OrderStatusItemBody extends Component {
                 bootstrapVariant="primary"
                 bootstrapSize="sm"
                 label="Download Access Script"
-                tooltip="Download executable shell script (requires UNIX enviornment)"
+                tooltip="Download executable shell script (requires UNIX environment)"
                 tooltipPlacement="bottom"
                 tooltipId="tooltip__download-access-script"
               >

--- a/static/src/js/components/ShapefileUploadModal/ShapefileUploadModal.js
+++ b/static/src/js/components/ShapefileUploadModal/ShapefileUploadModal.js
@@ -55,7 +55,7 @@ export class ShapefileUploadModal extends Component {
             Valid formats include:
           </p>
           <ul>
-            <li>ESRI Shapefile (.zip including .shp, .dbf, and .shx file)</li>
+            <li>Shapefile (.zip including .shp, .dbf, and .shx file)</li>
             <li>Keyhole Markup Language (.kml or .kmz)</li>
             <li>GeoJSON (.json or .geojson)</li>
             <li>GeoRSS (.rss, .georss, or .xml)</li>

--- a/static/src/js/components/ShapefileUploadModal/tests__/ShapefileUploadModal.test.js
+++ b/static/src/js/components/ShapefileUploadModal/tests__/ShapefileUploadModal.test.js
@@ -44,7 +44,7 @@ describe('ShapefileUploadModal component', () => {
     const { enzymeWrapper } = setup()
 
     expect(enzymeWrapper.find(Modal.Body).find('p').at(1).text()).toEqual('Valid formats include:')
-    expect(enzymeWrapper.find(Modal.Body).find('li').at(0).text()).toEqual('ESRI Shapefile (.zip including .shp, .dbf, and .shx file)')
+    expect(enzymeWrapper.find(Modal.Body).find('li').at(0).text()).toEqual('Shapefile (.zip including .shp, .dbf, and .shx file)')
     expect(enzymeWrapper.find(Modal.Body).find('li').at(1).text()).toEqual('Keyhole Markup Language (.kml or .kmz)')
     expect(enzymeWrapper.find(Modal.Body).find('li').at(2).text()).toEqual('GeoJSON (.json or .geojson)')
     expect(enzymeWrapper.find(Modal.Body).find('li').at(3).text()).toEqual('GeoRSS (.rss, .georss, or .xml)')

--- a/static/src/js/components/SpatialDisplay/SpatialDisplay.js
+++ b/static/src/js/components/SpatialDisplay/SpatialDisplay.js
@@ -383,8 +383,8 @@ class SpatialDisplay extends Component {
       if (shapefileError) {
         const { type } = shapefileError
 
-        if (type === 'upload_esri') {
-          spatialError = 'To use an ESRI Shapefile, please upload a zip file that includes its .shp, .shx, and .dbf files.'
+        if (type === 'upload_shape') {
+          spatialError = 'To use a shapefile, please upload a zip file that includes its .shp, .shx, and .dbf files.'
         }
       }
 

--- a/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.js
+++ b/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.js
@@ -73,7 +73,7 @@ export const ShapefileDropzoneContainer = ({
 
       if (file.name.match('.*shp')) {
         onShapefileErrored({
-          type: 'upload_esri'
+          type: 'upload_shape'
         })
       }
     }}

--- a/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.js
+++ b/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.js
@@ -127,7 +127,7 @@ describe('ShapefileDropzoneContainer component', () => {
 
         expect(props.onShapefileErrored).toHaveBeenCalledTimes(1)
         expect(props.onShapefileErrored).toHaveBeenCalledWith({
-          type: 'upload_esri'
+          type: 'upload_shape'
         })
       })
     })


### PR DESCRIPTION
Updates the following:
* Tooltip for download script
* Shapefile labels have dropped the "ESRI" corporate branding.
* Upload method changed to `upload_shape` instead of `upload_esri`