### PR TITLE
EDSC-2911: Remove timeline shortcut text

### DIFF
--- a/static/src/js/components/KeyboardShortcutsModal/KeyboardShortcutsModal.js
+++ b/static/src/js/components/KeyboardShortcutsModal/KeyboardShortcutsModal.js
@@ -44,7 +44,6 @@ export class KeyboardShortcutsModal extends Component {
       a: 'Toggle advanced search modal',
       '/': 'Focus on search input field',
       '?': 'Display all keyboard shortcuts',
-      t: 'Toggle timeline'
     }
     return (
       <EDSCModalContainer


### PR DESCRIPTION
# Overview

### What is the feature?
Removes unimplemented shortcut text

### What is the Solution?
Remove text in `KeyboardShortcutsModal.js`

### What areas of the application does this impact?
Keyboard shortcut modal

# Testing

### Reproduction steps
1. Load the application
2. Hit `?`
3. Note no reference to timeline toggle shortcut

# Checklist
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
