### PR TITLE
EDSC-2919: Encode readableGranuleName before writing to URL

### DIFF
--- a/static/src/js/util/url/__tests__/granuleFiltersEncoders.test.js
+++ b/static/src/js/util/url/__tests__/granuleFiltersEncoders.test.js
@@ -32,7 +32,8 @@ describe('url#decodeGranuleFilters', () => {
         recurringDayEnd: '',
         recurringDayStart: '',
         isRecurring: false
-      }
+      },
+      readableGranuleName: ['first#id', 'anotherId']
     }
 
     expect(decodeGranuleFilters({
@@ -53,7 +54,8 @@ describe('url#decodeGranuleFilters', () => {
         min: -45,
         max: 45
       },
-      ecd: '2015-06-09T00:00.000Z,2016-05-09T00:00.000Z'
+      ecd: '2015-06-09T00:00.000Z,2016-05-09T00:00.000Z',
+      id: 'first%23id!anotherId'
     })).toEqual(expectedResult)
   })
 })
@@ -85,7 +87,8 @@ describe('url#encodeGranuleFilters', () => {
       equatorCrossingDate: {
         endDate: '2016-05-09T00:00.000Z',
         startDate: '2015-06-09T00:00.000Z'
-      }
+      },
+      readableGranuleName: ['first#id', 'anotherId']
     }
 
     expect(encodeGranuleFilters(props)).toEqual({
@@ -106,7 +109,8 @@ describe('url#encodeGranuleFilters', () => {
         min: -45,
         max: 45
       },
-      ecd: '2015-06-09T00:00.000Z,2016-05-09T00:00.000Z'
+      ecd: '2015-06-09T00:00.000Z,2016-05-09T00:00.000Z',
+      id: 'first%23id!anotherId'
     })
   })
 })

--- a/static/src/js/util/url/granuleFiltersEncoders.js
+++ b/static/src/js/util/url/granuleFiltersEncoders.js
@@ -30,7 +30,7 @@ export const encodeGranuleFilters = (granuleFilters) => {
   if (cloudCover) pg.cc = cloudCover
   if (orbitNumber) pg.on = orbitNumber
   if (equatorCrossingLongitude) pg.ecl = equatorCrossingLongitude
-  if (readableGranuleName) pg.id = readableGranuleName.join('!')
+  if (readableGranuleName) pg.id = encodeURIComponent(readableGranuleName.join('!'))
   if (equatorCrossingDate) {
     pg.ecd = encodeTemporal(granuleFilters.equatorCrossingDate)
   }
@@ -73,7 +73,7 @@ export const decodeGranuleFilters = (params = {}) => {
   if (cloudCover) granuleFilters.cloudCover = cloudCover
   if (orbitNumber) granuleFilters.orbitNumber = orbitNumber
   if (equatorCrossingLongitude) granuleFilters.equatorCrossingLongitude = equatorCrossingLongitude
-  if (readableGranuleName) granuleFilters.readableGranuleName = readableGranuleName.split('!')
+  if (readableGranuleName) granuleFilters.readableGranuleName = decodeURIComponent(readableGranuleName).split('!')
   if (equatorCrossingDate) granuleFilters.equatorCrossingDate = decodeTemporal(equatorCrossingDate)
   if (sortKey) granuleFilters.sortKey = sortKey
 


### PR DESCRIPTION
# Overview

### What is the feature?

readableGranuleName wasn't being encoded before written to the URL, so if the field had a `#` in it, it would mess up the URL when navigating between pages

### What is the Solution?

Use `encodeURIComponent` to encode the field, and `decodeURIComponent` to decode it.

# Testing

### Reproduction steps

- Search for C14758250-LPDAAC_ECS (prod collection)
- Click to load granules
- Use Granule Search to search for a single granule (AST_L1A#00310122020232154_10132020080234.hdf)
- Note that only 1 granule returns
- Click download
- Note that 1 collection and 1 granule are in the project
- Click download
- Note that only one granule is returned in the order

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
