### PR TITLE
EDSC-2882: Ensure all granule links are visible (via scrolling)

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
@@ -9,3 +9,8 @@
     }
   }
 }
+
+.dropdown-menu {
+  max-height: 250px;
+  overflow-y: scroll;
+}


### PR DESCRIPTION
# Overview

Fixes the granule download link list by adding a max height and making it scrollable.

### What is the feature?

This is a bug fix related multiple granule links when there are too many and the bottom of the list isn't visible.

### What is the Solution?

Added a bit of CSS to utilize scrolling to ensure access to all the links available.

### What areas of the application does this impact?

Granule card list and table.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
