### PR TITLE
EDSC-2672: Implement lazy loading on timeline container

### DIFF
--- a/static/src/js/containers/TimelineContainer/TimelineContainer.js
+++ b/static/src/js/containers/TimelineContainer/TimelineContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy, Suspense } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
@@ -10,8 +10,10 @@ import { getCollectionsMetadata } from '../../selectors/collectionMetadata'
 import { getFocusedCollectionId } from '../../selectors/focusedCollection'
 import { getProjectCollectionsIds } from '../../selectors/project'
 import { isPath } from '../../util/isPath'
+import Spinner from '../../components/Spinner/Spinner'
+import './TimelineContainer.scss'
 
-import Timeline from '../../components/Timeline/Timeline'
+const Timeline = lazy(() => import('../../components/Timeline/Timeline'))
 
 const mapDispatchToProps = dispatch => ({
   onChangeQuery: query => dispatch(actions.changeQuery(query)),
@@ -71,18 +73,25 @@ export const TimelineContainer = (props) => {
   if (collectionsToRender.length === 0) return null
 
   return (
-    <Timeline
-      browser={browser}
-      collectionMetadata={collectionMetadata}
-      pathname={pathname}
-      showOverrideModal={isProjectPage}
-      temporalSearch={temporalSearch}
-      timeline={timeline}
-      onChangeQuery={onChangeQuery}
-      onChangeTimelineQuery={onChangeTimelineQuery}
-      onToggleOverrideTemporalModal={onToggleOverrideTemporalModal}
-      onMetricsTimeline={onMetricsTimeline}
-    />
+    <Suspense fallback={(
+      <div className="timeline-loading">
+        <Spinner type="dots" size="small" />
+      </div>
+      )}
+    >
+      <Timeline
+        browser={browser}
+        collectionMetadata={collectionMetadata}
+        pathname={pathname}
+        showOverrideModal={isProjectPage}
+        temporalSearch={temporalSearch}
+        timeline={timeline}
+        onChangeQuery={onChangeQuery}
+        onChangeTimelineQuery={onChangeTimelineQuery}
+        onToggleOverrideTemporalModal={onToggleOverrideTemporalModal}
+        onMetricsTimeline={onMetricsTimeline}
+      />
+    </Suspense>
   )
 }
 

--- a/static/src/js/containers/TimelineContainer/TimelineContainer.js
+++ b/static/src/js/containers/TimelineContainer/TimelineContainer.js
@@ -10,8 +10,6 @@ import { getCollectionsMetadata } from '../../selectors/collectionMetadata'
 import { getFocusedCollectionId } from '../../selectors/focusedCollection'
 import { getProjectCollectionsIds } from '../../selectors/project'
 import { isPath } from '../../util/isPath'
-import Spinner from '../../components/Spinner/Spinner'
-import './TimelineContainer.scss'
 
 const Timeline = lazy(() => import('../../components/Timeline/Timeline'))
 
@@ -73,12 +71,7 @@ export const TimelineContainer = (props) => {
   if (collectionsToRender.length === 0) return null
 
   return (
-    <Suspense fallback={(
-      <div className="timeline-loading">
-        <Spinner type="dots" size="small" />
-      </div>
-      )}
-    >
+    <Suspense fallback={null}>
       <Timeline
         browser={browser}
         collectionMetadata={collectionMetadata}

--- a/static/src/js/containers/TimelineContainer/TimelineContainer.scss
+++ b/static/src/js/containers/TimelineContainer/TimelineContainer.scss
@@ -1,0 +1,7 @@
+.timeline-loading {
+  background-color: #191a1b;
+  height: 10px;
+  width: 100%;
+  padding: 0 10px;
+  position: relative;
+}

--- a/static/src/js/containers/TimelineContainer/TimelineContainer.scss
+++ b/static/src/js/containers/TimelineContainer/TimelineContainer.scss
@@ -1,7 +1,0 @@
-.timeline-loading {
-  background-color: #191a1b;
-  height: 10px;
-  width: 100%;
-  padding: 0 10px;
-  position: relative;
-}

--- a/static/src/js/containers/TimelineContainer/__tests__/TimelineContainer.test.js
+++ b/static/src/js/containers/TimelineContainer/__tests__/TimelineContainer.test.js
@@ -54,9 +54,8 @@ describe('TimelineContainer component', () => {
     const { enzymeWrapper } = setup({
       pathname: '/search/granules'
     })
-
-    expect(enzymeWrapper.find(Timeline).length).toBe(1)
-    expect(enzymeWrapper.find(Timeline).props().collectionMetadata).toEqual({
+    expect(enzymeWrapper.find(Timeline).at(1))
+    expect(enzymeWrapper.childAt(0).props().collectionMetadata).toEqual({
       focusedCollectionId: {
         title: 'focused'
       }
@@ -68,8 +67,8 @@ describe('TimelineContainer component', () => {
       pathname: '/projects'
     })
 
-    expect(enzymeWrapper.find(Timeline).length).toBe(1)
-    expect(enzymeWrapper.find(Timeline).props().collectionMetadata).toEqual({
+    expect(enzymeWrapper.find(Timeline).at(1))
+    expect(enzymeWrapper.childAt(0).props().collectionMetadata).toEqual({
       projectCollectionId: {
         title: 'project'
       }


### PR DESCRIPTION
# Overview
This PR addresses this issue: https://github.com/nasa/earthdata-search/issues/1219

### What is the feature?
- Implements lazy loading Timeline Container component

### What is the Solution?
- It uses React `lazy` and `Suspense` to handle lazy loading the timeline container component. 
- Adds the `Spinner` component as the fallback to display as the code for the timeline is being loaded.

### What areas of the application does this impact?
- The search feature

# Testing

### Reproduction steps

- **Environment for testing:**
This can be tested locally

- **Collection to test with:**

1. Run the application
2. You can test this with the usage of the browser dev tools. 
- To test the fallback component: You can emulate a slow network in order to make it easier. This can be done on the network panel of your browser devtools. Then click one of the search results and validate that on the bottom of the page you see the Spinner. After the JS file has been loaded validate you see the timeline and it should work as expected.
- To test the code splitting: On the network panel, you should see multiple js bundles been loaded after you click on the search results. These files contain the code for the timeline component which is being lazy-loaded.

### Attachments

Lazy loading the timeline component:

![image](https://user-images.githubusercontent.com/13956453/95030288-72fba700-0674-11eb-97d3-613103868769.png)



# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
