### PR TITLE
EDSC-2948: Continue loading page after named project params are loaded

### DIFF
--- a/static/src/js/actions/__tests__/urlQuery.test.js
+++ b/static/src/js/actions/__tests__/urlQuery.test.js
@@ -116,6 +116,8 @@ describe('changePath', () => {
       })
 
     const updateStoreMock = jest.spyOn(actions, 'updateStore').mockImplementation(() => jest.fn())
+    const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+    const getTimelineMock = jest.spyOn(actions, 'getTimeline').mockImplementation(() => jest.fn())
 
     const newPath = '/search?projectId=1'
 
@@ -131,6 +133,7 @@ describe('changePath', () => {
           byId: {}
         }
       },
+      query: {},
       router: {
         location: {
           pathname: '/search'
@@ -176,12 +179,16 @@ describe('changePath', () => {
           }
         })
       )
+
+      expect(getCollectionsMock).toBeCalledTimes(1)
+      expect(getTimelineMock).toBeCalledTimes(1)
     })
   })
 
   test('updates the store if there is not a projectId', () => {
     const updateStoreMock = jest.spyOn(actions, 'updateStore').mockImplementation(() => jest.fn())
     const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+    const getTimelineMock = jest.spyOn(actions, 'getTimeline').mockImplementation(() => jest.fn())
 
     const newPath = '/search?p=C00001-EDSC'
 
@@ -239,6 +246,7 @@ describe('changePath', () => {
     )
 
     expect(getCollectionsMock).toBeCalledTimes(1)
+    expect(getTimelineMock).toBeCalledTimes(1)
   })
 })
 

--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -81,9 +81,9 @@ export const changePath = (path = '') => async (dispatch, getState) => {
 
     const { projectId } = parse(queryString)
 
-    const projectResponse = await requestObject.fetch(projectId)
-
     try {
+      const projectResponse = await requestObject.fetch(projectId)
+
       const { data } = projectResponse
       const {
         name,

--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -81,45 +81,45 @@ export const changePath = (path = '') => async (dispatch, getState) => {
 
     const { projectId } = parse(queryString)
 
-    await requestObject.fetch(projectId)
-      .then((response) => {
-        const { data } = response
-        const {
-          name,
-          path: projectPath
-        } = data
+    const projectResponse = await requestObject.fetch(projectId)
 
-        // In the event that the user has the earthdata environment set to the deployed environment
-        // the ee param will not exist, we need to ensure its provided on the `state` param for redirect purposes
-        const [, projectQueryString] = projectPath.split('?')
+    try {
+      const { data } = projectResponse
+      const {
+        name,
+        path: projectPath
+      } = data
 
-        // Parse the query string into an object
-        const paramsObj = parse(projectQueryString)
+      // In the event that the user has the earthdata environment set to the deployed environment
+      // the ee param will not exist, we need to ensure its provided on the `state` param for redirect purposes
+      const [, projectQueryString] = projectPath.split('?')
 
-        // If the earthdata environment variable
-        if (!Object.keys(paramsObj).includes('ee')) {
-          paramsObj.ee = earthdataEnvironment
-        }
+      // Parse the query string into an object
+      const paramsObj = parse(projectQueryString)
 
-        // Save name, path and projectId into store
-        dispatch(actions.updateSavedProject({
-          path: projectPath,
-          name,
-          projectId
-        }))
+      // If the earthdata environment variable
+      if (!Object.keys(paramsObj).includes('ee')) {
+        paramsObj.ee = earthdataEnvironment
+      }
 
-        decodedParams = decodeUrlParams(stringify(paramsObj))
-        dispatch(actions.updateStore(decodedParams))
-      })
-      .catch((error) => {
-        dispatch(actions.handleError({
-          error,
-          action: 'changePath',
-          resource: 'project',
-          verb: 'updating',
-          requestObject
-        }))
-      })
+      // Save name, path and projectId into store
+      dispatch(actions.updateSavedProject({
+        path: projectPath,
+        name,
+        projectId
+      }))
+
+      decodedParams = decodeUrlParams(stringify(paramsObj))
+      dispatch(actions.updateStore(decodedParams))
+    } catch (error) {
+      dispatch(actions.handleError({
+        error,
+        action: 'changePath',
+        resource: 'project',
+        verb: 'updating',
+        requestObject
+      }))
+    }
   } else {
     decodedParams = decodeUrlParams(queryString)
 

--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -73,13 +73,15 @@ export const changePath = (path = '') => async (dispatch, getState) => {
 
   const [pathname, queryString] = path.split('?')
 
+  let decodedParams
+
   // If query string is a projectId, call getProject
   if (queryString && queryString.indexOf('projectId=') === 0) {
     const requestObject = new ProjectRequest(undefined, earthdataEnvironment)
 
     const { projectId } = parse(queryString)
 
-    const projectResponse = requestObject.fetch(projectId)
+    await requestObject.fetch(projectId)
       .then((response) => {
         const { data } = response
         const {
@@ -106,7 +108,8 @@ export const changePath = (path = '') => async (dispatch, getState) => {
           projectId
         }))
 
-        dispatch(actions.updateStore(decodeUrlParams(stringify(paramsObj))))
+        decodedParams = decodeUrlParams(stringify(paramsObj))
+        dispatch(actions.updateStore(decodedParams))
       })
       .catch((error) => {
         dispatch(actions.handleError({
@@ -117,13 +120,11 @@ export const changePath = (path = '') => async (dispatch, getState) => {
           requestObject
         }))
       })
+  } else {
+    decodedParams = decodeUrlParams(queryString)
 
-    return projectResponse
+    dispatch(actions.updateStore(decodedParams, pathname))
   }
-
-  const decodedParams = decodeUrlParams(queryString)
-
-  dispatch(actions.updateStore(decodedParams, pathname))
 
   // If we are moving to a /search path, fetch collection results, this saves an extra request on the non-search pages.
   // Setting requestAddedGranules forces all page types other than search to request only the added granules if they exist, in all


### PR DESCRIPTION
# Overview

### What is the feature?

Naming a project and then refreshing the page was causing nothing to load. This fixes that bug.

### What is the Solution?

A return statement in the action that loads the named project's parameters from lambda was causing none of our 'get' actions to be called to load the data. I removed that return statement and updated the code that uses the decoded parameters.

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

Name a project, refresh the page

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
