### PR TITLE
EDSC-2938: Prevent leaflet from requesting GIBS tiles that don't exist

### DIFF
--- a/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
+++ b/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
@@ -1,4 +1,4 @@
-import { gibsResponse } from './mocks'
+import { gibsResponse, matrixLimits } from './mocks'
 import { constructLayerTagData } from '../constructLayerTagData'
 
 beforeEach(() => {
@@ -15,6 +15,7 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
+    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -28,11 +29,14 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
+          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
+          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
+          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT',
@@ -57,6 +61,7 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
+    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -70,11 +75,14 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
+          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
+          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
+          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT'
@@ -98,6 +106,7 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
+    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -111,11 +120,14 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
+          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
+          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
+          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT',
@@ -149,6 +161,7 @@ describe('constructLayerTagData', () => {
       }
     }
     testingLayer.product = productObject
+    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -161,11 +174,14 @@ describe('constructLayerTagData', () => {
       data: {
         antarctic: false,
         antarctic_resolution: null,
+        antarctic_tile_matrix_limits: null,
         arctic: false,
         arctic_resolution: null,
+        arctic_tile_matrix_limits: null,
         format: 'png',
         geographic: true,
         geographic_resolution: '2km',
+        geographic_tile_matrix_limits: matrixLimits,
         group: 'overlays',
         match: {
           time_start: '>=2002-07-04T00:00:00Z',

--- a/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
+++ b/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import gibsResponse from './mocks'
+import { gibsResponse, capabilitiesResponse } from './mocks'
 import { getSupportedGibsLayers } from '../getSupportedGibsLayers'
 
 beforeEach(() => {
@@ -8,6 +8,18 @@ beforeEach(() => {
   nock(/worldview/)
     .get(/wv\.json/)
     .reply(200, gibsResponse)
+
+  nock(/gibs\.earthdata/)
+    .get(/epsg4326\/best\/wmts.cgi/)
+    .reply(200, capabilitiesResponse)
+
+  nock(/gibs\.earthdata/)
+    .get(/epsg3413\/best\/wmts.cgi/)
+    .reply(200, capabilitiesResponse)
+
+  nock(/gibs\.earthdata/)
+    .get(/epsg3031\/best\/wmts.cgi/)
+    .reply(200, capabilitiesResponse)
 })
 
 describe('getSupportedGibsLayers', () => {
@@ -16,6 +28,23 @@ describe('getSupportedGibsLayers', () => {
 
     expect(Object.keys(response)).not.toContain('ExcludedProjection_Value')
     expect(Object.keys(response)).not.toContain('MissingProjection_Value')
+
+    expect(response.MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.matrixLimits).toEqual({
+      '2km': {
+        0: {
+          matrixHeight: 1,
+          matrixWidth: 2
+        },
+        1: {
+          matrixHeight: 2,
+          matrixWidth: 3
+        },
+        2: {
+          matrixHeight: 3,
+          matrixWidth: 5
+        }
+      }
+    })
   })
 
   test('with custom gibs layers merged', async () => {
@@ -24,6 +53,23 @@ describe('getSupportedGibsLayers', () => {
     expect(Object.keys(response)).toContain('MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily')
     expect(Object.keys(response)).toContain('MOPITT_CO_Monthly_Total_Column_Day')
     expect(Object.keys(response).length).toEqual(48)
+
+    expect(response.MOPITT_CO_Monthly_Total_Column_Day.matrixLimits).toEqual({
+      '2km': {
+        0: {
+          matrixHeight: 1,
+          matrixWidth: 2
+        },
+        1: {
+          matrixHeight: 2,
+          matrixWidth: 3
+        },
+        2: {
+          matrixHeight: 3,
+          matrixWidth: 5
+        }
+      }
+    })
   })
 
   describe('without custom gibs layers merged', () => {
@@ -31,6 +77,23 @@ describe('getSupportedGibsLayers', () => {
       const response = await getSupportedGibsLayers(false)
 
       expect(Object.keys(response)).toEqual(['MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily'])
+
+      expect(response.MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.matrixLimits).toEqual({
+        '2km': {
+          0: {
+            matrixHeight: 1,
+            matrixWidth: 2
+          },
+          1: {
+            matrixHeight: 2,
+            matrixWidth: 3
+          },
+          2: {
+            matrixHeight: 3,
+            matrixWidth: 5
+          }
+        }
+      })
     })
   })
 })

--- a/serverless/src/generateGibsTags/__tests__/handler.test.js
+++ b/serverless/src/generateGibsTags/__tests__/handler.test.js
@@ -2,6 +2,7 @@ import AWS from 'aws-sdk'
 
 import * as getSupportedGibsLayers from '../getSupportedGibsLayers'
 import generateGibsTags from '../handler'
+import { matrixLimits } from './mocks'
 
 const OLD_ENV = process.env
 
@@ -62,7 +63,8 @@ describe('generateGibsTags', () => {
         },
         type: 'wmts',
         id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
-        tags: 'ssc podaac PO.DAAC'
+        tags: 'ssc podaac PO.DAAC',
+        matrixLimits
       },
       'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly': {
         startDate: '2000-02-01',
@@ -81,7 +83,8 @@ describe('generateGibsTags', () => {
             source: 'GIBS:geographic',
             matrixSet: '2km'
           }
-        }
+        },
+        matrixLimits
       }
     }))
 
@@ -120,10 +123,13 @@ describe('generateGibsTags', () => {
             format: 'png',
             antarctic: false,
             antarctic_resolution: null,
+            antarctic_tile_matrix_limits: null,
             arctic: false,
             arctic_resolution: null,
+            arctic_tile_matrix_limits: null,
             geographic: true,
-            geographic_resolution: '2km'
+            geographic_resolution: '2km',
+            geographic_tile_matrix_limits: matrixLimits
           }]
         }
       })
@@ -151,10 +157,13 @@ describe('generateGibsTags', () => {
           format: 'png',
           antarctic: false,
           antarctic_resolution: null,
+          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
+          arctic_tile_matrix_limits: null,
           geographic: true,
-          geographic_resolution: '2km'
+          geographic_resolution: '2km',
+          geographic_tile_matrix_limits: matrixLimits
         }]
       })
     }])

