### PR TITLE
EDSC-2893: Default project collections visibility to true

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.js
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.js
@@ -76,14 +76,20 @@ export const GranuleDownloadButton = (props) => {
 
     // We need to place the collection as the last collection in the project, get the number of collections in the project
     // so that we know what index to use
-    const projectCollectionCount = Object.keys(pg).length
+    let projectCollectionIndex = Object.keys(pg).length
+
+    // If there are no pg parameters in the URL already, the index for the first collection needs to be 1, not 0
+    if (projectCollectionIndex === 0) projectCollectionIndex = 1
 
     // Move the object at the 0 index (focused collection) into the project by adding it to the end of the pg array (resulting
     // in a non 0 index)
     pg = {
       ...pg,
       0: {},
-      [projectCollectionCount]: focusedCollection
+      [projectCollectionIndex]: {
+        ...focusedCollection,
+        v: 't' // Set the new project collection visibility to true
+      }
     }
   }
 

--- a/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
@@ -1,0 +1,123 @@
+import React from 'react'
+import Enzyme, { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+import GranuleDownloadButton from '../GranuleDownloadButton'
+import Button from '../../Button/Button'
+import PortalLinkContainer from '../../../containers/PortalLinkContainer/PortalLinkContainer'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+function setup(overrideProps) {
+  const props = {
+    badge: '294 Granules',
+    buttonText: 'Download All',
+    focusedCollectionId: 'collectionId',
+    granuleCount: 294,
+    granuleLimit: 1000000,
+    initialLoading: false,
+    isCollectionInProject: false,
+    location: {
+      pathname: '/search/granules',
+      search: '?p=collectionId&ff=Map%20Imagery'
+    },
+    projectCollection: {},
+    tooManyGranules: false,
+    onAddProjectCollection: jest.fn(),
+    onChangePath: jest.fn(),
+    ...overrideProps
+  }
+
+  const enzymeWrapper = shallow(<GranuleDownloadButton {...props} />)
+
+  return {
+    enzymeWrapper,
+    props
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GranuleDownloadButton component', () => {
+  describe('when there are too many granules', () => {
+    test('renders a disabled button', () => {
+      const { enzymeWrapper } = setup({ tooManyGranules: true })
+
+      const button = enzymeWrapper.find(Button)
+
+      expect(button.props().disabled).toBeTruthy()
+    })
+  })
+
+  describe('when the collection is already in the project', () => {
+    test('clicking the button calls onAddProjectCollection and onChangePath', () => {
+      const { enzymeWrapper, props } = setup({
+        isCollectionInProject: true,
+        location: {
+          pathname: '/search/granules',
+          search: '?p=collectionId!collectionId&pg[1][gsk]=start_date&ff=Map%20Imagery'
+        }
+      })
+
+      const button = enzymeWrapper.find(Button)
+
+      expect(button.props().disabled).toBeFalsy()
+
+      const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+      portalLinkContainer.props().onClick()
+
+      expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
+      expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
+      expect(props.onChangePath).toHaveBeenCalledTimes(1)
+      expect(props.onChangePath).toHaveBeenCalledWith('/projects?p=collectionId!collectionId&pg[1][gsk]=start_date&ff=Map%20Imagery')
+    })
+  })
+
+  describe('when the collection is not in the project', () => {
+    describe('when there are no other pg paramters in the URL', () => {
+      test('clicking the button calls onAddProjectCollection and onChangePath', () => {
+        const { enzymeWrapper, props } = setup()
+
+        const button = enzymeWrapper.find(Button)
+
+        expect(button.props().disabled).toBeFalsy()
+
+        const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+        portalLinkContainer.props().onClick()
+
+        expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
+        expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
+        expect(props.onChangePath).toHaveBeenCalledTimes(1)
+        expect(props.onChangePath).toHaveBeenCalledWith('/projects?p=collectionId!collectionId&ff=Map%20Imagery&pg[1][v]=t')
+      })
+    })
+
+    describe('when there are some pg paramters in the URL', () => {
+      test('clicking the button calls onAddProjectCollection and onChangePath', () => {
+        const { enzymeWrapper, props } = setup({
+          location: {
+            pathname: '/search/granules',
+            search: '?p=collectionId&pg[0][gsk]=start_date&ff=Map%20Imagery'
+          }
+        })
+
+        const button = enzymeWrapper.find(Button)
+
+        expect(button.props().disabled).toBeFalsy()
+
+        const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+        portalLinkContainer.props().onClick()
+
+        expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
+        expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
+        expect(props.onChangePath).toHaveBeenCalledTimes(1)
+        expect(props.onChangePath).toHaveBeenCalledWith('/projects?p=collectionId!collectionId&pg[1][gsk]=start_date&pg[1][v]=t&ff=Map%20Imagery')
+      })
+    })
+  })
+})

--- a/static/src/js/reducers/__tests__/project.test.js
+++ b/static/src/js/reducers/__tests__/project.test.js
@@ -55,7 +55,8 @@ describe('ADD_COLLECTION_TO_PROJECT', () => {
           collectionId: {
             granules: {
               ...initialGranuleState
-            }
+            },
+            isVisible: true
           }
         }
       }

--- a/static/src/js/reducers/project.js
+++ b/static/src/js/reducers/project.js
@@ -492,7 +492,8 @@ const projectReducer = (state = initialState, action) => {
           byId: {
             ...byId,
             [collectionId]: {
-              granules: initialGranuleState
+              granules: initialGranuleState,
+              isVisible: true
             }
           }
         }


### PR DESCRIPTION
# Overview

### What is the feature?

Selected granule outlines are not showing on the project page.

### What is the Solution?

The granules weren't visible because the project collection was set to not visible by default. This PR changes that to be true by default. It sets the default in the reducer, and ensures the Download All button sets it to true

# Testing

### Reproduction steps

Replicate:

https://search.uat.earthdata.nasa.gov/search/granules?p=C55424-LPDAAC_TS2!C55424-LPDAAC_TS2&pg[1][a]=75578!LPDAAC_TS2&pg[1][gsk]=-start_date&pg[1][m]=echoOrder0&m=42.17535863612541!-94.11328125!5!1!0!0%2C2&ff=Map%20Imagery&tag_key=gov.nasa.eosdis&tl=1585085356!4!!

Open link and select 'Download 1 Granule'. Selected granule outline is not displayed on project page.


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
