### PR TITLE
EDSC-2515: Add collections loading state skeleton

### DIFF
--- a/static/src/js/components/CollectionResults/CollectionResultsListItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsListItem.js
@@ -48,7 +48,7 @@ export const CollectionResultsListItem = memo(({
         className="collection-results-list-item collection-results-list-item--loading"
         style={style}
       >
-        <Skeleton 
+        <Skeleton
           containerStyle={{
             height: '140px',
             width: '100%',

--- a/static/src/js/components/CollectionResults/CollectionResultsListItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsListItem.js
@@ -4,6 +4,8 @@ import React, {
   useEffect
 } from 'react'
 import PropTypes from 'prop-types'
+import Skeleton from '../Skeleton/Skeleton';
+import { collectionResultsItemSkeleton } from './skeleton'
 
 import CollectionResultsItem from './CollectionResultsItem'
 
@@ -46,7 +48,16 @@ export const CollectionResultsListItem = memo(({
         className="collection-results-list-item collection-results-list-item--loading"
         style={style}
       >
-        Loading collections...
+        <Skeleton 
+          containerStyle={{
+            height: '140px',
+            width: '100%',
+            borderBottomWidth: '1px',
+            borderBottomStyle: 'solid',
+            borderBottomColor: '#dcdee0'
+          }}
+          shapes={collectionResultsItemSkeleton}
+        />
       </li>
     )
   }

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsList.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsList.test.js
@@ -8,6 +8,8 @@ import { VariableSizeList as List } from 'react-window'
 import CollectionResultsList from '../CollectionResultsList'
 import CollectionResultsItem from '../CollectionResultsItem'
 
+import Skeleton from '../../Skeleton/Skeleton'
+
 import configureStore from '../../../store/configureStore'
 
 Enzyme.configure({ adapter: new Adapter() })
@@ -92,7 +94,7 @@ describe('CollectionResultsList component', () => {
       })
 
       expect(enzymeWrapper.find('.collection-results-list__list').children().length).toEqual(1)
-      expect(enzymeWrapper.find('.collection-results-list__list').text()).toEqual('Loading collections...')
+      expect(enzymeWrapper.find(Skeleton).length).toEqual(1)
     })
 
     test('shows when additional items are being loaded', () => {
@@ -110,7 +112,7 @@ describe('CollectionResultsList component', () => {
       expect(enzymeWrapper.find(CollectionResultsItem).length).toEqual(2)
       expect(enzymeWrapper.find('.collection-results-list__list').text()).toContain('Collection Title 1')
       expect(enzymeWrapper.find('.collection-results-list__list').text()).toContain('Collection Title 2')
-      expect(enzymeWrapper.find('.collection-results-list__list').text()).toContain('Loading collections...')
+      expect(enzymeWrapper.find(Skeleton).length).toEqual(1)
     })
 
     test('does not show the loading item when items are loaded', () => {
@@ -126,7 +128,7 @@ describe('CollectionResultsList component', () => {
       expect(enzymeWrapper.find(CollectionResultsItem).length).toEqual(2)
       expect(enzymeWrapper.find('.collection-results-list__list').text()).toContain('Collection Title 1')
       expect(enzymeWrapper.find('.collection-results-list__list').text()).toContain('Collection Title 2')
-      expect(enzymeWrapper.find('.collection-results-list__list').text()).not.toContain('Loading collections...')
+      expect(enzymeWrapper.find(Skeleton).length).toEqual(0)
     })
   })
 })

--- a/static/src/js/components/CollectionResults/skeleton.js
+++ b/static/src/js/components/CollectionResults/skeleton.js
@@ -8,3 +8,54 @@ export const collectionResultsTotal = [
     radius: 2
   }
 ]
+
+export const collectionResultsItemSkeleton = [
+  {
+    shape: 'rectangle',
+    top: 10,
+    left: 20,
+    height: 75,
+    width: 75,
+    radius: 3
+  },
+  {
+    shape: 'rectangle',
+    top: 10,
+    left: 110,
+    height: 14,
+    width: '60%',
+    radius: 3
+  },
+  {
+    shape: 'rectangle',
+    top: 32,
+    left: 110,
+    height: 14,
+    width: '40%',
+    radius: 3
+  },
+  {
+    shape: 'rectangle',
+    top: 56,
+    left: 110,
+    height: 18,
+    width: '100px',
+    radius: 3
+  },
+  {
+    shape: 'rectangle',
+    top: 56,
+    left: 215,
+    height: 18,
+    width: '210px',
+    radius: 3
+  },
+  {
+    shape: 'rectangle',
+    top: 10,
+    right: 25,
+    height: 40,
+    width: 27,
+    radius: 3
+  }
+]

--- a/static/src/js/components/CollectionResults/skeleton.js
+++ b/static/src/js/components/CollectionResults/skeleton.js
@@ -10,14 +10,15 @@ export const collectionResultsTotal = [
 ]
 
 export const collectionResultsItemSkeleton = [
+  // image box
   {
     shape: 'rectangle',
-    top: 10,
-    left: 20,
+    top: 2,
+    left: 15,
     height: 75,
-    width: 75,
-    radius: 3
+    width: 75
   },
+  // 2x header lines
   {
     shape: 'rectangle',
     top: 10,
@@ -28,34 +29,61 @@ export const collectionResultsItemSkeleton = [
   },
   {
     shape: 'rectangle',
-    top: 32,
+    top: 30,
     left: 110,
     height: 14,
     width: '40%',
     radius: 3
   },
+  // 3x description lines
   {
     shape: 'rectangle',
-    top: 56,
+    top: 54,
     left: 110,
-    height: 18,
+    height: 10,
+    width: '60%',
+    radius: 1
+  },
+  {
+    shape: 'rectangle',
+    top: 68,
+    left: 110,
+    height: 10,
+    width: '54%',
+    radius: 1
+  },
+  {
+    shape: 'rectangle',
+    top: 82,
+    left: 110,
+    height: 10,
+    width: '58%',
+    radius: 1
+  },
+  // 2x inline tags
+  {
+    shape: 'rectangle',
+    top: 99,
+    left: 110,
+    height: 22,
     width: '100px',
     radius: 3
   },
   {
     shape: 'rectangle',
-    top: 56,
+    top: 99,
     left: 215,
-    height: 18,
+    height: 22,
     width: '210px',
     radius: 3
   },
+  // side buttons
   {
     shape: 'rectangle',
-    top: 10,
-    right: 25,
-    height: 40,
-    width: 27,
+    top: 2,
+    right: 16,
+    height: 35,
+    width: 35,
     radius: 3
   }
 ]


### PR DESCRIPTION
# Overview

### What is the feature?

Resolves: #1229 
This PR adds a skeleton loading state for the collection results component that emulates the current skeleton design for granule items loading state.

### What is the Solution?

I've created the new skeleton to replace the original loading state which was showing a "loading collections..." text in the collections panel while the collections loaded.

### What areas of the application does this impact?

This only impacts the visual aspect of the application. Specifically, this only impacts the CollectionsResultsHeader component visually. 

# Testing

### Reproduction steps

- **DEV Environment:**

1. Navigate to the main search page (http://localhost:8080/search)
4. Observe that a skeleton of a collection result will appear in the CollectionResultsHeader component
5. Observe that the skeleton disappears after collections load.
6. Scroll down to the bottom of the collection results list.
7. Observe that a skeleton appears at the bottom of the list while the application loads more collection items.

### Attachments

Screenshot of loading skeleton:
![loading](https://user-images.githubusercontent.com/11481182/95029093-01672d00-0663-11eb-8ded-30a54ab0b157.png)

### Note

The loading indicator at the bottom of the collections list not disappearing after all collections have loaded does not seem to be a bug caused by this feature as it can be observed on the production site currently. 

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
