### PR TITLE
EDSC-2882: Ensure all granule links are visible (via scrolling)

### DIFF
--- a/serverless/src/util/__tests__/getEdlConfig.test.js
+++ b/serverless/src/util/__tests__/getEdlConfig.test.js
@@ -10,32 +10,50 @@ describe('getEdlConfig', () => {
       edlHost: 'http://urs.example.com'
     }))
 
-    const secretsManagerData = jest.fn().mockReturnValue({
+    const prodSecretsManagerData = {
       promise: jest.fn().mockResolvedValue({
-        SecretString: '{"id":"test","secret":"secret"}'
+        SecretString: '{"id":"prodTest","secret":"prodSecret"}'
       })
-    })
+    }
+    const uatSecretsManagerData = {
+      promise: jest.fn().mockResolvedValue({
+        SecretString: '{"id":"uatTest","secret":"uatSecret"}'
+      })
+    }
 
-    AWS.SecretsManager = jest.fn()
-      .mockImplementationOnce(() => ({
-        getSecretValue: secretsManagerData
-      }))
+    AWS.SecretsManager = jest.fn(() => ({
+      getSecretValue: jest.fn()
+        .mockImplementationOnce(() => (prodSecretsManagerData))
+        .mockImplementationOnce(() => (uatSecretsManagerData))
+    }))
 
-    const response = await getEdlConfig('prod')
+    const prodResponse = await getEdlConfig('prod')
 
-    expect(response).toEqual({
+    expect(prodResponse).toEqual({
       auth: {
         tokenHost: 'http://urs.example.com'
       },
       client: {
-        id: 'test',
-        secret: 'secret'
+        id: 'prodTest',
+        secret: 'prodSecret'
       }
     })
 
-    expect(secretsManagerData).toBeCalledTimes(1)
-    expect(secretsManagerData.mock.calls[0]).toEqual([{
-      SecretId: 'UrsClientConfigSecret_prod'
-    }])
+    expect(prodSecretsManagerData.promise).toBeCalledTimes(1)
+
+    // call getEdlConfig again for a different value to ensure the cached value isn't being passed for the new env
+    const uatResponse = await getEdlConfig('uat')
+
+    expect(uatResponse).toEqual({
+      auth: {
+        tokenHost: 'http://urs.example.com'
+      },
+      client: {
+        id: 'uatTest',
+        secret: 'uatSecret'
+      }
+    })
+
+    expect(uatSecretsManagerData.promise).toBeCalledTimes(1)
   })
 })

--- a/serverless/src/util/getEdlConfig.js
+++ b/serverless/src/util/getEdlConfig.js
@@ -7,7 +7,7 @@ import {
 
 import { getSecretsManagerConfig } from './aws/getSecretsManagerConfig'
 
-let clientConfig
+const clientConfig = {}
 let secretsmanager
 
 /**
@@ -24,7 +24,8 @@ const oAuthConfig = earthdataEnvironment => ({
  * @param {Object} edlConfig A previously defined config object, or null if one has not be instantiated
  */
 export const getEdlConfig = async (earthdataEnvironment) => {
-  if (clientConfig == null) {
+  const { [earthdataEnvironment]: environmentConfig } = clientConfig
+  if (environmentConfig == null) {
     if (secretsmanager == null) {
       secretsmanager = new AWS.SecretsManager(getSecretsManagerConfig())
     }
@@ -50,11 +51,11 @@ export const getEdlConfig = async (earthdataEnvironment) => {
     // If not running in development mode fetch secrets from AWS
     const secretValue = await secretsmanager.getSecretValue(params).promise()
 
-    clientConfig = JSON.parse(secretValue.SecretString)
+    clientConfig[earthdataEnvironment] = JSON.parse(secretValue.SecretString)
   }
 
   return {
     ...oAuthConfig(earthdataEnvironment),
-    client: clientConfig
+    client: clientConfig[earthdataEnvironment]
   }
 }

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
@@ -9,3 +9,8 @@
     }
   }
 }
+
+.dropdown-menu {
+  max-height: 250px;
+  overflow-y: scroll;
+}

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
@@ -11,6 +11,6 @@
 }
 
 .dropdown-menu {
-  max-height: 250px;
+  max-height: 15.825rem;
   overflow-y: scroll;
 }

--- a/static/src/js/containers/GranuleImageContainer/GranuleImageContainer.js
+++ b/static/src/js/containers/GranuleImageContainer/GranuleImageContainer.js
@@ -16,6 +16,7 @@ const mapStateToProps = state => ({
 })
 
 export const GranuleImageContainer = ({
+  earthdataEnvironment,
   focusedGranuleId,
   granuleMetadata
 }) => {
@@ -24,7 +25,7 @@ export const GranuleImageContainer = ({
   let imageSrc = ''
 
   if (browseFlag) {
-    imageSrc = `${getEarthdataConfig(getEarthdataEnvironment).cmrHost}/browse-scaler/browse_images/granules/${focusedGranuleId}?h=512&w=512`
+    imageSrc = `${getEarthdataConfig(earthdataEnvironment).cmrHost}/browse-scaler/browse_images/granules/${focusedGranuleId}?h=512&w=512`
   }
 
   return (
@@ -33,6 +34,7 @@ export const GranuleImageContainer = ({
 }
 
 GranuleImageContainer.propTypes = {
+  earthdataEnvironment: PropTypes.string.isRequired,
   focusedGranuleId: PropTypes.string.isRequired,
   granuleMetadata: PropTypes.shape({}).isRequired
 }

--- a/static/src/js/containers/GranuleImageContainer/__tests__/GranuleImageContainer.test.js
+++ b/static/src/js/containers/GranuleImageContainer/__tests__/GranuleImageContainer.test.js
@@ -11,6 +11,7 @@ Enzyme.configure({ adapter: new Adapter() })
 
 function setup() {
   const props = {
+    earthdataEnvironment: 'prod',
     focusedGranuleId: 'focusedGranule',
     granuleMetadata: {
       browseFlag: true


### PR DESCRIPTION
# Overview

Fixes the granule download link list by adding a max height and making it scrollable.

### What is the feature?

This is a bug fix related multiple granule links when there are too many and the bottom of the list isn't visible.

### What is the Solution?

Added a bit of CSS to utilize scrolling to ensure access to all the links available.

### What areas of the application does this impact?

Granule card list and table.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