--- a/serverless/src/generateGibsTags/__tests__/mocks.js
+++ b/serverless/src/generateGibsTags/__tests__/mocks.js
@@ -192,4 +192,61 @@ export const gibsResponse = {
   }
 }
 
-export default gibsResponse
+export const capabilitiesResponse = `<Capabilities
+  xmlns="http://www.opengis.net/wmts/1.0"
+  xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+  <Contents>
+      <TileMatrixSet>
+          <ows:Identifier>2km</ows:Identifier>
+          <ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>
+          <TileMatrix>
+              <ows:Identifier>0</ows:Identifier>
+              <ScaleDenominator>223632905.6114871</ScaleDenominator>
+              <TopLeftCorner>-180 90</TopLeftCorner>
+              <TileWidth>512</TileWidth>
+              <TileHeight>512</TileHeight>
+              <MatrixWidth>2</MatrixWidth>
+              <MatrixHeight>1</MatrixHeight>
+          </TileMatrix>
+          <TileMatrix>
+              <ows:Identifier>1</ows:Identifier>
+              <ScaleDenominator>111816452.8057436</ScaleDenominator>
+              <TopLeftCorner>-180 90</TopLeftCorner>
+              <TileWidth>512</TileWidth>
+              <TileHeight>512</TileHeight>
+              <MatrixWidth>3</MatrixWidth>
+              <MatrixHeight>2</MatrixHeight>
+          </TileMatrix>
+          <TileMatrix>
+              <ows:Identifier>2</ows:Identifier>
+              <ScaleDenominator>55908226.40287178</ScaleDenominator>
+              <TopLeftCorner>-180 90</TopLeftCorner>
+              <TileWidth>512</TileWidth>
+              <TileHeight>512</TileHeight>
+              <MatrixWidth>5</MatrixWidth>
+              <MatrixHeight>3</MatrixHeight>
+          </TileMatrix>
+      </TileMatrixSet>
+  </Contents>
+  <ServiceMetadataURL xlink:href="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/WMTSCapabilities.xml"/>
+</Capabilities>`
+
+export const matrixLimits = {
+  '2km': {
+    0: {
+      matrixHeight: 1,
+      matrixWidth: 2
+    },
+    1: {
+      matrixHeight: 2,
+      matrixWidth: 3
+    },
+    2: {
+      matrixHeight: 3,
+      matrixWidth: 5
+    }
+  }
+}

