### PR TITLE
EDSC-2553

### DIFF
--- a/portals/standardproducts/config.json
+++ b/portals/standardproducts/config.json
@@ -2,7 +2,7 @@
   "hasStyles": false,
   "hasScripts": false,
   "hideCollectionFilters": true,
-  "org": "Earthdata Standard Products",
+  "org": "Standard Products",
   "query": {
     "tagKey": "gov.nasa.eosdis.standardproduct",
     "hasGranulesOrCwic": null

--- a/portals/standardproducts/config.json
+++ b/portals/standardproducts/config.json
@@ -1,0 +1,11 @@
+{
+  "hasStyles": false,
+  "hasScripts": false,
+  "hideCollectionFilters": true,
+  "org": "Earthdata Standard Products",
+  "query": {
+    "tagKey": "gov.nasa.eosdis.standardproduct",
+    "hasGranulesOrCwic": null
+  },
+  "title": "Search"
+}


### PR DESCRIPTION
Created a new Portal for NASA Standard Products.  NASA HQ and management will be the users of the new portal. The new portal retrieves CMR collections based on the following tag: gov.nasa.eosdis.standardproduct.  The details of the tagging process, input files, software, and output files are documented in JIRA issue ECSE-720.