### PR TITLE
EDSC-2898: Fix clearing existing granule filter in search bar

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsHeader.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsHeader.js
@@ -101,7 +101,9 @@ class GranuleResultsHeader extends Component {
     const { searchValue, prevSearchValue } = this.state
 
     if (searchValue !== prevSearchValue) {
-      let readableGranuleName = null
+      // empty array (truthy value) necessary
+      // to override existing filter with empty input
+      let readableGranuleName = []
 
       if (searchValue) {
         readableGranuleName = searchValue.split(',')

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsHeader.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsHeader.test.js
@@ -223,7 +223,7 @@ describe('GranuleResultsHeader component', () => {
 
       expect(props.onApplyGranuleFilters).toHaveBeenCalledTimes(1)
       expect(props.onApplyGranuleFilters).toHaveBeenCalledWith({
-        readableGranuleName: null
+        readableGranuleName: []
       })
     })
   })


### PR DESCRIPTION
## Fixes
Fixes: #1226 

## Description
In the collections.js file, in the updateFocusedCollectionGranuleFilters function, we only add a filter or overwrite an existing filter if at least one truthy value exists within the new filter. However if we clear the granule search bar it will pass a null value through to said function, which will never set due to the falsy nature of null. My fix passes an empty array for two reasons:

1) Normally the search input is converted into an array of values when not blank, so this keeps the datatype consistent regardless of content inside the search input.
2) An empty array is a truthy value, therefore it will successfully override the current filter inside the updateFocusedCollectionGranuleFilters function.

<details>
<summary><b>updateFocusedCollectionGranuleFilters</b> function inside <i>/static/src/js/actions/collections.js</i> that contains the condition that checks for at least one truthy value in order to set the new filter:
</summary>
<p>

```js
export const updateFocusedCollectionGranuleFilters = granuleFilters => (dispatch, getState) => {
  const state = getState()

  const focusedCollectionId = getFocusedCollectionId(state)

  const { query = {} } = state
  const { collection = {} } = query
  const { byId = {} } = collection
  const { [focusedCollectionId]: focusedCollectionQuery = {} } = byId
  const { granules: existingGranuleFilters = {} } = focusedCollectionQuery

  const allGranuleFilters = {
    ...existingGranuleFilters,
    ...granuleFilters
  }

  // Prune empty filters before sending to the store
  const prunedFilters = Object.keys(allGranuleFilters).reduce((obj, key) => {
    const newObj = obj

    // If the value is not an object, only add the key if the value is truthy. This removes
    // any unset values
    if (!isPlainObject(allGranuleFilters[key])) {
      if (allGranuleFilters[key]) {
        newObj[key] = allGranuleFilters[key]
      }
    //--------- v CONDITION PREVENTING FALSY VALUES FROM SETTING NEW FILTER v----------//
    } else if (Object.values(allGranuleFilters[key]).some(key => !!key)) {
      // Otherwise, only add an object if it contains at least one truthy value
      newObj[key] = allGranuleFilters[key]
    }

    return newObj
  }, {})

  dispatch({
    type: UPDATE_GRANULE_SEARCH_QUERY,
    payload: {
      collectionId: focusedCollectionId,
      ...prunedFilters
    }
  })
}
```
</p>
</details>

## Tests
After applying the fix, I've repeated the repro steps as defined in issue #1226 and observed the query within the url related to text in the search bar successfully is removed when the search bar is cleared and is either unfocused or when the enter key has been depressed.

## Important Note
I was unsuccessful migrating the db over to a local db, so I cannot say for certain if the granules are refreshed at the time of the clearing of the query within the url. If someone would like to help me solve my issue with migration I'd be happy to confirm this portion of the Acceptance criteria, otherwise if someone can pull my PR and confirm this for me who has access to a running local db, that would be equally as helpful. 