--- a/serverless/src/generateGibsTags/constructLayerTagData.js
+++ b/serverless/src/generateGibsTags/constructLayerTagData.js
@@ -12,6 +12,7 @@ export const constructLayerTagData = (layer) => {
     format,
     group,
     id,
+    matrixLimits,
     product,
     projections,
     subtitle,
@@ -50,9 +51,11 @@ export const constructLayerTagData = (layer) => {
 
       tagData[projection] = true
       tagData[`${projection}_resolution`] = resolution
+      tagData[`${projection}_tile_matrix_limits`] = matrixLimits
     } else {
       tagData[projection] = false
       tagData[`${projection}_resolution`] = null
+      tagData[`${projection}_tile_matrix_limits`] = null
     }
   })
 

--- a/serverless/src/generateGibsTags/getSupportedGibsLayers.js
+++ b/serverless/src/generateGibsTags/getSupportedGibsLayers.js
@@ -1,5 +1,7 @@
 import 'array-foreach-async'
 import request from 'request-promise'
+import { parse as parseXml } from 'fast-xml-parser'
+
 import customGibsProducts from '../static/gibs'
 import { getClientId } from '../../../sharedUtils/getClientId'
 
@@ -17,11 +19,59 @@ export const getSupportedGibsLayers = async (mergeCustomProducts = true) => {
     }
   })
 
-  const supportedProjections = [
-    'GIBS:antarctic',
-    'GIBS:arctic',
-    'GIBS:geographic'
-  ]
+  const projectionMap = {
+    epsg4326: 'GIBS:geographic',
+    epsg3413: 'GIBS:arctic',
+    epsg3031: 'GIBS:antarctic'
+  }
+
+  const capabilitiesMatrixSets = {}
+
+  // For each projection, parse the capabilities document and pull out TileMatrixSet for each resolution
+  await Object.keys(projectionMap).forEachAsync(async (projection) => {
+    const capabilitiesUrl = `https://gibs.earthdata.nasa.gov/wmts/${projection}/best/wmts.cgi?SERVICE=WMTS&request=GetCapabilities`
+    const capabilitiesResponse = await request.get({
+      uri: capabilitiesUrl,
+      resolveWithFullResponse: true
+    })
+
+    const parsedCapabilities = parseXml(capabilitiesResponse.body, {
+      ignoreAttributes: false,
+      attributeNamePrefix: ''
+    })
+
+    const { Capabilities: capabilities = {} } = parsedCapabilities
+    const { Contents: contents = {} } = capabilities
+    let { TileMatrixSet: capabilityTileMatrixSets = [] } = contents
+    capabilityTileMatrixSets = [].concat(capabilityTileMatrixSets).filter(Boolean)
+
+    const matrixLimits = {}
+    capabilityTileMatrixSets.forEach((matrixSet) => {
+      const { 'ows:Identifier': resolution } = matrixSet
+      let { TileMatrix: tileMatrix = [] } = matrixSet
+      tileMatrix = [].concat(tileMatrix).filter(Boolean)
+
+      const resolutionMap = {}
+      tileMatrix.forEach((matrix) => {
+        const {
+          'ows:Identifier': id,
+          MatrixWidth: matrixWidth,
+          MatrixHeight: matrixHeight
+        } = matrix
+
+        resolutionMap[id] = {
+          matrixWidth,
+          matrixHeight
+        }
+      })
+
+      matrixLimits[resolution] = resolutionMap
+    })
+
+    capabilitiesMatrixSets[projectionMap[projection]] = matrixLimits
+  })
+
+  const supportedProjections = Object.values(projectionMap)
 
   const { body: worldviewProducts } = worldviewResponse
 
@@ -73,6 +123,8 @@ export const getSupportedGibsLayers = async (mergeCustomProducts = true) => {
       if (!supportedProjections.includes(projection.source)) {
         delete projections[key]
       }
+
+      currentLayer.matrixLimits = capabilitiesMatrixSets[projection.source]
     })
 
     // Ensure the layer has projections that we support

--- a/static/src/js/components/Map/GranuleGridLayer.js
+++ b/static/src/js/components/Map/GranuleGridLayer.js
@@ -76,7 +76,6 @@ class GranuleGridLayerExtended extends L.GridLayer {
     const { granules: projectCollectionGranules = {} } = projectCollection
 
     this.collectionId = collectionId
-    this.projection = projection
     this.onChangeFocusedGranule = onChangeFocusedGranule
     this.onExcludeGranule = onExcludeGranule
     this.onMetricsMap = onMetricsMap
@@ -103,6 +102,7 @@ class GranuleGridLayerExtended extends L.GridLayer {
       isProjectPage,
       metadata,
       projectCollection,
+      projection,
       removedGranuleIds
     })
 
