### PR TITLE
EDSC-2951: Merge portal configs successfully

### DIFF
--- a/static/src/js/util/__tests__/portals.test.js
+++ b/static/src/js/util/__tests__/portals.test.js
@@ -1,4 +1,4 @@
-import { isDefaultPortal } from '../portals'
+import { getPortalConfig, isDefaultPortal } from '../portals'
 import * as getApplicationConfig from '../../../../../sharedUtils/config'
 
 beforeEach(() => {
@@ -19,5 +19,60 @@ describe('isDefaultPortal', () => {
 
   test('returns false if the portalId does not match the defaultPortal', () => {
     expect(isDefaultPortal('simple')).toBeFalsy()
+  })
+})
+
+describe('getPortalConfig', () => {
+  test('builds a portal config of portal > edsc portal > default portal', () => {
+    const config = getPortalConfig('idn')
+
+    expect(config).toEqual({
+      features: {
+        advancedSearch: true,
+        authentication: true,
+        featureFacets: {
+          showMapImagery: true,
+          showNearRealTime: true,
+          showCustomizable: true
+        }
+      },
+      footer: {
+        displayVersion: true,
+        attributionText: 'NASA Official: Stephen Berrick',
+        primaryLinks: [{
+          title: 'FOIA',
+          href: 'http://www.nasa.gov/FOIA/index.html'
+        },
+        {
+          title: 'NASA Privacy Policy',
+          href: 'http://www.nasa.gov/about/highlights/HP_Privacy.html'
+        },
+        {
+          title: 'USA.gov',
+          href: 'http://www.usa.gov'
+        }],
+        secondaryLinks: [{
+          title: 'Earthdata Access: A Section 508 accessible alternative',
+          href: 'https://access.earthdata.nasa.gov/'
+        }]
+      },
+      hasScripts: false,
+      hasStyles: true,
+      logo: {
+        id: 'idn-logo',
+        link: 'https://idn.ceos.org/',
+        title: 'CEOS IDN Search'
+      },
+      org: 'IDN',
+      pageTitle: 'IDN',
+      query: { hasGranulesOrCwic: null },
+      title: 'Search',
+      ui: {
+        showOnlyGranulesCheckbox: false,
+        showNonEosdisCheckbox: false,
+        showTophat: true
+      },
+      parentConfig: 'edsc'
+    })
   })
 })

--- a/static/src/js/util/portals.js
+++ b/static/src/js/util/portals.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-dynamic-require, global-require */
 
-import { merge } from 'lodash'
+import { cloneDeep, merge } from 'lodash'
 
 import { getApplicationConfig } from '../../../../sharedUtils/config'
 
@@ -23,8 +23,9 @@ const buildConfig = (json) => {
   // If the current config has a parent, merge the current config into the result of the parents being merged together
   if (parentConfig) {
     const parentJson = require(`../../../../portals/${parentConfig}/config.json`)
-
-    return merge(buildConfig(parentJson), json)
+    const parent = buildConfig(parentJson)
+    const merged = merge(parent, json)
+    return cloneDeep(merged)
   }
 
   // If the config doesn't have a parent, merge the current config into the default portal config


### PR DESCRIPTION
# Overview

### What is the feature?

Portal configs were not properly being merged together with their parent configs. This resulted in some values (like `showOnlyGranulesCheckbox` and `showNonEosdisCheckbox`) not being disabled in EDSC when portals disabled them in their config (like `idn` portal).

### What is the Solution?

Fixed the merge logic for portal configs.

### What areas of the application does this impact?

Portals.

# Testing

### Reproduction steps

Load the IDN portal `/portals/idn`
See that the `Only include collections with granules` and `Include non-EOSDIS collections` checkboxes are hidden

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
