### PR TITLE
Fix podaac portal

### DIFF
--- a/portals/podaac/config.json
+++ b/portals/podaac/config.json
@@ -10,7 +10,7 @@
   "org": "PO.DAAC",
   "pageTitle": "PO.DAAC",
   "query": {
-    "dataCenter": "PO.DAAC",
+    "dataCenter": "NASA/JPL/PODAAC",
     "hasGranulesOrCwic": null
   },
   "title": "Search"


### PR DESCRIPTION
The current PO.DAAC portal configuration has the wrong value for the dataCenter, with the result that no results are returned :-(. The correct name of the dataCenter in the collections query is "NASA/JPL/PODAAC", now replaced in the config.json, and returning 543 collections.