### PR TITLE
EDSC-2911: Add keyboard shortcut to toggle advanced search modal

### DIFF
--- a/static/src/js/components/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/static/src/js/components/AdvancedSearchModal/AdvancedSearchModal.js
@@ -31,9 +31,18 @@ export class AdvancedSearchModal extends Component {
   constructor(props) {
     super(props)
 
+    this.keyboardShortcuts = {
+      toggleAdvancedSearchInput: 'a'
+    }
+
     this.onApplyClick = this.onApplyClick.bind(this)
     this.onCancelClick = this.onCancelClick.bind(this)
     this.onModalClose = this.onModalClose.bind(this)
+    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+  }
+
+  componentDidMount() {
+    window.addEventListener('keydown', this.onWindowKeyDown)
   }
 
   onApplyClick(e) {
@@ -52,6 +61,23 @@ export class AdvancedSearchModal extends Component {
 
   onModalClose() {
     this.resetAndClose()
+  }
+
+  onWindowKeyDown(e) {
+    const { key } = e
+    const { keyboardShortcuts } = this
+
+    if (key === keyboardShortcuts.toggleAdvancedSearchInput) {
+      const {
+        onToggleAdvancedSearchModal,
+        isOpen
+      } = this.props
+
+      onToggleAdvancedSearchModal(!isOpen)
+
+      e.preventDefault()
+      e.stopPropagation()
+    }
   }
 
   resetAndClose() {

--- a/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
+++ b/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
@@ -7,6 +7,8 @@ import EDSCModalContainer from '../../../containers/EDSCModalContainer/EDSCModal
 
 Enzyme.configure({ adapter: new Adapter() })
 
+const windowEventMap = {}
+
 function setup(overrideProps) {
   const props = {
     advancedSearch: {},
@@ -39,6 +41,10 @@ function setup(overrideProps) {
 
 beforeEach(() => {
   jest.clearAllMocks()
+
+  window.addEventListener = jest.fn((event, cb) => {
+    windowEventMap[event] = cb
+  })
 })
 
 describe('AdvancedSearchModal component', () => {
@@ -96,6 +102,50 @@ describe('AdvancedSearchModal component', () => {
 
       expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledTimes(1)
       expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('onWindowKeydown', () => {
+    describe('when the "a" key is pressed', () => {
+      test('opens the modal when it is closed', () => {
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        const { props } = setup({
+          isOpen: false
+        })
+
+        windowEventMap.keydown({
+          key: 'a',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        })
+
+        expect(preventDefaultMock).toHaveBeenCalledTimes(1)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledWith(true)
+      })
+
+      test('closes the modal when it is opened', () => {
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        const { props } = setup({
+          isOpen: true
+        })
+
+        windowEventMap.keydown({
+          key: 'a',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        })
+
+        expect(preventDefaultMock).toHaveBeenCalledTimes(1)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledWith(false)
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview

Resolves: #1222 

### What is the feature?

Keyboard shortcut to toggle advanced search modal.

### What is the Solution?

When the user presses 'a' key, it toggles advanced search modal.

### What areas of the application does this impact?

AdvancedSearchModal.js and AdvancedSearchModal.test.js is changed.

# Testing

### Reproduction steps

- **Environment for testing:**

Version 85.0.4183.121 (Official Build) (64-bit) (Ubuntu 18.04)

- **Collection to test with:**

1. Press the 'a' on the homepage to toggle the advanced search modal.

### Attachments

![image](https://user-images.githubusercontent.com/968651/95112205-53827e00-0749-11eb-84a3-3c8f1005100c.png)

![image](https://user-images.githubusercontent.com/968651/95112249-62693080-0749-11eb-946a-fe8cff119c4d.png)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
