### PR TITLE
EDSC-2333: Prepopulate temporal values in echoforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3088,9 +3088,9 @@
       }
     },
     "@edsc/echoforms": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.7.tgz",
-      "integrity": "sha512-aHRexshUGhShkjDZZ+W4G5cOf74QzAvyCI1YCoFo+xDgoZrlQd6n19QxobwMjvtF+PxIuPBDuYWQWR5LH4Tn+Q==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.8.tgz",
+      "integrity": "sha512-doRMp23NHRA8ZvMy11JDy02TzUjO0ZrVrpml3j4VnvRnTTt/93gjjMcG/5ZS1xMuL7MmvRusrD9NzQxxHOD1ag==",
       "requires": {
         "murmurhash": "^1.0.0",
         "react-icons": "^3.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3088,9 +3088,9 @@
       }
     },
     "@edsc/echoforms": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.8.tgz",
-      "integrity": "sha512-doRMp23NHRA8ZvMy11JDy02TzUjO0ZrVrpml3j4VnvRnTTt/93gjjMcG/5ZS1xMuL7MmvRusrD9NzQxxHOD1ag==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.9.tgz",
+      "integrity": "sha512-epvgByHSnMJ1Dp95E2EE9PsclQtta07UgtD/SpVaLqWBK/Vd7yxj9RZWkcqSV0yPqc0ddYUEa3DCyn+W9LQRlg==",
       "requires": {
         "murmurhash": "^1.0.0",
         "react-icons": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
-    "@edsc/echoforms": "^1.1.8",
+    "@edsc/echoforms": "^1.1.9",
     "@googlemaps/google-maps-services-js": "^2.3.1",
     "@hot-loader/react-dom": "^16.12.0",
     "ajv": "^6.12.3",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
-    "@edsc/echoforms": "^1.1.7",
+    "@edsc/echoforms": "^1.1.8",
     "@googlemaps/google-maps-services-js": "^2.3.1",
     "@hot-loader/react-dom": "^16.12.0",
     "ajv": "^6.12.3",

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -177,7 +177,9 @@ export class AccessMethod extends Component {
       onUpdateAccessMethod,
       selectedAccessMethod,
       shapefileId,
-      spatial
+      spatial,
+      temporal,
+      overrideTemporal
     } = this.props
 
     const { conceptId: collectionId } = metadata
@@ -400,6 +402,8 @@ export class AccessMethod extends Component {
                           rawModel={rawModel}
                           shapefileId={shapefileId}
                           spatial={spatial}
+                          temporal={temporal}
+                          overrideTemporal={overrideTemporal}
                           onUpdateAccessMethod={onUpdateAccessMethod}
                         />
                       </Suspense>
@@ -532,7 +536,9 @@ AccessMethod.propTypes = {
   onUpdateAccessMethod: PropTypes.func.isRequired,
   selectedAccessMethod: PropTypes.string,
   shapefileId: PropTypes.string,
-  spatial: PropTypes.shape({})
+  spatial: PropTypes.shape({}),
+  temporal: PropTypes.shape({}).isRequired,
+  overrideTemporal: PropTypes.shape({}).isRequired
 }
 
 export default AccessMethod

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -17,6 +17,8 @@ function setup() {
     metadata: {},
     shapefileId: null,
     spatial: {},
+    temporal: {},
+    overrideTemporal: {},
     onSelectAccessMethod: jest.fn(),
     onSetActivePanel: jest.fn(),
     onUpdateAccessMethod: jest.fn(),

--- a/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
@@ -16,6 +16,8 @@ function setup(overrideProps) {
     rawModel: '',
     shapefileId: null,
     spatial: {},
+    temporal: {},
+    overrideTemporal: {},
     onUpdateAccessMethod: jest.fn(),
     ...overrideProps
   }
@@ -47,6 +49,38 @@ describe('EchoForm component', () => {
       BBOX_NORTH: 38.00105844675541,
       BBOX_SOUTH: 37.99999999999998,
       BBOX_WEST: -77
+    })
+  })
+
+  test('renders an EDSCEchoform with temporal prepopulated', () => {
+    const { enzymeWrapper } = setup({
+      temporal: {
+        endDate: '2020-03-05T17:49:07.369Z',
+        startDate: '2019-12-06T07:34:12.613Z'
+      }
+    })
+
+    expect(enzymeWrapper.find(EDSCEchoform).props().prepopulateValues).toEqual({
+      TEMPORAL_START: '2019-12-06T07:34:12',
+      TEMPORAL_END: '2020-03-05T17:49:07'
+    })
+  })
+
+  test('renders an EDSCEchoform with overrideTemporal prepopulated', () => {
+    const { enzymeWrapper } = setup({
+      temporal: {
+        endDate: '2020-12-31T59:59:59.999Z',
+        startDate: '1990-01-01T00:00:00.000Z'
+      },
+      overrideTemporal: {
+        endDate: '2020-03-05T17:49:07.369Z',
+        startDate: '2019-12-06T07:34:12.613Z'
+      }
+    })
+
+    expect(enzymeWrapper.find(EDSCEchoform).props().prepopulateValues).toEqual({
+      TEMPORAL_START: '2019-12-06T07:34:12',
+      TEMPORAL_END: '2020-03-05T17:49:07'
     })
   })
 

--- a/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
@@ -44,12 +44,14 @@ describe('EchoForm component', () => {
       }
     })
 
