### PR TITLE
EDSC-2895: Fix download granule dropdown in table view

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -13,7 +13,7 @@ import './GranuleResultsDataLinksButton.scss'
  * @param {Object} props - The props passed into the component.
  * @param {Function} props.onClick - The click callback.null
  */
-class CustomDataLinksToggle extends Component {
+export class CustomDataLinksToggle extends Component {
   constructor(props, context) {
     super(props, context)
     this.handleClick = this.handleClick.bind(this)

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -20,6 +20,7 @@ class CustomDataLinksToggle extends Component {
 
   handleClick(e) {
     e.preventDefault()
+    e.stopPropagation()
     const { onClick } = this.props
     onClick(e)
   }
@@ -28,7 +29,7 @@ class CustomDataLinksToggle extends Component {
     return (
       <Button
         className="button granule-results-data-links-button__button"
-        type="button"
+        type="button"clear
         label="Download single granule data"
         onClick={this.handleClick}
       >

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
 import { Dropdown } from 'react-bootstrap'
 import { PropTypes } from 'prop-types'
 
@@ -61,31 +62,36 @@ export const GranuleResultsDataLinksButton = ({
     return (
       <Dropdown>
         <Dropdown.Toggle as={CustomDataLinksToggle} />
-        <Dropdown.Menu>
-          {
-            dataLinks.map((dataLink, i) => {
-              const key = `data_link_${i}`
-              let dataLinkTitle = dataLink.title
+        {
+          ReactDOM.createPortal(
+            <Dropdown.Menu>
+              {
+                dataLinks.map((dataLink, i) => {
+                  const key = `data_link_${i}`
+                  let dataLinkTitle = dataLink.title
 
-              if (!dataLinkTitle) dataLinkTitle = getFilenameFromPath(dataLink.href)
+                  if (!dataLinkTitle) dataLinkTitle = getFilenameFromPath(dataLink.href)
 
-              return (
-                <Dropdown.Item
-                  key={key}
-                  href={dataLink.href}
-                  onClick={() => onMetricsDataAccess({
-                    type: 'single_granule_download',
-                    collections: [{
-                      collectionId
-                    }]
-                  })}
-                >
-                  {dataLinkTitle}
-                </Dropdown.Item>
-              )
-            })
-          }
-        </Dropdown.Menu>
+                  return (
+                    <Dropdown.Item
+                      key={key}
+                      href={dataLink.href}
+                      onClick={() => onMetricsDataAccess({
+                        type: 'single_granule_download',
+                        collections: [{
+                          collectionId
+                        }]
+                      })}
+                    >
+                      {dataLinkTitle}
+                    </Dropdown.Item>
+                  )
+                })
+              }
+            </Dropdown.Menu>,
+            document.querySelector('#root')
+          )
+        }
       </Dropdown>
     )
   }

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -29,7 +29,7 @@ class CustomDataLinksToggle extends Component {
     return (
       <Button
         className="button granule-results-data-links-button__button"
-        type="button"clear
+        type="button"
         label="Download single granule data"
         onClick={this.handleClick}
       >

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.js
@@ -150,13 +150,9 @@ export const GranuleResultsTable = ({
   })
 
   const onRowClick = useCallback((e, row) => {
-    const isDownloadButtonClicked = e.target.classList.contains('granule-results-data-links-button__button')
-    // We don't triger onRowClick if the click target is download granule button.
-    if (!isDownloadButtonClicked) {
-      const { original: rowOriginal } = row
-      const { handleClick } = rowOriginal
-      if (handleClick) handleClick(e, row)
-    }
+    const { original: rowOriginal } = row
+    const { handleClick } = rowOriginal
+    if (handleClick) handleClick(e, row)
   }, [])
 
   const onRowMouseEnter = useCallback((e, row) => {

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.js
@@ -150,9 +150,13 @@ export const GranuleResultsTable = ({
   })
 
   const onRowClick = useCallback((e, row) => {
-    const { original: rowOriginal } = row
-    const { handleClick } = rowOriginal
-    if (handleClick) handleClick(e, row)
+    const isDownloadButtonClicked = e.target.classList.contains('granule-results-data-links-button__button')
+    // We don't triger onRowClick if the click target is download granule button.
+    if (!isDownloadButtonClicked) {
+      const { original: rowOriginal } = row
+      const { handleClick } = rowOriginal
+      if (handleClick) handleClick(e, row)
+    }
   }, [])
 
   const onRowMouseEnter = useCallback((e, row) => {

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
@@ -4,7 +4,7 @@ import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Dropdown } from 'react-bootstrap'
 
-import { GranuleResultsDataLinksButton } from '../GranuleResultsDataLinksButton'
+import { GranuleResultsDataLinksButton, CustomDataLinksToggle } from '../GranuleResultsDataLinksButton'
 import Button from '../../Button/Button'
 
 Enzyme.configure({ adapter: new Adapter() })
@@ -78,7 +78,7 @@ describe('GranuleResultsDataLinksButton component', () => {
   describe('with multiple granule links', () => {
     test('renders the correct element', () => {
       // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
-      ReactDOM.createPortal = jest.fn(modal => modal);
+      ReactDOM.createPortal = jest.fn(dropdown => dropdown)
 
       const { enzymeWrapper } = setup({
         dataLinks: [
@@ -95,5 +95,23 @@ describe('GranuleResultsDataLinksButton component', () => {
       })
       expect(enzymeWrapper.type()).toBe(Dropdown)
     })
+  })
+})
+
+describe('CustomDataLinksToggle component', () => {
+  test('calls expected event methods on download click', () => {
+    const mockClickEvent = {
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn()
+    }
+
+    const mockClickCallback = jest.fn()
+
+    shallow(<CustomDataLinksToggle onClick={mockClickCallback} />)
+      .simulate('click', mockClickEvent)
+
+    expect(mockClickEvent.stopPropagation).toHaveBeenCalled()
+    expect(mockClickEvent.preventDefault).toHaveBeenCalled()
+    expect(mockClickCallback).toHaveBeenCalled()
   })
 })

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Dropdown } from 'react-bootstrap'
@@ -76,6 +77,9 @@ describe('GranuleResultsDataLinksButton component', () => {
 
   describe('with multiple granule links', () => {
     test('renders the correct element', () => {
+      // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+      ReactDOM.createPortal = jest.fn(modal => modal);
+
       const { enzymeWrapper } = setup({
         dataLinks: [
           {


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes #1227 

### What is the Solution?

~Not 100% sure of the possible cause but it was possibly because rowClick event of table triggering after the onClick of download button so it was immediately removing the dropdown menu.~

Edit: Changed implementation to use `e.stopPropogation()`

### What areas of the application does this impact?

~It will impact the parts which has the same `onRowClick` function reference that I've made changes into. 
It checks if it has the `granule-results-data-links-button__button` class to check if it is the download button element.~

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**


1. Search for a collection that has multi-file granules and click on it to load granules (NSIDC-0481 in 
2. Click on the download icon in the list view and observe that multiple files appear
3.  Confirm that clicking on those links downloads the intended file
4. Switch to table view using the toggle at the top of the granules panel
5. Click on the download icon in the table view and observe that multiple files appear
6. Confirm that clicking on those links downloads the intended file

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
