### PR TITLE
EDSC-2912: Adds keyboard shortcut to focus on search bar

### DIFF
--- a/static/src/js/components/SearchForm/SearchForm.js
+++ b/static/src/js/components/SearchForm/SearchForm.js
@@ -140,10 +140,12 @@ class SearchForm extends Component {
   onWindowKeyDown(e) {
     const { key } = e
     const { inputRef, keyboardShortcuts } = this
-    const inputIsRendered = inputRef.current && inputRef.current.input
+    const inputIsRenderedAndNotFocused = inputRef.current
+    && inputRef.current.input
+    && inputRef.current.input !== document.activeElement
 
     // Focus the search input when the forward slash key is pressed
-    if (key === keyboardShortcuts.focusSearchInput && inputIsRendered) {
+    if (key === keyboardShortcuts.focusSearchInput && inputIsRenderedAndNotFocused) {
       inputRef.current.input.focus()
 
       e.preventDefault()

--- a/static/src/js/components/SearchForm/SearchForm.js
+++ b/static/src/js/components/SearchForm/SearchForm.js
@@ -64,6 +64,10 @@ class SearchForm extends Component {
     }
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.onWindowKeyDown)
+  }
+
   onFormSubmit(e) {
     e.preventDefault()
 

--- a/static/src/js/components/SearchForm/SearchForm.js
+++ b/static/src/js/components/SearchForm/SearchForm.js
@@ -34,16 +34,26 @@ class SearchForm extends Component {
       selectedSuggestion: null
     }
 
+    this.inputRef = React.createRef()
+    this.keyboardShortcuts = {
+      focusSearchInput: '/'
+    }
+
     this.onFormSubmit = this.onFormSubmit.bind(this)
     this.onAutoSuggestChange = this.onAutoSuggestChange.bind(this)
     this.onSearchClear = this.onSearchClear.bind(this)
     this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this)
     this.onToggleFilterStack = this.onToggleFilterStack.bind(this)
     this.onSuggestionHighlighted = this.onSuggestionHighlighted.bind(this)
+    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
     this.getSuggestionValue = this.getSuggestionValue.bind(this)
     this.renderSuggestion = this.renderSuggestion.bind(this)
     this.selectSuggestion = this.selectSuggestion.bind(this)
     this.shouldRenderSuggestions = this.shouldRenderSuggestions.bind(this)
+  }
+
+  componentDidMount() {
+    window.addEventListener('keydown', this.onWindowKeyDown)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -121,6 +131,20 @@ class SearchForm extends Component {
     } = this.props
 
     onToggleAdvancedSearchModal(true)
+  }
+
+  onWindowKeyDown(e) {
+    const { key } = e
+    const { inputRef, keyboardShortcuts } = this
+    const inputIsRendered = inputRef.current && inputRef.current.input
+
+    // Focus the search input when the forward slash key is pressed
+    if (key === keyboardShortcuts.focusSearchInput && inputIsRendered) {
+      inputRef.current.input.focus()
+
+      e.preventDefault()
+      e.stopPropagation()
+    }
   }
 
   /**
@@ -270,6 +294,7 @@ class SearchForm extends Component {
         <div className="search-form__primary">
           <form className="search-form__form" onSubmit={this.onFormSubmit}>
             <Autosuggest
+              ref={this.inputRef}
               suggestions={suggestions}
               onSuggestionsFetchRequested={onFetchAutocomplete}
               onSuggestionsClearRequested={onClearAutocompleteSuggestions}

--- a/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
+++ b/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
@@ -1,15 +1,33 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
+import Enzyme, { shallow, mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import Autosuggest from 'react-autosuggest'
 
 import SearchForm from '../SearchForm'
 import PortalFeatureContainer from '../../../containers/PortalFeatureContainer/PortalFeatureContainer'
 import AdvancedSearchDisplayContainer from '../../../containers/AdvancedSearchDisplayContainer/AdvancedSearchDisplayContainer'
+import configureStore from '../../../store/configureStore'
 
 Enzyme.configure({ adapter: new Adapter() })
 
-function setup(overrideProps) {
+const windowEventMap = {}
+
+beforeEach(() => {
+  jest.clearAllTimers()
+  jest.clearAllMocks()
+
+  window.addEventListener = jest.fn((event, cb) => {
+    windowEventMap[event] = cb
+  })
+
+  window.removeEventListener = jest.fn()
+})
+
+const store = configureStore()
+
+// use shallowMount, unless we require instance properties like refs
+function setup(overrideProps, useShallow = true) {
   const props = {
     advancedSearch: {},
     autocomplete: {
@@ -31,10 +49,24 @@ function setup(overrideProps) {
     ...overrideProps
   }
 
-  const enzymeWrapper = shallow(<SearchForm {...props} />)
+  if (useShallow) {
+    return {
+      enzymeWrapper: shallow(<SearchForm {...props} />),
+      props
+    }
+  }
 
+  // Allow the rendered component to affect the document scope
+  const container = document.createElement('div')
+  document.body.appendChild(container)
   return {
-    enzymeWrapper,
+    enzymeWrapper: mount(
+      <Provider store={store}>
+        <SearchForm {...props} />
+      </Provider>,
+
+      { attachTo: container }
+    ),
     props
   }
 }
@@ -126,6 +158,61 @@ describe('SearchForm component', () => {
       enzymeWrapper.find('.search-form__form').simulate('submit', { preventDefault: jest.fn() })
 
       expect(props.onCancelAutocomplete).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onWindowKeydown', () => {
+    describe('when the / key is pressed', () => {
+      test('focuses the search input', () => {
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        const { enzymeWrapper } = setup({}, false)
+
+        const { inputRef } = enzymeWrapper.find(SearchForm).instance()
+        const inputElement = inputRef.current.input
+
+        // Trigger the simulated window event
+        windowEventMap.keydown({
+          key: '/',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        })
+
+        expect(document.activeElement).toBe(inputElement)
+        expect(preventDefaultMock).toHaveBeenCalledTimes(1)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when the / key is pressed twice', () => {
+      test('does not focus the input if it is already focused', () => {
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        const { enzymeWrapper } = setup({}, false)
+
+        const { inputRef } = enzymeWrapper.find(SearchForm).instance()
+        const inputElement = inputRef.current.input
+        const focusSpy = jest.spyOn(inputElement, 'focus')
+
+        // Trigger the simulated event twice
+        windowEventMap.keydown({
+          key: '/',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        })
+
+        windowEventMap.keydown({
+          key: '/',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        })
+
+        expect(focusSpy).toHaveBeenCalledTimes(1)
+        expect(preventDefaultMock).toHaveBeenCalledTimes(1)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
+++ b/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
@@ -64,7 +64,6 @@ function setup(overrideProps, useShallow = true) {
       <Provider store={store}>
         <SearchForm {...props} />
       </Provider>,
-
       { attachTo: container }
     ),
     props


### PR DESCRIPTION
Implements #1223

I've followed the same pattern as for the panel open/close shortcut in [this PR](https://github.com/nasa/earthdata-search/commit/e58d0195f17441fca1e44ff9094368c3947464e3); I did wonder if it might be desirable to have shortcuts organised somewhere more centrally rather than scattered about between components, but I think that would be outside the scope of this issue.

Please let me know about any needed changes!