### PR TITLE
EDSC-2828: Prepare for deprecation of supported output formats (UMM-S 1.3.4)

### DIFF
--- a/serverless/src/getAccessMethods/__tests__/handler.test.js
+++ b/serverless/src/getAccessMethods/__tests__/handler.test.js
@@ -375,13 +375,15 @@ describe('getAccessMethods', () => {
             items: [{
               conceptId: 'S1000000-EDSC',
               type: 'OPeNDAP',
-              supportedOutputFormats: [
-                'HDF4',
-                'NETCDF-3',
-                'NETCDF-4',
-                'BINARY',
-                'ASCII'
-              ]
+              supportedReformattings: [{
+                supportedOutputFormats: [
+                  'HDF4',
+                  'NETCDF-3',
+                  'NETCDF-4',
+                  'BINARY',
+                  'ASCII'
+                ]
+              }]
             }]
           },
           tags: {

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -149,16 +149,20 @@ const getAccessMethods = async (event, context) => {
         conceptId,
         longName,
         name,
+        supportedReformattings,
         type
       } = fullServiceObject
 
       const { keywordMappings, variables } = getVariables(associatedVariables)
 
-      let supportedOutputFormats = null
+      const outputFormats = []
 
-      if (fullServiceObject) {
-        ({ supportedOutputFormats } = fullServiceObject)
-      }
+      supportedReformattings.forEach((reformatting) => {
+        const { supportedOutputFormats } = reformatting
+
+        // Collect all supported output formats from each mapping
+        outputFormats.push(...supportedOutputFormats)
+      })
 
       accessMethods.opendap = {
         id: conceptId,
@@ -166,7 +170,7 @@ const getAccessMethods = async (event, context) => {
         keywordMappings,
         longName,
         name,
-        supportedOutputFormats,
+        supportedOutputFormats: outputFormats,
         type,
         variables
       }

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -170,7 +170,7 @@ const getAccessMethods = async (event, context) => {
         keywordMappings,
         longName,
         name,
-        supportedOutputFormats: outputFormats,
+        supportedOutputFormats: [...new Set(outputFormats)],
         type,
         variables
       }

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -110,7 +110,6 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
             name
             type
             url
-            supportedOutputFormats
             supportedReformattings
           }
         }

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -212,7 +212,6 @@ export const getProjectCollections = () => async (dispatch, getState) => {
               name
               type
               url
-              supportedOutputFormats
               supportedReformattings
             }
           }

--- a/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
@@ -135,7 +135,6 @@ export const CollectionDetailsBody = ({
     )
   }
 
-  const outputFormats = []
   const reformattings = []
 
   if (services) {
@@ -144,13 +143,8 @@ export const CollectionDetailsBody = ({
     if (items) {
       items.forEach((service) => {
         const {
-          supportedOutputFormats,
           supportedReformattings: supportedReformattingsList
         } = service
-
-        if (supportedOutputFormats) {
-          outputFormats.push(...supportedOutputFormats)
-        }
 
         if (supportedReformattingsList) {
           reformattings.push(...supportedReformattingsList)
@@ -232,16 +226,6 @@ export const CollectionDetailsBody = ({
                         {
                           nativeFormats.length > 0 && buildNativeFormatList(nativeFormats)
                         }
-                      </dd>
-                    </>
-                  )
-                }
-                {
-                  outputFormats.length > 0 && (
-                    <>
-                      <dt>{`Output ${pluralize('Format', outputFormats.length)}`}</dt>
-                      <dd>
-                        {outputFormats.join(', ')}
                       </dd>
                     </>
                   )

--- a/static/src/js/components/CollectionDetails/__tests__/CollectionDetailsBody.test.js
+++ b/static/src/js/components/CollectionDetails/__tests__/CollectionDetailsBody.test.js
@@ -406,24 +406,25 @@ describe('CollectionDetails component', () => {
             items: [
               {
                 type: 'ECHO ORDERS',
-                supportedOutputFormats: null,
                 supportedReformattings: null
               },
               {
                 type: 'ESI',
-                supportedOutputFormats: [
-                  'ASCII',
-                  'GEOTIFF',
-                  'HDF-EOS5',
-                  'KML',
-                  'NETCDF-3',
-                  'NETCDF-4'
-                ],
-                supportedReformattings: null
+                supportedReformattings: [
+                  {
+                    supportedOutputFormats: [
+                      'ASCII',
+                      'GEOTIFF',
+                      'HDF-EOS5',
+                      'KML',
+                      'NETCDF-3',
+                      'NETCDF-4'
+                    ]
+                  }
+                ]
               },
               {
                 type: 'NOT PROVIDED',
-                supportedOutputFormats: null,
                 supportedReformattings: null
               }
             ]


### PR DESCRIPTION
`supportedOutputFormats` is being deprecated as of UMM-S 1.3.4 and is being moved within `supportedReformattings`. We already support `supportedReformattings` so this PR just removes/replaces references to `supportedOutputFormats` to prevent issues with the upcoming GraphQL update to UMM-S 1.3.4.