### PR TITLE
EDSC-2911: Improving keyboard shortcuts

### DIFF
--- a/cypress/integration/panels/behavior_spec.js
+++ b/cypress/integration/panels/behavior_spec.js
@@ -40,14 +40,14 @@ describe('Panel Behavior', () => {
 
   it('opens and closes when using keyboard shortcuts', () => {
     // Press the key
-    cy.window().trigger('keydown', { key: ']' }).wait(600)
+    cy.window().trigger('keyup', { key: ']' }).wait(600)
 
     // Panel is minimized
     cy.get('.panels--is-open').should('have.length', 0)
     cy.get('.panels--is-minimized').should('have.length', 1)
 
     // Press the key
-    cy.window().trigger('keydown', { key: ']' }).wait(600)
+    cy.window().trigger('keyup', { key: ']' }).wait(600)
 
     // Panel is visible
     cy.get('.panels--is-open').should('have.length', 1)

--- a/static/src/js/components/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/static/src/js/components/AdvancedSearchModal/AdvancedSearchModal.js
@@ -5,6 +5,8 @@ import AdvancedSearchForm from './AdvancedSearchForm'
 import EDSCModalContainer from '../../containers/EDSCModalContainer/EDSCModalContainer'
 import RegionSearchResults from './RegionSearchResults'
 
+import { triggerKeyboardShortcut } from '../../util/triggerKeyboardShortcut'
+
 import './AdvancedSearchModal.scss'
 
 /**
@@ -38,11 +40,15 @@ export class AdvancedSearchModal extends Component {
     this.onApplyClick = this.onApplyClick.bind(this)
     this.onCancelClick = this.onCancelClick.bind(this)
     this.onModalClose = this.onModalClose.bind(this)
-    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
   }
 
   componentDidMount() {
-    window.addEventListener('keydown', this.onWindowKeyDown)
+    window.addEventListener('keyup', this.onWindowKeyUp)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keyup', this.onWindowKeyUp)
   }
 
   onApplyClick(e) {
@@ -63,21 +69,21 @@ export class AdvancedSearchModal extends Component {
     this.resetAndClose()
   }
 
-  onWindowKeyDown(e) {
-    const { key } = e
+  onWindowKeyUp(e) {
     const { keyboardShortcuts } = this
 
-    if (key === keyboardShortcuts.toggleAdvancedSearchInput) {
-      const {
-        onToggleAdvancedSearchModal,
-        isOpen
-      } = this.props
+    const {
+      onToggleAdvancedSearchModal,
+      isOpen
+    } = this.props
 
-      onToggleAdvancedSearchModal(!isOpen)
+    const toggleModal = () => onToggleAdvancedSearchModal(!isOpen)
 
-      e.preventDefault()
-      e.stopPropagation()
-    }
+    triggerKeyboardShortcut({
+      event: e,
+      shortcutKey: keyboardShortcuts.toggleAdvancedSearchInput,
+      shortcutCallback: toggleModal
+    })
   }
 
   resetAndClose() {

--- a/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
+++ b/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
@@ -5,6 +5,8 @@ import Adapter from 'enzyme-adapter-react-16'
 import AdvancedSearchModal from '../AdvancedSearchModal'
 import EDSCModalContainer from '../../../containers/EDSCModalContainer/EDSCModalContainer'
 
+import * as triggerKeyboardShortcut from '../../../util/triggerKeyboardShortcut'
+
 Enzyme.configure({ adapter: new Adapter() })
 
 const windowEventMap = {}
@@ -111,16 +113,21 @@ describe('AdvancedSearchModal component', () => {
         const preventDefaultMock = jest.fn()
         const stopPropagationMock = jest.fn()
 
+        const shortcutSpy = jest.spyOn(triggerKeyboardShortcut, 'triggerKeyboardShortcut')
+
         const { props } = setup({
           isOpen: false
         })
 
-        windowEventMap.keydown({
+        windowEventMap.keyup({
           key: 'a',
+          tagName: 'body',
+          type: 'keyup',
           preventDefault: preventDefaultMock,
           stopPropagation: stopPropagationMock
         })
 
+        expect(shortcutSpy).toHaveBeenCalledTimes(1)
         expect(preventDefaultMock).toHaveBeenCalledTimes(1)
         expect(stopPropagationMock).toHaveBeenCalledTimes(1)
         expect(props.onToggleAdvancedSearchModal).toHaveBeenCalledTimes(1)
@@ -135,8 +142,10 @@ describe('AdvancedSearchModal component', () => {
           isOpen: true
         })
 
-        windowEventMap.keydown({
+        windowEventMap.keyup({
           key: 'a',
+          tagName: 'body',
+          type: 'keyup',
           preventDefault: preventDefaultMock,
           stopPropagation: stopPropagationMock
         })

--- a/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
+++ b/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchModal.test.js
@@ -107,7 +107,7 @@ describe('AdvancedSearchModal component', () => {
     })
   })
 
-  describe('onWindowKeydown', () => {
+  describe('onWindowKeyup', () => {
     describe('when the "a" key is pressed', () => {
       test('opens the modal when it is closed', () => {
         const preventDefaultMock = jest.fn()

--- a/static/src/js/components/GranuleResults/GranuleResultsHeader.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsHeader.js
@@ -9,6 +9,7 @@ import { generateHandoffs } from '../../util/handoffs/generateHandoffs'
 import { pluralize } from '../../util/pluralize'
 import { locationPropType } from '../../util/propTypes/location'
 import { pathStartsWith } from '../../util/pathStartsWith'
+import { triggerKeyboardShortcut } from '../../util/triggerKeyboardShortcut'
 
 import Button from '../Button/Button'
 import GranuleResultsActionsContainer from '../../containers/GranuleResultsActionsContainer/GranuleResultsActionsContainer'
@@ -58,11 +59,11 @@ class GranuleResultsHeader extends Component {
     this.handleBlurSearchValue = this.handleBlurSearchValue.bind(this)
     this.handleUndoExcludeGranule = this.handleUndoExcludeGranule.bind(this)
     this.handleSearchKeyUp = this.handleSearchKeyUp.bind(this)
-    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
   }
 
   componentDidMount() {
-    window.addEventListener('keydown', this.onWindowKeyDown)
+    window.addEventListener('keyup', this.onWindowKeyUp)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -81,19 +82,24 @@ class GranuleResultsHeader extends Component {
     }
   }
 
-  onWindowKeyDown(e) {
-    const { key } = e
+  componentWillUnmount() {
+    window.removeEventListener('keyup', this.onWindowKeyUp)
+  }
+
+  onWindowKeyUp(e) {
     const { keyboardShortcuts } = this
     const { location, onToggleSecondaryOverlayPanel, secondaryOverlayPanel } = this.props
 
     const { isOpen: granuleFiltersOpen } = secondaryOverlayPanel
 
-    // Toggle the granule filters when the `g` character is pressed
-    if (key === keyboardShortcuts.toggleGranuleFilters && pathStartsWith(location.pathname, ['/search/granules'])) {
-      onToggleSecondaryOverlayPanel(!granuleFiltersOpen)
+    const toggleModal = () => onToggleSecondaryOverlayPanel(!granuleFiltersOpen)
 
-      e.preventDefault()
-      e.stopPropagation()
+    if (pathStartsWith(location.pathname, ['/search/granules'])) {
+      triggerKeyboardShortcut({
+        event: e,
+        shortcutKey: keyboardShortcuts.toggleGranuleFilters,
+        shortcutCallback: toggleModal
+      })
     }
   }
 

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsHeader.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsHeader.test.js
@@ -312,23 +312,25 @@ describe('granuleFilters link', () => {
     test('toggles the granule panel state correctly', () => {
       const preventDefaultMock = jest.fn()
       const stopPropagationMock = jest.fn()
-  
+
       const { props } = setup({
         secondaryOverlayPanel: {
           isOpen: true
         }
       })
-  
+
       // Test thats the panel starts open
       expect(props.secondaryOverlayPanel.isOpen).toEqual(true)
-  
+
       // Trigger the simulated window event
-      windowEventMap.keydown({
+      windowEventMap.keyup({
         key: 'g',
+        tagName: 'body',
+        type: 'keyup',
         preventDefault: preventDefaultMock,
         stopPropagation: stopPropagationMock
-      });
-  
+      })
+
       // Test that the panel is toggled and the event propagation has been prevented
       expect(props.onToggleSecondaryOverlayPanel).toHaveBeenCalledTimes(1)
       expect(props.onToggleSecondaryOverlayPanel).toHaveBeenCalledWith(false)
@@ -336,10 +338,10 @@ describe('granuleFilters link', () => {
       expect(stopPropagationMock).toHaveBeenCalledTimes(1)
     })
 
-    test('does not toggle granule panel', () => {
+    test('does not toggle granule panel when not on the granules page', () => {
       const preventDefaultMock = jest.fn()
       const stopPropagationMock = jest.fn()
-  
+
       const { props } = setup({
         location: {
           pathname: '/search'
@@ -348,17 +350,19 @@ describe('granuleFilters link', () => {
           isOpen: false
         }
       })
-  
+
       // Test thats the panel starts closed
       expect(props.secondaryOverlayPanel.isOpen).toEqual(false)
-  
+
       // Trigger the simulated window event
-      windowEventMap.keydown({
+      windowEventMap.keyup({
         key: 'g',
+        tagName: 'body',
+        type: 'keyup',
         preventDefault: preventDefaultMock,
         stopPropagation: stopPropagationMock
       })
-  
+
       // Test that the panel is not toggled the event propagating
       expect(props.onToggleSecondaryOverlayPanel).toHaveBeenCalledTimes(0)
       expect(props.onToggleSecondaryOverlayPanel).toHaveBeenCalledTimes(0)

--- a/static/src/js/components/KeyboardShortcutsModal/KeyboardShortcutsModal.js
+++ b/static/src/js/components/KeyboardShortcutsModal/KeyboardShortcutsModal.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { Container, Row, Col } from 'react-bootstrap'
 import EDSCModalContainer from '../../containers/EDSCModalContainer/EDSCModalContainer'
 
+import { triggerKeyboardShortcut } from '../../util/triggerKeyboardShortcut'
+
 export class KeyboardShortcutsModal extends Component {
   constructor(props) {
     super(props)
@@ -10,33 +12,28 @@ export class KeyboardShortcutsModal extends Component {
       toggleModal: '?',
       escapeModal: 'Escape'
     }
-    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
   }
 
   componentDidMount() {
-    window.addEventListener('keydown', this.onWindowKeyDown)
+    window.addEventListener('keyup', this.onWindowKeyUp)
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.onWindowKeyDown)
+    window.removeEventListener('keyup', this.onWindowKeyUp)
   }
 
-  onWindowKeyDown(e) {
-    const { key } = e
+  onWindowKeyUp(e) {
     const { keyboardShortcuts } = this
     const { isOpen, onToggleKeyboardShortcutsModal } = this.props
-    // Toggle the modal when question key pressed
-    if (key === keyboardShortcuts.toggleModal) {
-      onToggleKeyboardShortcutsModal(!isOpen)
 
-      e.preventDefault()
-      e.stopPropagation()
-    } else if (key === keyboardShortcuts.escapeModal) {
-      if (isOpen) onToggleKeyboardShortcutsModal(false)
+    const toggleModal = () => onToggleKeyboardShortcutsModal(!isOpen)
 
-      e.preventDefault()
-      e.stopPropagation()
-    }
+    triggerKeyboardShortcut({
+      event: e,
+      shortcutKey: keyboardShortcuts.toggleModal,
+      shortcutCallback: toggleModal
+    })
   }
 
   render() {

--- a/static/src/js/components/KeyboardShortcutsModal/__tests__/KeyboardShortcutsModal.test.js
+++ b/static/src/js/components/KeyboardShortcutsModal/__tests__/KeyboardShortcutsModal.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
   document.removeEventListener = jest.fn()
 })
 
-const setupForModal = (visibility) => {
+const setup = (visibility) => {
   const props = {
     isOpen: visibility,
     onToggleKeyboardShortcutsModal: jest.fn()
@@ -41,38 +41,40 @@ const setupForModal = (visibility) => {
 
 describe('KeyboardShortcutsModal component', () => {
   test('initial state of modal', () => {
-    const { enzymeWrapper } = setupForModal(false)
+    const { enzymeWrapper } = setup(false)
     expect(enzymeWrapper.find(EDSCModal).props().isOpen).toEqual(false)
   })
 
   test('when modal is visible', () => {
-    const { enzymeWrapper } = setupForModal(true)
+    const { enzymeWrapper } = setup(true)
     expect(enzymeWrapper.find(EDSCModal).props().isOpen).toEqual(true)
   })
 
   test('modal should be centered', () => {
-    const { enzymeWrapper } = setupForModal(true)
+    const { enzymeWrapper } = setup(true)
     expect(enzymeWrapper.find(Modal).props().centered).toEqual(true)
   })
 
   test('modal shouldn\'t be empty', () => {
-    const { enzymeWrapper } = setupForModal(true)
+    const { enzymeWrapper } = setup(true)
     expect(enzymeWrapper.find('kbd').length).not.toEqual(0)
   })
 
   test('modal should have a close button', () => {
-    const { enzymeWrapper } = setupForModal(true)
+    const { enzymeWrapper } = setup(true)
     expect(enzymeWrapper.find('button').length).not.toEqual(0)
   })
 })
 
 describe('KeyboardShortcutsModal actions', () => {
   test('keyboard action for displaying the modal', () => {
-    const { props } = setupForModal(false)
+    const { props } = setup(false)
     const preventDefaultMock = jest.fn()
     const stopPropagationMock = jest.fn()
-    windowEventMap.keydown({
+    windowEventMap.keyup({
       key: '?',
+      tagName: 'input',
+      type: 'keyup',
       preventDefault: preventDefaultMock,
       stopPropagation: stopPropagationMock
     })
@@ -82,38 +84,13 @@ describe('KeyboardShortcutsModal actions', () => {
   })
 
   test('keyboard action for closing the modal by pressing ?', () => {
-    const { props } = setupForModal(true)
+    const { props } = setup(true)
     const preventDefaultMock = jest.fn()
     const stopPropagationMock = jest.fn()
-    windowEventMap.keydown({
+    windowEventMap.keyup({
       key: '?',
-      preventDefault: preventDefaultMock,
-      stopPropagation: stopPropagationMock
-    })
-
-    expect(props.onToggleKeyboardShortcutsModal).toHaveBeenCalledTimes(1)
-    expect(props.onToggleKeyboardShortcutsModal).toHaveBeenCalledWith(false)
-  })
-
-  test('modal shouldn\'t pop up by pressing Escape', () => {
-    const { props } = setupForModal(false)
-    const preventDefaultMock = jest.fn()
-    const stopPropagationMock = jest.fn()
-    windowEventMap.keydown({
-      key: 'Escape',
-      preventDefault: preventDefaultMock,
-      stopPropagation: stopPropagationMock
-    })
-
-    expect(props.onToggleKeyboardShortcutsModal).toHaveBeenCalledTimes(0)
-  })
-
-  test('closing the modal by pressing Esc', () => {
-    const { props } = setupForModal(true)
-    const preventDefaultMock = jest.fn()
-    const stopPropagationMock = jest.fn()
-    windowEventMap.keydown({
-      key: 'Escape',
+      tagName: 'input',
+      type: 'keyup',
       preventDefault: preventDefaultMock,
       stopPropagation: stopPropagationMock
     })
@@ -123,7 +100,7 @@ describe('KeyboardShortcutsModal actions', () => {
   })
 
   test('closing the modal by pressing Close button', () => {
-    const { enzymeWrapper } = setupForModal(true)
+    const { enzymeWrapper } = setup(true)
     enzymeWrapper.find('button').simulate('click')
 
     expect(enzymeWrapper.props().onToggleKeyboardShortcutsModal).toHaveBeenCalledTimes(1)

--- a/static/src/js/components/Panels/Panels.js
+++ b/static/src/js/components/Panels/Panels.js
@@ -9,6 +9,7 @@ import PanelGroup from './PanelGroup'
 
 import history from '../../util/history'
 import { getPanelSizeMap } from '../../util/getPanelSizeMap'
+import { triggerKeyboardShortcut } from '../../util/triggerKeyboardShortcut'
 
 import './Panels.scss'
 
@@ -56,7 +57,7 @@ export class Panels extends PureComponent {
     this.onMouseUp = this.onMouseUp.bind(this)
     this.onMouseDown = this.onMouseDown.bind(this)
     this.onWindowResize = this.onWindowResize.bind(this)
-    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
     this.onPanelHandleClickOrKeypress = this.onPanelHandleClickOrKeypress.bind(this)
     this.onPanelHandleMouseOver = this.onPanelHandleMouseOver.bind(this)
     this.onPanelHandleMouseOut = this.onPanelHandleMouseOut.bind(this)
@@ -67,7 +68,7 @@ export class Panels extends PureComponent {
 
   componentDidMount() {
     window.addEventListener('resize', this.onWindowResize)
-    window.addEventListener('keydown', this.onWindowKeyDown)
+    window.addEventListener('keyup', this.onWindowKeyUp)
     window.addEventListener('resize', this.onWindowResize)
     this.browserHistoryUnlisten = history.listen(this.onWindowResize)
 
@@ -135,7 +136,7 @@ export class Panels extends PureComponent {
   componentWillUnmount() {
     if (this.rafId) window.cancelAnimationFrame(this.rafId)
     window.removeEventListener('resize', this.onWindowResize)
-    window.removeEventListener('keydown', this.onWindowKeyDown)
+    window.removeEventListener('keyup', this.onWindowKeyUp)
     document.removeEventListener('mousemove', this.onMouseMove)
     document.removeEventListener('mouseup', this.onMouseUp)
     if (this.browserHistoryUnlisten) this.browserHistoryUnlisten()
@@ -164,21 +165,23 @@ export class Panels extends PureComponent {
     }
   }
 
-  onWindowKeyDown(e) {
+  onWindowKeyUp(e) {
     const { show } = this.state
-    const { key } = e
     const { keyboardShortcuts } = this
 
-    // Toggle the panel when the closing bracket character is pressed
-    if (key === keyboardShortcuts.togglePanel) {
+    const togglePanels = () => {
+      console.warn('calling togglePanels')
       this.setState({
         show: !show,
         willMinimize: show
       })
-
-      e.preventDefault()
-      e.stopPropagation()
     }
+
+    triggerKeyboardShortcut({
+      event: e,
+      shortcutKey: keyboardShortcuts.togglePanel,
+      shortcutCallback: togglePanels
+    })
   }
 
   onChangePanel(panelId) {

--- a/static/src/js/components/Panels/Panels.js
+++ b/static/src/js/components/Panels/Panels.js
@@ -170,7 +170,6 @@ export class Panels extends PureComponent {
     const { keyboardShortcuts } = this
 
     const togglePanels = () => {
-      console.warn('calling togglePanels')
       this.setState({
         show: !show,
         willMinimize: show

--- a/static/src/js/components/Panels/__tests__/Panels.test.js
+++ b/static/src/js/components/Panels/__tests__/Panels.test.js
@@ -7,6 +7,8 @@ import PanelSection from '../PanelSection'
 import PanelGroup from '../PanelGroup'
 import PanelItem from '../PanelItem'
 
+import * as triggerKeyboardShortcut from '../../../util/triggerKeyboardShortcut'
+
 Enzyme.configure({ adapter: new Adapter() })
 
 const windowEventMap = {}
@@ -932,11 +934,13 @@ describe('Panels component', () => {
     })
   })
 
-  describe('onWindowKeydown', () => {
+  describe('onWindowKeyUp', () => {
     describe('when the ] key is pressed', () => {
       test('toggles the panel state correctly', () => {
         const preventDefaultMock = jest.fn()
         const stopPropagationMock = jest.fn()
+
+        const shortcutSpy = jest.spyOn(triggerKeyboardShortcut, 'triggerKeyboardShortcut')
 
         const { enzymeWrapper } = setup()
 
@@ -945,17 +949,20 @@ describe('Panels component', () => {
         expect(enzymeWrapper.state().willMinimize).toEqual(false)
 
         // Trigger the simulated window event
-        windowEventMap.keydown({
+        windowEventMap.keyup({
           key: ']',
+          tagName: 'body',
+          type: 'keyup',
           preventDefault: preventDefaultMock,
           stopPropagation: stopPropagationMock
         })
 
         // Test that the panel is closed and the event propagation has been prevented
-        expect(enzymeWrapper.state().show).toEqual(false)
-        expect(enzymeWrapper.state().willMinimize).toEqual(true)
+        expect(shortcutSpy).toHaveBeenCalledTimes(1)
         expect(preventDefaultMock).toHaveBeenCalledTimes(1)
         expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+        expect(enzymeWrapper.state().show).toEqual(false)
+        expect(enzymeWrapper.state().willMinimize).toEqual(true)
       })
     })
   })

--- a/static/src/js/components/SearchForm/SearchForm.js
+++ b/static/src/js/components/SearchForm/SearchForm.js
@@ -22,6 +22,8 @@ import Spinner from '../Spinner/Spinner'
 import AutocompleteSuggestion from '../AutocompleteSuggestion/AutocompleteSuggestion'
 import PortalFeatureContainer from '../../containers/PortalFeatureContainer/PortalFeatureContainer'
 
+import { triggerKeyboardShortcut } from '../../util/triggerKeyboardShortcut'
+
 import './SearchForm.scss'
 
 class SearchForm extends Component {
@@ -45,7 +47,7 @@ class SearchForm extends Component {
     this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this)
     this.onToggleFilterStack = this.onToggleFilterStack.bind(this)
     this.onSuggestionHighlighted = this.onSuggestionHighlighted.bind(this)
-    this.onWindowKeyDown = this.onWindowKeyDown.bind(this)
+    this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
     this.getSuggestionValue = this.getSuggestionValue.bind(this)
     this.renderSuggestion = this.renderSuggestion.bind(this)
     this.selectSuggestion = this.selectSuggestion.bind(this)
@@ -53,7 +55,7 @@ class SearchForm extends Component {
   }
 
   componentDidMount() {
-    window.addEventListener('keydown', this.onWindowKeyDown)
+    window.addEventListener('keyup', this.onWindowKeyUp)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -65,7 +67,7 @@ class SearchForm extends Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.onWindowKeyDown)
+    window.removeEventListener('keyup', this.onWindowKeyUp)
   }
 
   onFormSubmit(e) {
@@ -137,20 +139,16 @@ class SearchForm extends Component {
     onToggleAdvancedSearchModal(true)
   }
 
-  onWindowKeyDown(e) {
-    const { key } = e
+  onWindowKeyUp(e) {
     const { inputRef, keyboardShortcuts } = this
-    const inputIsRenderedAndNotFocused = inputRef.current
-    && inputRef.current.input
-    && inputRef.current.input !== document.activeElement
 
-    // Focus the search input when the forward slash key is pressed
-    if (key === keyboardShortcuts.focusSearchInput && inputIsRenderedAndNotFocused) {
-      inputRef.current.input.focus()
+    const focusElement = () => inputRef.current.input.focus()
 
-      e.preventDefault()
-      e.stopPropagation()
-    }
+    triggerKeyboardShortcut({
+      event: e,
+      shortcutKey: keyboardShortcuts.focusSearchInput,
+      shortcutCallback: focusElement
+    })
   }
 
   /**

--- a/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
+++ b/static/src/js/components/SearchForm/__tests__/SearchForm.test.js
@@ -8,6 +8,7 @@ import SearchForm from '../SearchForm'
 import PortalFeatureContainer from '../../../containers/PortalFeatureContainer/PortalFeatureContainer'
 import AdvancedSearchDisplayContainer from '../../../containers/AdvancedSearchDisplayContainer/AdvancedSearchDisplayContainer'
 import configureStore from '../../../store/configureStore'
+import * as triggerKeyboardShortcut from '../../../util/triggerKeyboardShortcut'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -160,11 +161,13 @@ describe('SearchForm component', () => {
     })
   })
 
-  describe('onWindowKeydown', () => {
+  describe('onWindowKeyup', () => {
     describe('when the / key is pressed', () => {
       test('focuses the search input', () => {
         const preventDefaultMock = jest.fn()
         const stopPropagationMock = jest.fn()
+
+        const shortcutSpy = jest.spyOn(triggerKeyboardShortcut, 'triggerKeyboardShortcut')
 
         const { enzymeWrapper } = setup({}, false)
 
@@ -172,22 +175,27 @@ describe('SearchForm component', () => {
         const inputElement = inputRef.current.input
 
         // Trigger the simulated window event
-        windowEventMap.keydown({
+        windowEventMap.keyup({
           key: '/',
+          tagName: 'body',
+          type: 'keyup',
           preventDefault: preventDefaultMock,
           stopPropagation: stopPropagationMock
         })
 
+        expect(shortcutSpy).toHaveBeenCalledTimes(1)
         expect(document.activeElement).toBe(inputElement)
         expect(preventDefaultMock).toHaveBeenCalledTimes(1)
         expect(stopPropagationMock).toHaveBeenCalledTimes(1)
       })
     })
 
-    describe('when the / key is pressed twice', () => {
-      test('does not focus the input if it is already focused', () => {
+    describe('while in an input', () => {
+      test('does not focus', () => {
         const preventDefaultMock = jest.fn()
         const stopPropagationMock = jest.fn()
+
+        const shortcutSpy = jest.spyOn(triggerKeyboardShortcut, 'triggerKeyboardShortcut')
 
         const { enzymeWrapper } = setup({}, false)
 
@@ -195,19 +203,15 @@ describe('SearchForm component', () => {
         const inputElement = inputRef.current.input
         const focusSpy = jest.spyOn(inputElement, 'focus')
 
-        // Trigger the simulated event twice
-        windowEventMap.keydown({
+        windowEventMap.keyup({
           key: '/',
+          tagName: 'input',
+          type: 'keyup',
           preventDefault: preventDefaultMock,
           stopPropagation: stopPropagationMock
         })
 
-        windowEventMap.keydown({
-          key: '/',
-          preventDefault: preventDefaultMock,
-          stopPropagation: stopPropagationMock
-        })
-
+        expect(shortcutSpy).toHaveBeenCalledTimes(1)
         expect(focusSpy).toHaveBeenCalledTimes(1)
         expect(preventDefaultMock).toHaveBeenCalledTimes(1)
         expect(stopPropagationMock).toHaveBeenCalledTimes(1)

--- a/static/src/js/util/__tests__/triggerKeyboardShortcut.test.js
+++ b/static/src/js/util/__tests__/triggerKeyboardShortcut.test.js
@@ -1,0 +1,164 @@
+import { triggerKeyboardShortcut } from '../triggerKeyboardShortcut'
+
+describe('triggerKeyboardShortcut', () => {
+  describe('if the event target is not defined', () => {
+    test('does not trigger the shortcut', () => {
+      const callbackMock = jest.fn()
+
+      triggerKeyboardShortcut({
+        shortcutKey: 'a',
+        shortcutCallback: callbackMock
+      })
+
+      expect(callbackMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('if the event tagName is not defined', () => {
+    test('does not trigger the shortcut', () => {
+      const callbackMock = jest.fn()
+
+      triggerKeyboardShortcut({
+        event: {
+          target: {}
+        },
+        shortcutKey: 'a',
+        shortcutCallback: callbackMock
+      })
+
+      expect(callbackMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('if the keyup event is triggered in an input', () => {
+    test('does not trigger the shortcut', () => {
+      const callbackMock = jest.fn()
+      const preventDefaultMock = jest.fn()
+      const stopPropagationMock = jest.fn()
+
+      triggerKeyboardShortcut({
+        event: {
+          target: {
+            tagName: 'input'
+          },
+          key: 'a',
+          type: 'keyup',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        },
+        shortcutKey: 'a',
+        shortcutCallback: callbackMock
+      })
+
+      expect(callbackMock).toHaveBeenCalledTimes(0)
+      expect(preventDefaultMock).toHaveBeenCalledTimes(0)
+      expect(stopPropagationMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('if the assigned to a keydown event', () => {
+    test('does not trigger the shortcut', () => {
+      const callbackMock = jest.fn()
+      const preventDefaultMock = jest.fn()
+      const stopPropagationMock = jest.fn()
+
+      triggerKeyboardShortcut({
+        event: {
+          target: {
+            tagName: 'body'
+          },
+          key: 'a',
+          type: 'keydown',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        },
+        shortcutKey: 'a',
+        shortcutCallback: callbackMock
+      })
+
+      expect(callbackMock).toHaveBeenCalledTimes(0)
+      expect(preventDefaultMock).toHaveBeenCalledTimes(0)
+      expect(stopPropagationMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('if the assigned to a keydown event', () => {
+    test('does not trigger the shortcut', () => {
+      const callbackMock = jest.fn()
+      const preventDefaultMock = jest.fn()
+      const stopPropagationMock = jest.fn()
+
+      triggerKeyboardShortcut({
+        event: {
+          target: {
+            tagName: 'body'
+          },
+          key: 'a',
+          type: 'keydown',
+          preventDefault: preventDefaultMock,
+          stopPropagation: stopPropagationMock
+        },
+        shortcutKey: 'a',
+        shortcutCallback: callbackMock
+      })
+
+      expect(callbackMock).toHaveBeenCalledTimes(0)
+      expect(preventDefaultMock).toHaveBeenCalledTimes(0)
+      expect(stopPropagationMock).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('if assigned to a keyup', () => {
+    describe('and the key does not match', () => {
+      test('does not trigger the shortcut', () => {
+        const callbackMock = jest.fn()
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        triggerKeyboardShortcut({
+          event: {
+            target: {
+              tagName: 'body'
+            },
+            key: 'b',
+            type: 'keyup',
+            preventDefault: preventDefaultMock,
+            stopPropagation: stopPropagationMock
+          },
+          shortcutKey: 'a',
+          shortcutCallback: callbackMock
+        })
+
+        expect(callbackMock).toHaveBeenCalledTimes(0)
+        expect(preventDefaultMock).toHaveBeenCalledTimes(0)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    describe('and the key matches', () => {
+      test('triggers the shortcut', () => {
+        const callbackMock = jest.fn()
+        const preventDefaultMock = jest.fn()
+        const stopPropagationMock = jest.fn()
+
+        triggerKeyboardShortcut({
+          event: {
+            target: {
+              tagName: 'body'
+            },
+            key: 'a',
+            type: 'keyup',
+            preventDefault: preventDefaultMock,
+            stopPropagation: stopPropagationMock
+          },
+          shortcutKey: 'a',
+          shortcutCallback: callbackMock
+        })
+
+        expect(callbackMock).toHaveBeenCalledTimes(1)
+        expect(preventDefaultMock).toHaveBeenCalledTimes(1)
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})

--- a/static/src/js/util/triggerKeyboardShortcut.js
+++ b/static/src/js/util/triggerKeyboardShortcut.js
@@ -1,0 +1,39 @@
+/**
+ * Triggers a callback function if a specific key is pressed, preventing the shortcut in specific cases.
+ * @param {Object} event The event object.
+ * @param {String} shortcutKey The key that should trigger the keyboard shortcut.
+ * @param {Function} shortcutCallback The callback to call when the key is pressed.
+ */
+export const triggerKeyboardShortcut = ({
+  event = {},
+  shortcutKey = '',
+  shortcutCallback
+}) => {
+  const {
+    target: eventTarget = {},
+    key: eventKey = '',
+    type: eventType = ''
+  } = event
+
+  let { tagName = '' } = eventTarget
+  if (tagName) tagName = tagName.toLowerCase()
+
+  // If an input is triggering the keydown, return
+  if (tagName === 'input') return
+
+  // If not triggered by a keydown event, return
+  if (eventType !== 'keyup') return
+
+  // If no key is defined, return
+  if (eventKey !== shortcutKey) return
+
+  // If the callback is not a valid callback, return
+  if (typeof shortcutCallback !== 'function') return
+
+  // Trigger the keyboard shortcut
+  shortcutCallback()
+  event.preventDefault()
+  event.stopPropagation()
+}
+
+export default triggerKeyboardShortcut


### PR DESCRIPTION
# Overview

### What is the feature?

Improves existing keyboard shortcuts.

### What is the Solution?

- Fixes issue that caused accidental triggering of keyboard shortcuts when entering text in an input
- Swapping keydown to keyup, which prevents rapid triggering of the shortcut when a key is held

### What areas of the application does this impact?

 - Search input shortcut (/)
 - Advanced search shortcut (a)
 - Panel shortcut (])
 - Shortcut shortcut (?)
 - Existing text inputs (search, granule search, etc.)

# Testing

### Reproduction steps

- Can be tested in any environment
- Can be tested with any collection

1. Trigger any keyboard shortcut
2. Confirm the shortcut is triggered only when the shortcut is released
3. Focus in any text input
4. Try triggering a keyboard shortcut
5. Confirm the no shortcuts can be triggered
6. Unfocus from the input
7. Confirm the shortcuts work appropriately

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