@@ -764,7 +764,8 @@ class GranuleGridLayerExtended extends L.GridLayer {
       focusedCollectionId,
       addedGranuleIds = [],
       removedGranuleIds = [],
-      isProjectPage
+      isProjectPage,
+      projection
     } = props
 
     this.granules = granules
@@ -773,6 +774,7 @@ class GranuleGridLayerExtended extends L.GridLayer {
     this.isProjectPage = isProjectPage
     this.collectionId = collectionId
     this.focusedCollectionId = focusedCollectionId
+    this.projection = projection
 
     if (defaultGranules) {
       this.defaultGranules = defaultGranules
@@ -1337,6 +1339,7 @@ export class GranuleGridLayer extends MapLayer {
           lightColor,
           metadata,
           projectCollection,
+          projection,
           removedGranuleIds
         })
 

--- a/static/src/js/components/Map/GranuleGridLayer.js
+++ b/static/src/js/components/Map/GranuleGridLayer.js
@@ -1,8 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 
 import L from 'leaflet'
-import { capitalize, difference, isEqual } from 'lodash'
-import camelcaseKeys from 'camelcase-keys'
+import {
+  camelCase,
+  capitalize,
+  difference,
+  isEqual
+} from 'lodash'
 import $ from 'jquery'
 
 import {
@@ -12,8 +16,7 @@ import {
 
 import {
   addPath,
-  isClockwise,
-  getlprojection
+  isClockwise
 } from '../../util/map/granules'
 
 import {
@@ -42,7 +45,7 @@ const config = {
   // eslint-disable-next-line max-len
   gibsUrl: 'https://gibs.earthdata.nasa.gov/wmts/{lprojection}/best/{product}/default/{time}/{resolution}/{z}/{y}/{x}.{format}',
   // eslint-disable-next-line max-len
-  gibsGranuleUrl: 'http://uat.gibs.earthdata.nasa.gov/wmts/{projection}/std/{product}/default/{time}/{resolution}/{z}/{y}/{x}.{format}'
+  gibsGranuleUrl: 'http://uat.gibs.earthdata.nasa.gov/wmts/{lprojection}/std/{product}/default/{time}/{resolution}/{z}/{y}/{x}.{format}'
 }
 
 const MAX_RETRIES = 1 // Maximum number of times to attempt to reload an image
@@ -203,7 +206,9 @@ class GranuleGridLayerExtended extends L.GridLayer {
     const operators = ['>=', '<=']
     Object.keys(matcher || {}).forEach((prop) => {
       let value = matcher[prop]
-      const granuleValue = granule[prop].split('T')[0]
+
+      // Granule metadata is camel case, so camelCase the prop in order to find the granuleValue
+      const granuleValue = granule[camelCase(prop)].split('T')[0]
       if (value && !granuleValue) { return false }
       let op = null
       operators.forEach((operator) => {
@@ -232,28 +237,56 @@ class GranuleGridLayerExtended extends L.GridLayer {
       const newOptionSet = optionSet
       if (this.matches(granule, newOptionSet.match)) {
         let newResolution
+        let tileMatrixLimits
 
         const oldResolution = newOptionSet.resolution
 
         // Set resolution to {projection}_resolution if it exists and if the layer exists within newOptionSet
         if ((this.projection === projections.geographic) && newOptionSet.geographic) {
           matched = true
-          newResolution = newOptionSet.geographicResolution
+          newResolution = newOptionSet.geographic_resolution
+          tileMatrixLimits = newOptionSet.geographic_tile_matrix_limits
         } else if ((this.projection === projections.arctic) && newOptionSet.arctic) {
           matched = true
-          newResolution = newOptionSet.arcticResolution
+          newResolution = newOptionSet.arctic_resolution
+          tileMatrixLimits = newOptionSet.arctic_tile_matrix_limits
         } else if ((this.projection === projections.antarctic) && newOptionSet.antarctic) {
           matched = true
-          newResolution = newOptionSet.antarcticResolution
+          newResolution = newOptionSet.antarctic_resolution
+          tileMatrixLimits = newOptionSet.antarctic_tile_matrix_limits
         }
 
         // Use default resolution unless newResolution exists
         if (newResolution == null) { newResolution = oldResolution }
         newOptionSet.resolution = newResolution
+        newOptionSet.tileMatrixLimits = tileMatrixLimits
 
         this.options = L.extend({}, this.originalOptions, newOptionSet)
       }
     })
+
+    const { resolution, tileMatrixLimits = {} } = this.options
+    const { [resolution]: tileMatrixLimitsByResolution = {} } = tileMatrixLimits
+
+    // If the z point is not included in the tile matrix limits, return null
+    if (!Object.keys(tileMatrixLimitsByResolution).includes(tilePoint.z.toString())) {
+      return null
+    }
+
+    const {
+      matrixHeight,
+      matrixWidth
+    } = tileMatrixLimitsByResolution[tilePoint.z]
+
+    // If the x or y points are less than 0 or greater than the width - 1 or height - 1 return null
+    // Subtract 1 because the tilePoints start at 0 instead of 1
+    if (
+      tilePoint.x < 0 || tilePoint.x > matrixWidth - 1
+      || tilePoint.y < 0 || tilePoint.y > matrixHeight - 1
+    ) {
+      return null
+    }
+
 
     if (!matched) { return false }
 
@@ -267,7 +300,7 @@ class GranuleGridLayerExtended extends L.GridLayer {
     }
 
     const data = {
-      lprojection: getlprojection(this.options),
+      lprojection: this.projection, // use current map projection
       x: tilePoint.x,
       y: tilePoint.y,
       z: tilePoint.z,
@@ -760,7 +793,7 @@ class GranuleGridLayerExtended extends L.GridLayer {
       const { tags } = metadata
 
       if (tags) {
-        this.multiOptions = camelcaseKeys(getValueForTag('gibs', tags), { deep: true })
+        this.multiOptions = getValueForTag('gibs', tags)
       }
     }
 

--- a/static/src/js/util/map/__tests__/granules.test.js
+++ b/static/src/js/util/map/__tests__/granules.test.js
@@ -1,6 +1,5 @@
 import {
-  isClockwise,
-  getlprojection
+  isClockwise
 } from '../granules'
 
 import {
@@ -102,23 +101,5 @@ describe('granules#getRectangles', () => {
 
   test('returns an empty array if no rectangles exist', () => {
     expect(getRectangles({})).toEqual([])
-  })
-})
-
-describe('granules#getlprojection', () => {
-  test('returns epsg4326 for geo', () => {
-    expect(getlprojection({ geographic: true })).toEqual(projections.geographic)
-  })
-
-  test('returns epsg3031 for arctic', () => {
-    expect(getlprojection({ arctic: true })).toEqual(projections.arctic)
-  })
-
-  test('returns epsg3413 for antarctic', () => {
-    expect(getlprojection({ antarctic: true })).toEqual(projections.antarctic)
-  })
-
-  test('returns an empty string for anything else', () => {
-    expect(getlprojection({})).toEqual('')
   })
 })

--- a/static/src/js/util/map/granules.js
+++ b/static/src/js/util/map/granules.js
@@ -1,5 +1,3 @@
-import projections from './projections'
-
 function pairs(array) {
   const len = array.length
 
@@ -41,18 +39,4 @@ export function addPath(ctx, path) {
     poly.slice(1).forEach(p => ctx.lineTo(p.x, p.y))
     if (line == null) ctx.closePath()
   }
-}
-
-// Translate project types into 'epsg####' strings
-export function getlprojection(options) {
-  if (options.geographic) {
-    return projections.geographic
-  }
-  if (options.arctic) {
-    return projections.arctic
-  }
-  if (options.antarctic) {
-    return projections.antarctic
-  }
-  return ''
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Limit the requests Leaflet makes for images to only those map tiles that exist in GIBS

### What is the Solution?

Utilize the GIBS capabilities document to find the tile matrix height and width. Add that information into the GIBS tagging job and use that information to limit the requests Leaflet makes for granule imagery.

### What areas of the application does this impact?

GIBS Tagging job
Leaflet

# Testing

### Reproduction steps

While viewing the dev tools network tab, view a collection with Map imagery and move the map to the edge of the map. Previously this would result in many image requests with a 400 error. Now you should not see any 400s for granule imagery. You may still see errors with Reference_Features or Reference_Labels in the URL

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