-    expect(enzymeWrapper.find(EDSCEchoform).props().prepopulateValues).toEqual({
-      BBOX_EAST: -76,
-      BBOX_NORTH: 38.00105844675541,
-      BBOX_SOUTH: 37.99999999999998,
-      BBOX_WEST: -77
-    })
+    expect(enzymeWrapper.find(EDSCEchoform).props().prepopulateValues).toEqual(
+      expect.objectContaining({
+        BBOX_EAST: -76,
+        BBOX_NORTH: 38.00105844675541,
+        BBOX_SOUTH: 37.99999999999998,
+        BBOX_WEST: -77
+      })
+    )
   })
 
   test('renders an EDSCEchoform with temporal prepopulated', () => {

--- a/static/src/js/components/ProjectPanels/ProjectPanels.js
+++ b/static/src/js/components/ProjectPanels/ProjectPanels.js
@@ -274,7 +274,9 @@ class ProjectPanels extends PureComponent {
       project,
       projectCollectionsMetadata,
       shapefileId,
-      spatial
+      spatial,
+      temporal,
+      overrideTemporal
     } = this.props
 
     const { selectedVariable } = this.state
@@ -447,6 +449,8 @@ class ProjectPanels extends PureComponent {
               selectedAccessMethod={selectedAccessMethod}
               shapefileId={shapefileId}
               spatial={spatial}
+              temporal={temporal}
+              overrideTemporal={overrideTemporal}
             />
           </PanelItem>
           <PanelItem
@@ -545,7 +549,9 @@ ProjectPanels.propTypes = {
   project: PropTypes.shape({}).isRequired,
   projectCollectionsMetadata: PropTypes.shape({}).isRequired,
   shapefileId: PropTypes.string,
-  spatial: PropTypes.shape({}).isRequired
+  spatial: PropTypes.shape({}).isRequired,
+  temporal: PropTypes.shape({}).isRequired,
+  overrideTemporal: PropTypes.shape({}).isRequired
 }
 
 export default ProjectPanels

--- a/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
@@ -81,6 +81,8 @@ function setup(overrideProps) {
     },
     shapefileId: '',
     spatial: {},
+    temporal: {},
+    overrideTemporal: {},
     onChangePath: jest.fn(),
     onSelectAccessMethod: jest.fn(),
     onTogglePanels: jest.fn(),

--- a/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
+++ b/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
@@ -22,7 +22,9 @@ const mapStateToProps = state => ({
   project: state.project,
   projectCollectionsMetadata: getProjectCollectionsMetadata(state),
   shapefileId: state.shapefile.shapefileId,
-  spatial: state.query.collection.spatial
+  spatial: state.query.collection.spatial,
+  temporal: state.query.collection.temporal,
+  overrideTemporal: state.query.collection.overrideTemporal
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -77,7 +79,9 @@ export const ProjectPanelsContainer = ({
   project,
   projectCollectionsMetadata,
   shapefileId,
-  spatial
+  spatial,
+  temporal,
+  overrideTemporal
 }) => (
   <ProjectPanels
     dataQualitySummaries={dataQualitySummaries}
@@ -103,11 +107,15 @@ export const ProjectPanelsContainer = ({
     projectCollectionsMetadata={projectCollectionsMetadata}
     shapefileId={shapefileId}
     spatial={spatial}
+    temporal={temporal}
+    overrideTemporal={overrideTemporal}
   />
 )
 
 ProjectPanelsContainer.defaultProps = {
-  shapefileId: null
+  shapefileId: null,
+  temporal: {},
+  overrideTemporal: {}
 }
 
 ProjectPanelsContainer.propTypes = {
@@ -133,7 +141,9 @@ ProjectPanelsContainer.propTypes = {
   project: PropTypes.shape({}).isRequired,
   projectCollectionsMetadata: PropTypes.shape({}).isRequired,
   shapefileId: PropTypes.string,
-  spatial: PropTypes.shape({}).isRequired
+  spatial: PropTypes.shape({}).isRequired,
+  temporal: PropTypes.shape({}),
+  overrideTemporal: PropTypes.shape({})
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectPanelsContainer)


### PR DESCRIPTION
# Overview

### What is the feature?

Prepopulate temporal values in echoforms.

### What is the Solution?

Send temporal values to the prepopulateValues prop for EDSCEchoForm component.

### What areas of the application does this impact?

EchoForms.

# Testing

### Reproduction steps

http://localhost:8080/projects?p=C1705401930-NSIDC_ECS!C1705401930-NSIDC_ECS&pg[1][gsk]=-start_date&pg[1][m]=esi0&q=ICESat-2&qt=2020-03-08T18%3A57%3A13.890Z%2C2020-03-15T19%3A23%3A27.812Z&ff=Customizable&tl=1586120496!4!!


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
