### PR TITLE
CMRSCI_3584: add line hideCollectionFilters to file

### DIFF
--- a/portals/idn/config.json
+++ b/portals/idn/config.json
@@ -1,6 +1,7 @@
 {
   "hasStyles": true,
   "hasScripts": false,
+  "hideCollectionFilters": true,
   "logo": {
     "id": "idn-logo",
     "link": "https://idn.ceos.org/",


### PR DESCRIPTION
Remove "Only include collections with granules" and "Include non-EOSDIS collections" filter check boxes (JIRA tickets: CMRSCI-3584 and EDSC-2485).