### PR TITLE
EDSC-2964: Adds support for earthdata environment on /downloads

### DIFF
--- a/serverless/src/getRetrieval/__tests__/handler.test.js
+++ b/serverless/src/getRetrieval/__tests__/handler.test.js
@@ -1,5 +1,6 @@
 import knex from 'knex'
 import mockKnex from 'mock-knex'
+import * as determineEarthdataEnvironment from '../../util/determineEarthdataEnvironment'
 import * as getDbConnection from '../../util/database/getDbConnection'
 import * as getEarthdataConfig from '../../../../sharedUtils/config'
 import * as getJwtToken from '../../util/getJwtToken'
@@ -39,6 +40,8 @@ afterEach(() => {
 
 describe('getRetrieval', () => {
   test('correctly retrieves a known retrieval', async () => {
+    const determineEarthdataEnvironmentMock = jest.spyOn(determineEarthdataEnvironment, 'determineEarthdataEnvironment')
+
     dbTracker.on('query', (query) => {
       query.response([{
         jsondata: {},
@@ -58,6 +61,8 @@ describe('getRetrieval', () => {
 
     expect(body).toEqual('{"id":2,"jsondata":{},"collections":{},"links":[]}')
     expect(statusCode).toEqual(200)
+    expect(determineEarthdataEnvironmentMock).toBeCalledTimes(1)
+    expect(determineEarthdataEnvironmentMock).toBeCalledWith({ 'Earthdata-Env': 'prod' })
   })
 
   test('correctly retrieves a known retrieval with collection retrievals', async () => {

--- a/serverless/src/getRetrieval/__tests__/mocks.js
+++ b/serverless/src/getRetrieval/__tests__/mocks.js
@@ -1,5 +1,6 @@
 export const retrievalPayload = {
   pathParameters: {
     id: 2
-  }
+  },
+  headers: { 'Earthdata-Env': 'prod' }
 }

--- a/serverless/src/getRetrieval/handler.js
+++ b/serverless/src/getRetrieval/handler.js
@@ -1,7 +1,7 @@
 import { keyBy } from 'lodash'
 
 import { deobfuscateId } from '../util/obfuscation/deobfuscateId'
-import { deployedEnvironment } from '../../../sharedUtils/deployedEnvironment'
+import { determineEarthdataEnvironment } from '../util/determineEarthdataEnvironment'
 import { getApplicationConfig } from '../../../sharedUtils/config'
 import { getDbConnection } from '../util/database/getDbConnection'
 import { getJwtToken } from '../util/getJwtToken'
@@ -22,9 +22,9 @@ export default async function getRetrieval(event, context) {
   const { defaultResponseHeaders } = getApplicationConfig()
 
   try {
-    const { pathParameters } = event
+    const { headers, pathParameters } = event
 
-    const earthdataEnvironment = deployedEnvironment()
+    const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
     const { id: providedRetrieval } = pathParameters
 

--- a/serverless/src/getRetrievalCollection/__tests__/handler.test.js
+++ b/serverless/src/getRetrievalCollection/__tests__/handler.test.js
@@ -1,5 +1,6 @@
 import knex from 'knex'
 import mockKnex from 'mock-knex'
+import * as determineEarthdataEnvironment from '../../util/determineEarthdataEnvironment'
 import * as getJwtToken from '../../util/getJwtToken'
 import * as getDbConnection from '../../util/database/getDbConnection'
 import * as getVerifiedJwtToken from '../../util/getVerifiedJwtToken'
@@ -36,6 +37,7 @@ afterEach(() => {
 describe('getRetrievalCollection', () => {
   test('correctly retrieves retrievals', async () => {
     process.env.obfuscationSpin = 1000
+    const determineEarthdataEnvironmentMock = jest.spyOn(determineEarthdataEnvironment, 'determineEarthdataEnvironment')
 
     dbTracker.on('query', (query) => {
       query.response([{
@@ -62,7 +64,8 @@ describe('getRetrievalCollection', () => {
     const retrievalResponse = await getRetrievalCollection({
       pathParameters: {
         id: 1
-      }
+      },
+      headers: { 'Earthdata-Env': 'prod' }
     }, {})
 
     const { queries } = dbTracker.queries
@@ -84,6 +87,8 @@ describe('getRetrievalCollection', () => {
       urs_id: 'test_user'
     }))
     expect(statusCode).toEqual(200)
+    expect(determineEarthdataEnvironmentMock).toBeCalledTimes(1)
+    expect(determineEarthdataEnvironmentMock).toBeCalledWith({ 'Earthdata-Env': 'prod' })
   })
 
   test('correctly returns an error', async () => {

--- a/serverless/src/getRetrievals/__tests__/handler.test.js
+++ b/serverless/src/getRetrievals/__tests__/handler.test.js
@@ -1,5 +1,6 @@
 import knex from 'knex'
 import mockKnex from 'mock-knex'
+import * as determineEarthdataEnvironment from '../../util/determineEarthdataEnvironment'
 import * as getJwtToken from '../../util/getJwtToken'
 import * as getDbConnection from '../../util/database/getDbConnection'
 import * as getVerifiedJwtToken from '../../util/getVerifiedJwtToken'
@@ -35,6 +36,8 @@ afterEach(() => {
 
 describe('getRetrievals', () => {
   test('correctly retrieves retrievals', async () => {
+    const determineEarthdataEnvironmentMock = jest.spyOn(determineEarthdataEnvironment, 'determineEarthdataEnvironment')
+
     dbTracker.on('query', (query) => {
       query.response([{
         id: 1,
@@ -63,7 +66,7 @@ describe('getRetrievals', () => {
       }])
     })
 
-    const retrievalResponse = await getRetrievals({}, {})
+    const retrievalResponse = await getRetrievals({ headers: { 'Earthdata-Env': 'prod' } }, {})
 
     const { queries } = dbTracker.queries
 
@@ -98,8 +101,11 @@ describe('getRetrievals', () => {
         ]
       }
     ]
+
     expect(body).toEqual(JSON.stringify(responseObj))
     expect(statusCode).toEqual(200)
+    expect(determineEarthdataEnvironmentMock).toBeCalledTimes(1)
+    expect(determineEarthdataEnvironmentMock).toBeCalledWith({ 'Earthdata-Env': 'prod' })
   })
 
   test('correctly returns an error', async () => {

--- a/serverless/src/getRetrievals/handler.js
+++ b/serverless/src/getRetrievals/handler.js
@@ -1,6 +1,6 @@
 import { groupBy, sortBy } from 'lodash'
 
-import { deployedEnvironment } from '../../../sharedUtils/deployedEnvironment'
+import { determineEarthdataEnvironment } from '../util/determineEarthdataEnvironment'
 import { getApplicationConfig } from '../../../sharedUtils/config'
 import { getDbConnection } from '../util/database/getDbConnection'
 import { getJwtToken } from '../util/getJwtToken'
@@ -21,7 +21,9 @@ export default async function getRetrievals(event, context) {
   const { defaultResponseHeaders } = getApplicationConfig()
 
   try {
-    const earthdataEnvironment = deployedEnvironment()
+    const { headers } = event
+
+    const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
     const jwtToken = getJwtToken(event)
 

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -91,6 +91,7 @@ describe('submitCatalogRestOrder', () => {
       if (step === 1) {
         query.response([{
           id: '1',
+          environment: 'prod',
           jsondata: { source: '?sf=1', shapefileId: 1 },
           access_method: {
             type: 'ESI',
@@ -164,6 +165,7 @@ describe('submitCatalogRestOrder', () => {
       if (step === 1) {
         query.response([{
           id: '1',
+          environment: 'prod',
           jsondata: { source: '?sf=1', shapefileId: 1 },
           access_method: {
             type: 'ESI',
@@ -187,6 +189,74 @@ describe('submitCatalogRestOrder', () => {
     await submitCatalogRestOrder(mockCatalogRestOrder, context)
 
     expect(prepareGranuleAccessParams.prepareGranuleAccessParams).toHaveBeenCalledTimes(1)
+  })
+
+  test('adds the ee param to the CLIENT_STRING when the environment doesn\'t match the deployed environment', async () => {
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+      cmrHost: 'https://cmr.earthdata.nasa.gov',
+      edscHost: 'http://localhost:8080'
+    }))
+
+    jest.spyOn(prepareGranuleAccessParams, 'prepareGranuleAccessParams')
+
+    nock(/cmr/)
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
+      .reply(200, {
+        feed: {
+          entry: [{
+            id: 'G10000005-EDSC',
+            title: 'GRANULE_SHORT_NAME'
+          }]
+        }
+      })
+
+    // This nock will fail if the ee param is wrong
+    nock('https://n5eil09e.ecs.edsc.org')
+      .post('/egi/request', stringify({
+        FILE_IDS: 'GRANULE_SHORT_NAME',
+        CLIENT_STRING:
+          'To view the status of your request, please see: http://localhost:8080/downloads/4517239960?ee=uat',
+        CLIENT: 'ESI',
+        FORMAT: 'HDF-EOS',
+        INCLUDE_META: 'Y',
+        INTERPOLATION: 'CC',
+        PROJECTION: 'LAMBERT AZIMUTHAL',
+        REQUEST_MODE: 'async',
+        SUBAGENT_ID: 'HEG',
+        PROJECTION_PARAMETERS: 'Sphere:45,FE:54',
+        RESAMPLE: 'PERCENT:100',
+        SUBSET_DATA_LAYERS:
+          '/MI1B2E/BlueBand,/MI1B2E/BRF Conversion Factors,/MI1B2E/GeometricParameters,/MI1B2E/NIRBand,/MI1B2E/RedBand',
+        BBOX: '-180,-90,180,90'
+      }))
+      .reply(201, '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><eesi:agentResponse><order><orderId>9876978</orderId><Instructions>To view the status of your request, please see: http://localhost:8080/downloads/C10000005-EDSC</Instructions></order></eesi:agentResponse>')
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          id: '1',
+          environment: 'uat',
+          jsondata: { source: '?sf=1', shapefileId: 1 },
+          access_method: {
+            type: 'ESI',
+            model: '<ecs:options xmlns:ecs="http://ecs.nasa.gov/options"><ecs:distribution xmlns="http://ecs.nasa.gov/options"><ecs:mediatype><ecs:value>HTTPS</ecs:value></ecs:mediatype><ecs:mediaformat><ecs:ftppull-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppull-format><ecs:ftppush-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppush-format></ecs:mediaformat></ecs:distribution><ecs:ancillary xmlns="http://ecs.nasa.gov/options"><ecs:orderPH>false</ecs:orderPH><ecs:orderQA>false</ecs:orderQA><ecs:orderHDF_MAP>false</ecs:orderHDF_MAP><ecs:orderBrowse>false</ecs:orderBrowse></ecs:ancillary><ecs:esi-xml><!--NOTE: elements in caps losely match the ESI API, those in lowercase are helper elements --><!--Dataset ID will be injected by Reverb--><ecs:CLIENT>ESI</ecs:CLIENT><!--First SubsetAgent in the input capabilities XML is used as the default.--><ecs:SUBAGENT_ID><ecs:value>HEG</ecs:value></ecs:SUBAGENT_ID><!-- hardcode to async for Reverb services --><ecs:REQUEST_MODE>async</ecs:REQUEST_MODE><ecs:SPATIAL_MSG>Click the checkbox to enable spatial subsetting.</ecs:SPATIAL_MSG><ecs:PROJ_MSG_1>CAUTION: Re-projection parameters may alter results.</ecs:PROJ_MSG_1><ecs:PROJ_MSG_2>Leave blank to choose default values for each re-projected granule.</ecs:PROJ_MSG_2><ecs:INTRPL_MSG_1>Used to calculate data of resampled and reprojected pixels.</ecs:INTRPL_MSG_1><ecs:HEG-request><!--Need to populate BBOX in final ESI request as follows: "&BBOX=ullon,lrlat,lrlon,ullat"--><ecs:spatial_subsetting><ecs:boundingbox><ecs:ullat>90</ecs:ullat><ecs:ullon>-180</ecs:ullon><ecs:lrlat>-90</ecs:lrlat><ecs:lrlon>180</ecs:lrlon></ecs:boundingbox></ecs:spatial_subsetting><ecs:band_subsetting><ecs:SUBSET_DATA_LAYERS style="tree"><ecs:MI1B2E><ecs:dataset>/MI1B2E/BlueBand</ecs:dataset><ecs:dataset>/MI1B2E/BRF Conversion Factors</ecs:dataset><ecs:dataset>/MI1B2E/GeometricParameters</ecs:dataset><ecs:dataset>/MI1B2E/NIRBand</ecs:dataset><ecs:dataset>/MI1B2E/RedBand</ecs:dataset></ecs:MI1B2E></ecs:SUBSET_DATA_LAYERS></ecs:band_subsetting><!--First Format in the input XML is used as the default.--><ecs:FORMAT><ecs:value>HDF-EOS</ecs:value></ecs:FORMAT><!-- OUTPUT_GRID is never used in ESI (but should be enabled for SSW)--><!-- FILE_IDS must be injected by Reverb --><!-- FILE_URLS is not used in requests from ECHO, Use FILE_IDS instead --><ecs:projection_options><ecs:PROJECTION><ecs:value>LAMBERT AZIMUTHAL</ecs:value></ecs:PROJECTION><!--In final ESI request, projection parameters should be included as follows: "&PROJECTION_PARAMETERS=param1:value1,param2:value2,...paramn:valuen"--><ecs:PROJECTION_PARAMETERS><ecs:LAMBERT_AZIMUTHAL_projection><ecs:Sphere>45</ecs:Sphere><ecs:FE>54</ecs:FE></ecs:LAMBERT_AZIMUTHAL_projection></ecs:PROJECTION_PARAMETERS></ecs:projection_options><ecs:advanced_file_options><!--In final ESI request, resample options should be formatted like: "&RESAMPLE=dimension:value"--><ecs:RESAMPLE><ecs:GEOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:GEOGRAPHIC-dimension><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:STATE_PLANE-dimension><ecs:value>PERCENT</ecs:value></ecs:STATE_PLANE-dimension><ecs:ALBERS-dimension><ecs:value>PERCENT</ecs:value></ecs:ALBERS-dimension><ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:MERCATOR-dimension><ecs:POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:POLAR_STEREOGRAPHIC-dimension><ecs:TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:TRANSVERSE_MERCATOR-dimension><ecs:LAMBERT_AZIMUTHAL-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_AZIMUTHAL-dimension><ecs:SINUSOIDAL-dimension><ecs:value>PERCENT</ecs:value></ecs:SINUSOIDAL-dimension><ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:value>PERCENT</ecs:value></ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:NO_CHANGE-dimension><ecs:value>PERCENT</ecs:value></ecs:NO_CHANGE-dimension><ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:GEOGRAPHIC-PERCENT-value>100</ecs:GEOGRAPHIC-PERCENT-value><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value><ecs:STATE_PLANE-PERCENT-value>100</ecs:STATE_PLANE-PERCENT-value><ecs:ALBERS-PERCENT-value>100</ecs:ALBERS-PERCENT-value><ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value>100</ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value><ecs:MERCATOR-PERCENT-value>100</ecs:MERCATOR-PERCENT-value><ecs:POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:POLAR_STEREOGRAPHIC-PERCENT-value><ecs:TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:TRANSVERSE_MERCATOR-PERCENT-value><ecs:LAMBERT_AZIMUTHAL-PERCENT-value>100</ecs:LAMBERT_AZIMUTHAL-PERCENT-value><ecs:SINUSOIDAL-PERCENT-value>100</ecs:SINUSOIDAL-PERCENT-value><ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value>100</ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value><ecs:NO_CHANGE-PERCENT-value>100</ecs:NO_CHANGE-PERCENT-value><ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value><ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value></ecs:RESAMPLE><ecs:INTERPOLATION><ecs:value>CC</ecs:value></ecs:INTERPOLATION><!--INCLUDE_META needs to be converted from true/false here to Y/N in the request.--><ecs:INCLUDE_META>true</ecs:INCLUDE_META></ecs:advanced_file_options><ecs:spatial_subset_flag>true</ecs:spatial_subset_flag><ecs:band_subset_flag>true</ecs:band_subset_flag><ecs:temporal_subset_flag>false</ecs:temporal_subset_flag></ecs:HEG-request></ecs:esi-xml></ecs:options>',
+            url: 'https://n5eil09e.ecs.edsc.org/egi/request'
+          },
+          granule_params: {
+            concept_id: ['G10000005-EDSC']
+          }
+        }])
+      } else if (step === 2) {
+        query.response({
+          file: 'mock shapefile'
+        })
+      } else {
+        query.response([])
+      }
+    })
+
+    const context = {}
+    await submitCatalogRestOrder(mockCatalogRestOrder, context)
   })
 
   test('creates a limited shapefile if the shapefile was limited by the user', async () => {
@@ -235,6 +305,7 @@ describe('submitCatalogRestOrder', () => {
       if (step === 1) {
         query.response([{
           id: '1',
+          environment: 'prod',
           user_id: 1,
           jsondata: { source: '?sf=1&sfs[0]=1', shapefileId: 1, selectedFeatures: ['1'] },
           access_method: {

--- a/serverless/src/submitCatalogRestOrder/handler.js
+++ b/serverless/src/submitCatalogRestOrder/handler.js
@@ -12,6 +12,7 @@ import {
   getApplicationConfig,
   getEarthdataConfig
 } from '../../../sharedUtils/config'
+import { deployedEnvironment } from '../../../sharedUtils/deployedEnvironment'
 import { getNameValuePairsForProjections } from '../util/echoForms/getNameValuePairsForProjections'
 import { getNameValuePairsForResample } from '../util/echoForms/getNameValuePairsForResample'
 import { getShapefile } from '../util/echoForms/getShapefile'
@@ -115,8 +116,10 @@ const submitCatalogRestOrder = async (event, context) => {
 
     const obfuscatedRetrievalId = obfuscateId(retrievalId)
 
+    const eeLink = environment === deployedEnvironment() ? '' : `?ee=${environment}`
+
     // URL used when submitting the order to inform the user where they can retrieve their order status
-    const edscStatusUrl = `${edscHost}${portalPath({ portalId })}/downloads/${obfuscatedRetrievalId}`
+    const edscStatusUrl = `${edscHost}${portalPath({ portalId })}/downloads/${obfuscatedRetrievalId}${eeLink}`
 
     const { model, url, type } = accessMethod
 

--- a/static/src/js/actions/__tests__/retrievalHistory.test.js
+++ b/static/src/js/actions/__tests__/retrievalHistory.test.js
@@ -1,0 +1,135 @@
+import nock from 'nock'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import {
+  SET_RETRIEVAL_HISTORY,
+  SET_RETRIEVAL_HISTORY_LOADING
+} from '../../constants/actionTypes'
+
+import { fetchRetrievalHistory } from '../retrievalHistory'
+
+import * as earthdataEnvironmentSelector from '../../selectors/earthdataEnvironment'
+
+const mockStore = configureMockStore([thunk])
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('fetchRetrievalHistory', () => {
+  test('calls lambda to get the retrievals', async () => {
+    nock(/localhost/)
+      .get(/retrievals/)
+      .reply(200, [
+        {
+          id: '1234',
+          environment: 'prod',
+          collections: [],
+          jsondata: {
+            portalId: 'edsc',
+            source: '?p=!C1234-EDSC'
+          }
+        }
+      ])
+
+    // mockStore with initialState
+    const store = mockStore({
+      authToken: 'mockToken',
+      earthdataEnvironment: 'prod'
+    })
+
+    // call the dispatch
+    await store.dispatch(fetchRetrievalHistory('prod')).then(() => {
+      expect(store.getActions().length).toEqual(2)
+      expect(store.getActions()[0]).toEqual({
+        type: SET_RETRIEVAL_HISTORY_LOADING
+      })
+      expect(store.getActions()[1]).toEqual({
+        payload: [
+          {
+            id: '1234',
+            environment: 'prod',
+            collections: [],
+            jsondata: {
+              portalId: 'edsc',
+              source: '?p=!C1234-EDSC'
+            }
+          }
+        ],
+        type: SET_RETRIEVAL_HISTORY
+      })
+    })
+  })
+
+  test('retrieves the earthdataEnvironment from the state if not provided', async () => {
+    nock(/localhost/)
+      .get(/retrievals/)
+      .reply(200, [
+        {
+          id: '1234',
+          environment: 'prod',
+          collections: [],
+          jsondata: {
+            portalId: 'edsc',
+            source: '?p=!C1234-EDSC'
+          }
+        }
+      ])
+
+    // mockStore with initialState
+    const store = mockStore({
+      authToken: 'mockToken',
+      earthdataEnvironment: 'prod'
+    })
+
+    const getEarthdataEnvironmentMock = jest.spyOn(earthdataEnvironmentSelector, 'getEarthdataEnvironment')
+
+    // call the dispatch
+    await store.dispatch(fetchRetrievalHistory()).then(() => {
+      expect(store.getActions().length).toEqual(2)
+      expect(store.getActions()[0]).toEqual({
+        type: SET_RETRIEVAL_HISTORY_LOADING
+      })
+      expect(store.getActions()[1]).toEqual({
+        payload: [
+          {
+            id: '1234',
+            environment: 'prod',
+            collections: [],
+            jsondata: {
+              portalId: 'edsc',
+              source: '?p=!C1234-EDSC'
+            }
+          }
+        ],
+        type: SET_RETRIEVAL_HISTORY
+      })
+
+      expect(getEarthdataEnvironmentMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('does not call setRetrievalHistory on error', async () => {
+    nock(/localhost/)
+      .get(/retrievals/)
+      .reply(500, {
+        errors: ['An error occured.']
+      })
+
+    nock(/localhost/)
+      .post(/error_logger/)
+      .reply(200)
+
+    const store = mockStore({
+      authToken: 'mockToken',
+      earthdataEnvironment: 'prod'
+    })
+
+    const consoleMock = jest.spyOn(console, 'error').mockImplementationOnce(() => jest.fn())
+
+    await store.dispatch(fetchRetrievalHistory('prod')).then(() => {
+      expect(consoleMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/static/src/js/actions/__tests__/retrievalHistory.test.js
+++ b/static/src/js/actions/__tests__/retrievalHistory.test.js
@@ -40,52 +40,6 @@ describe('fetchRetrievalHistory', () => {
     })
 
     // call the dispatch
-    await store.dispatch(fetchRetrievalHistory('prod')).then(() => {
-      expect(store.getActions().length).toEqual(2)
-      expect(store.getActions()[0]).toEqual({
-        type: SET_RETRIEVAL_HISTORY_LOADING
-      })
-      expect(store.getActions()[1]).toEqual({
-        payload: [
-          {
-            id: '1234',
-            environment: 'prod',
-            collections: [],
-            jsondata: {
-              portalId: 'edsc',
-              source: '?p=!C1234-EDSC'
-            }
-          }
-        ],
-        type: SET_RETRIEVAL_HISTORY
-      })
-    })
-  })
-
-  test('retrieves the earthdataEnvironment from the state if not provided', async () => {
-    nock(/localhost/)
-      .get(/retrievals/)
-      .reply(200, [
-        {
-          id: '1234',
-          environment: 'prod',
-          collections: [],
-          jsondata: {
-            portalId: 'edsc',
-            source: '?p=!C1234-EDSC'
-          }
-        }
-      ])
-
-    // mockStore with initialState
-    const store = mockStore({
-      authToken: 'mockToken',
-      earthdataEnvironment: 'prod'
-    })
-
-    const getEarthdataEnvironmentMock = jest.spyOn(earthdataEnvironmentSelector, 'getEarthdataEnvironment')
-
-    // call the dispatch
     await store.dispatch(fetchRetrievalHistory()).then(() => {
       expect(store.getActions().length).toEqual(2)
       expect(store.getActions()[0]).toEqual({
@@ -105,8 +59,6 @@ describe('fetchRetrievalHistory', () => {
         ],
         type: SET_RETRIEVAL_HISTORY
       })
-
-      expect(getEarthdataEnvironmentMock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/static/src/js/actions/retrieval.js
+++ b/static/src/js/actions/retrieval.js
@@ -14,6 +14,7 @@ import { portalPathFromState } from '../../../../sharedUtils/portalPath'
 import { prepareRetrievalParams } from '../util/retrievals'
 import { removeRetrievalHistory } from './retrievalHistory'
 import { submittingProject, submittedProject } from './project'
+import deployedEnvironment from '../../../../sharedUtils/deployedEnvironment'
 
 export const setRetrievalLoading = () => ({
   type: SET_RETRIEVAL_LOADING
@@ -91,7 +92,10 @@ export const submitRetrieval = () => (dispatch, getState) => {
       const { id: retrievalId } = response.data
 
       dispatch(submittedProject())
-      dispatch(push(`${portalPathFromState(state)}/downloads/${retrievalId}`))
+
+      const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
+
+      dispatch(push(`${portalPathFromState(state)}/downloads/${retrievalId}${eeLink}`))
     })
     .catch((error) => {
       dispatch(handleError({

--- a/static/src/js/actions/retrievalHistory.js
+++ b/static/src/js/actions/retrievalHistory.js
@@ -26,12 +26,14 @@ export const removeRetrievalHistory = retrievalId => ({
 /**
  * Fetch a retrieval from the database
  */
-export const fetchRetrievalHistory = () => (dispatch, getState) => {
+export const fetchRetrievalHistory = ee => (dispatch, getState) => {
   const state = getState()
 
   // Retrieve data from Redux using selectors
-  const earthdataEnvironment = getEarthdataEnvironment(state)
-
+  let earthdataEnvironment = ee
+  if (!ee) {
+    earthdataEnvironment = getEarthdataEnvironment(state)
+  }
   const { authToken } = state
 
   dispatch(setRetrievalHistoryLoading())

--- a/static/src/js/actions/retrievalHistory.js
+++ b/static/src/js/actions/retrievalHistory.js
@@ -26,14 +26,12 @@ export const removeRetrievalHistory = retrievalId => ({
 /**
  * Fetch a retrieval from the database
  */
-export const fetchRetrievalHistory = ee => (dispatch, getState) => {
+export const fetchRetrievalHistory = () => (dispatch, getState) => {
   const state = getState()
 
   // Retrieve data from Redux using selectors
-  let earthdataEnvironment = ee
-  if (!ee) {
-    earthdataEnvironment = getEarthdataEnvironment(state)
-  }
+  const earthdataEnvironment = getEarthdataEnvironment(state)
+
   const { authToken } = state
 
   dispatch(setRetrievalHistoryLoading())

--- a/static/src/js/components/DownloadHistory/DownloadHistory.js
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.js
@@ -5,6 +5,7 @@ import TimeAgo from 'react-timeago'
 
 import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
 import pluralize from '../../util/pluralize'
+import { stringify } from '../../util/url/url'
 
 import Button from '../Button/Button'
 import Spinner from '../Spinner/Spinner'
@@ -63,8 +64,6 @@ export class DownloadHistory extends Component {
       retrievalHistoryLoaded
     } = this.props
 
-    const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
-
     return (
       <>
         <h2 className="route-wrapper__page-heading">Download Status & History</h2>
@@ -116,7 +115,10 @@ export class DownloadHistory extends Component {
                           <td>
                             <PortalLinkContainer
                               portalId={portalId}
-                              to={`/downloads/${id}${eeLink}`}
+                              to={{
+                                pathname: `/downloads/${id}`,
+                                search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
+                              }}
                             >
                               {this.retrievalDescription(collections)}
                             </PortalLinkContainer>

--- a/static/src/js/components/DownloadHistory/DownloadHistory.js
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Table } from 'react-bootstrap'
 import TimeAgo from 'react-timeago'
 
+import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
 import pluralize from '../../util/pluralize'
 
 import Button from '../Button/Button'
@@ -56,10 +57,13 @@ export class DownloadHistory extends Component {
 
   render() {
     const {
+      earthdataEnvironment,
       retrievalHistory,
       retrievalHistoryLoading,
       retrievalHistoryLoaded
     } = this.props
+
+    const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
 
     return (
       <>
@@ -112,7 +116,7 @@ export class DownloadHistory extends Component {
                           <td>
                             <PortalLinkContainer
                               portalId={portalId}
-                              to={`/downloads/${id}`}
+                              to={`/downloads/${id}${eeLink}`}
                             >
                               {this.retrievalDescription(collections)}
                             </PortalLinkContainer>
@@ -141,6 +145,7 @@ DownloadHistory.defaultProps = {
 }
 
 DownloadHistory.propTypes = {
+  earthdataEnvironment: PropTypes.string.isRequired,
   retrievalHistory: PropTypes.arrayOf(
     PropTypes.shape({})
   ),

--- a/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.js
+++ b/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.js
@@ -64,7 +64,7 @@ describe('DownloadHistory component', () => {
       })
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
-      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual({ pathname: '/downloads/8069076', search: '' })
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('1 collection')
     })
 
@@ -86,7 +86,7 @@ describe('DownloadHistory component', () => {
       })
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
-      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual({ pathname: '/downloads/8069076', search: '' })
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title')
     })
 
@@ -110,7 +110,7 @@ describe('DownloadHistory component', () => {
       })
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
-      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual({ pathname: '/downloads/8069076', search: '' })
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title and 1 other collection')
     })
 
@@ -135,7 +135,7 @@ describe('DownloadHistory component', () => {
 
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
-      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual({ pathname: '/downloads/8069076', search: '' })
       expect(enzymeWrapper.find(PortalLinkContainer).prop('portalId')).toEqual('test')
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title')
     })
@@ -161,7 +161,10 @@ describe('DownloadHistory component', () => {
 
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
-      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076?ee=uat')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual({
+        pathname: '/downloads/8069076',
+        search: '?ee=uat'
+      })
       expect(enzymeWrapper.find(PortalLinkContainer).prop('portalId')).toEqual('test')
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title')
     })

--- a/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.js
+++ b/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.js
@@ -23,6 +23,7 @@ describe('DownloadHistory component', () => {
     test('renders a spinner when retrievals are loading', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [],
         retrievalHistoryLoading: true,
         retrievalHistoryLoaded: false,
@@ -35,6 +36,7 @@ describe('DownloadHistory component', () => {
     test('renders a message when no retrievals exist', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [],
         retrievalHistoryLoading: false,
         retrievalHistoryLoaded: true,
@@ -49,6 +51,7 @@ describe('DownloadHistory component', () => {
     test('renders a table when a retrieval exists with one collection that has no title', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [{
           id: '8069076',
           jsondata: {},
@@ -68,6 +71,7 @@ describe('DownloadHistory component', () => {
     test('renders a table when a retrieval exists with one collection', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [{
           id: '8069076',
           jsondata: {},
@@ -89,6 +93,7 @@ describe('DownloadHistory component', () => {
     test('renders a table when a retrieval exists with two collections', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [{
           id: '8069076',
           jsondata: {},
@@ -112,6 +117,7 @@ describe('DownloadHistory component', () => {
     test('renders links correctly when portals were used to place an order', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
         retrievalHistory: [{
           id: '8069076',
           jsondata: {
@@ -130,6 +136,32 @@ describe('DownloadHistory component', () => {
       expect(enzymeWrapper.find(Table).length).toBe(1)
       expect(enzymeWrapper.find('tbody tr').length).toBe(1)
       expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('portalId')).toEqual('test')
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title')
+    })
+
+    test('renders links correctly when the earthdataEnvironment doesn\'t match the deployed environment', () => {
+      const { enzymeWrapper } = setup({
+        authToken: 'testToken',
+        earthdataEnvironment: 'uat',
+        retrievalHistory: [{
+          id: '8069076',
+          jsondata: {
+            portal_id: 'test'
+          },
+          created_at: '2019-08-25T11:58:14.390Z',
+          collections: [{
+            title: 'Collection Title'
+          }]
+        }],
+        retrievalHistoryLoading: false,
+        retrievalHistoryLoaded: true,
+        onDeleteRetrieval: jest.fn()
+      })
+
+      expect(enzymeWrapper.find(Table).length).toBe(1)
+      expect(enzymeWrapper.find('tbody tr').length).toBe(1)
+      expect(enzymeWrapper.find(PortalLinkContainer).prop('to')).toEqual('/downloads/8069076?ee=uat')
       expect(enzymeWrapper.find(PortalLinkContainer).prop('portalId')).toEqual('test')
       expect(enzymeWrapper.find(PortalLinkContainer).prop('children')).toEqual('Collection Title')
     })

--- a/static/src/js/components/OrderStatus/OrderStatus.js
+++ b/static/src/js/components/OrderStatus/OrderStatus.js
@@ -7,9 +7,10 @@ import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLink
 import Skeleton from '../Skeleton/Skeleton'
 
 import { orderStatusSkeleton, orderStatusLinksSkeleton } from './skeleton'
-import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
+import { deployedEnvironment } from '../../../../../sharedUtils/deployedEnvironment'
 import { portalPath } from '../../../../../sharedUtils/portalPath'
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
+import { stringify } from '../../util/url/url'
 
 import './OrderStatus.scss'
 
@@ -81,11 +82,26 @@ export class OrderStatus extends Component {
     const introduction = (
       <p>
         {'This page will automatically update as your orders are processed. The Download Status page can be accessed later by visiting '}
-        <a href={`${edscHost}${portalPath(portal)}/downloads/${id}`}>
-          {`${edscHost}${portalPath(portal)}/downloads/${id}`}
+        {/* <PortalLinkContainer
+          to={{
+            pathname: '/downloads',
+            search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
+          }}
+        >
+          Download Status and History
+        </PortalLinkContainer> */}
+        <a href={`${edscHost}${portalPath(portal)}/downloads/${id}${eeLink}`}>
+          {`${edscHost}${portalPath(portal)}/downloads/${id}${eeLink}`}
         </a>
         {' or the '}
-        <a href={`${edscHost}${portalPath(portal)}/downloads${eeLink}`}>Download Status and History</a>
+        <PortalLinkContainer
+          to={{
+            pathname: '/downloads',
+            search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
+          }}
+        >
+          Download Status and History
+        </PortalLinkContainer>
         {' page.'}
       </p>
     )
@@ -211,7 +227,8 @@ export class OrderStatus extends Component {
                 <PortalLinkContainer
                   className="order-status__footer-link"
                   to={{
-                    pathname: '/search'
+                    pathname: '/search',
+                    search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
                   }}
                   onClick={() => { onChangePath('/search') }}
                 >
@@ -220,7 +237,15 @@ export class OrderStatus extends Component {
               </li>
               <li className="order-status__footer-link-item">
                 <i className="fa fa-chevron-circle-right order-status__footer-link-icon" />
-                <a className="order-status__footer-link" href={`${portalPath(portal)}/downloads`}>View Your Download Status & History</a>
+                <PortalLinkContainer
+                  className="order-status__footer-link"
+                  to={{
+                    pathname: '/downloads',
+                    search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
+                  }}
+                >
+                  View Your Download Status & History
+                </PortalLinkContainer>
               </li>
             </ul>
           </Well.Footer>

--- a/static/src/js/components/OrderStatus/OrderStatus.js
+++ b/static/src/js/components/OrderStatus/OrderStatus.js
@@ -7,6 +7,7 @@ import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLink
 import Skeleton from '../Skeleton/Skeleton'
 
 import { orderStatusSkeleton, orderStatusLinksSkeleton } from './skeleton'
+import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
 import { portalPath } from '../../../../../sharedUtils/portalPath'
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
 
@@ -75,6 +76,8 @@ export class OrderStatus extends Component {
 
     const { edscHost } = getEnvironmentConfig()
 
+    const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
+
     const introduction = (
       <p>
         {'This page will automatically update as your orders are processed. The Download Status page can be accessed later by visiting '}
@@ -82,7 +85,7 @@ export class OrderStatus extends Component {
           {`${edscHost}${portalPath(portal)}/downloads/${id}`}
         </a>
         {' or the '}
-        <a href={`${edscHost}${portalPath(portal)}/downloads`}>Download Status and History</a>
+        <a href={`${edscHost}${portalPath(portal)}/downloads${eeLink}`}>Download Status and History</a>
         {' page.'}
       </p>
     )

--- a/static/src/js/components/OrderStatus/OrderStatus.js
+++ b/static/src/js/components/OrderStatus/OrderStatus.js
@@ -82,14 +82,6 @@ export class OrderStatus extends Component {
     const introduction = (
       <p>
         {'This page will automatically update as your orders are processed. The Download Status page can be accessed later by visiting '}
-        {/* <PortalLinkContainer
-          to={{
-            pathname: '/downloads',
-            search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
-          }}
-        >
-          Download Status and History
-        </PortalLinkContainer> */}
         <a href={`${edscHost}${portalPath(portal)}/downloads/${id}${eeLink}`}>
           {`${edscHost}${portalPath(portal)}/downloads/${id}${eeLink}`}
         </a>

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
@@ -78,9 +78,22 @@ describe('OrderStatus component', () => {
       expect(enzymeWrapper.find(Well.Introduction).find('a').at(0).props().href).toEqual('http://localhost/downloads/7')
     })
 
+    test('download status link has correct href when earthdataEnvironment is different than the deployed environment', () => {
+      jest.spyOn(config, 'getApplicationConfig').mockImplementation(() => ({
+        defaultPortal: 'edsc',
+        env: 'uat'
+      }))
+
+      const { enzymeWrapper } = setup()
+      expect(enzymeWrapper.find(Well.Introduction).find('a').at(0).props().href).toEqual('http://localhost/downloads/7?ee=prod')
+    })
+
     test('status link has correct href', () => {
       const { enzymeWrapper } = setup()
-      expect(enzymeWrapper.find(Well.Introduction).find('a').at(1).props().href).toEqual('http://localhost/downloads')
+      expect(enzymeWrapper.find(Well.Introduction).find(PortalLinkContainer).at(0).props().to).toEqual({
+        pathname: '/downloads',
+        search: ''
+      })
     })
 
     test('status link has correct href when earthdataEnvironment is different than the deployed environment', () => {
@@ -90,7 +103,10 @@ describe('OrderStatus component', () => {
       }))
 
       const { enzymeWrapper } = setup()
-      expect(enzymeWrapper.find(Well.Introduction).find('a').at(1).props().href).toEqual('http://localhost/downloads?ee=prod')
+      expect(enzymeWrapper.find(Well.Introduction).find(PortalLinkContainer).at(0).props().to).toEqual({
+        pathname: '/downloads',
+        search: '?ee=prod'
+      })
     })
   })
 

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import Enzyme, { mount } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { StaticRouter } from 'react-router'
+
 import { retrievalStatusProps, retrievalStatusPropsTwo } from './mocks'
 import { Well } from '../../Well/Well'
 import { OrderStatus } from '../OrderStatus'
@@ -62,7 +63,8 @@ describe('OrderStatus component', () => {
     beforeEach(() => {
       jest.spyOn(config, 'getEnvironmentConfig').mockImplementation(() => ({ edscHost: 'http://localhost' }))
       jest.spyOn(config, 'getApplicationConfig').mockImplementation(() => ({
-        defaultPortal: 'edsc'
+        defaultPortal: 'edsc',
+        env: 'prod'
       }))
     })
 
@@ -79,6 +81,16 @@ describe('OrderStatus component', () => {
     test('status link has correct href', () => {
       const { enzymeWrapper } = setup()
       expect(enzymeWrapper.find(Well.Introduction).find('a').at(1).props().href).toEqual('http://localhost/downloads')
+    })
+
+    test('status link has correct href when earthdataEnvironment is different than the deployed environment', () => {
+      jest.spyOn(config, 'getApplicationConfig').mockImplementation(() => ({
+        defaultPortal: 'edsc',
+        env: 'uat'
+      }))
+
+      const { enzymeWrapper } = setup()
+      expect(enzymeWrapper.find(Well.Introduction).find('a').at(1).props().href).toEqual('http://localhost/downloads?ee=prod')
     })
   })
 

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
@@ -4,7 +4,7 @@ import { Col, Dropdown, Form } from 'react-bootstrap'
 import { LinkContainer } from 'react-router-bootstrap'
 import { parse } from 'qs'
 
-import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
+import { deployedEnvironment } from '../../../../../sharedUtils/deployedEnvironment'
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
 import { isPath } from '../../util/isPath'
 import { locationPropType } from '../../util/propTypes/location'
@@ -183,8 +183,6 @@ class SecondaryToolbar extends Component {
       </Button>
     )
 
-    const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
-
     const loggedInDropdown = (
       <Dropdown className="secondary-toolbar__user-dropdown">
         <Dropdown.Toggle
@@ -215,7 +213,10 @@ class SecondaryToolbar extends Component {
             </Dropdown.Item>
           </LinkContainer>
           <LinkContainer
-            to={`${portalPath(portal)}/downloads${eeLink}`}
+            to={{
+              pathname: `${portalPath(portal)}/downloads`,
+              search: stringify({ ee: earthdataEnvironment === deployedEnvironment() ? '' : earthdataEnvironment })
+            }}
           >
             <Dropdown.Item
               className="secondary-toolbar__downloads"

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
@@ -4,6 +4,7 @@ import { Col, Dropdown, Form } from 'react-bootstrap'
 import { LinkContainer } from 'react-router-bootstrap'
 import { parse } from 'qs'
 
+import deployedEnvironment from '../../../../../sharedUtils/deployedEnvironment'
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
 import { isPath } from '../../util/isPath'
 import { locationPropType } from '../../util/propTypes/location'
@@ -182,6 +183,8 @@ class SecondaryToolbar extends Component {
       </Button>
     )
 
+    const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
+
     const loggedInDropdown = (
       <Dropdown className="secondary-toolbar__user-dropdown">
         <Dropdown.Toggle
@@ -212,7 +215,7 @@ class SecondaryToolbar extends Component {
             </Dropdown.Item>
           </LinkContainer>
           <LinkContainer
-            to={`${portalPath(portal)}/downloads`}
+            to={`${portalPath(portal)}/downloads${eeLink}`}
           >
             <Dropdown.Item
               className="secondary-toolbar__downloads"

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -106,7 +106,7 @@ describe('SecondaryToolbar component', () => {
         const downloadLink = enzymeWrapper.find('.secondary-toolbar__downloads')
         const linkContainer = downloadLink.parents(LinkContainer)
 
-        expect(linkContainer.props().to).toEqual('/downloads?ee=uat')
+        expect(linkContainer.props().to).toEqual({ pathname: '/downloads', search: '?ee=uat' })
       })
 
       test('does not add the ee param if the earthdataEnvironment is the deployed environment', () => {
@@ -115,7 +115,7 @@ describe('SecondaryToolbar component', () => {
         const downloadLink = enzymeWrapper.find('.secondary-toolbar__downloads')
         const linkContainer = downloadLink.parents(LinkContainer)
 
-        expect(linkContainer.props().to).toEqual('/downloads')
+        expect(linkContainer.props().to).toEqual({ pathname: '/downloads', search: '' })
       })
     })
   })

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
+import { LinkContainer } from 'react-router-bootstrap'
 
 import SecondaryToolbar from '../SecondaryToolbar'
 import PortalFeatureContainer from '../../../containers/PortalFeatureContainer/PortalFeatureContainer'
-import { LinkContainer } from 'react-router-bootstrap'
+import * as getApplicationConfig from '../../../../../../sharedUtils/config'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -58,6 +59,13 @@ describe('SecondaryToolbar component', () => {
   })
 
   describe('when logged in', () => {
+    beforeEach(() => {
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        defaultPortal: 'edsc',
+        env: 'prod'
+      }))
+    })
+
     test('should render the user dropdown', () => {
       const { enzymeWrapper } = setup('loggedIn')
 

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -4,6 +4,7 @@ import Adapter from 'enzyme-adapter-react-16'
 
 import SecondaryToolbar from '../SecondaryToolbar'
 import PortalFeatureContainer from '../../../containers/PortalFeatureContainer/PortalFeatureContainer'
+import { LinkContainer } from 'react-router-bootstrap'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -88,6 +89,26 @@ describe('SecondaryToolbar component', () => {
       logoutButton.simulate('click')
 
       expect(instance.handleLogout).toBeCalledTimes(1)
+    })
+
+    describe('Download Status and History link', () => {
+      test('adds the ee param if the earthdataEnvironment is different than the deployed environment', () => {
+        const { enzymeWrapper } = setup('loggedIn', { earthdataEnvironment: 'uat' })
+
+        const downloadLink = enzymeWrapper.find('.secondary-toolbar__downloads')
+        const linkContainer = downloadLink.parents(LinkContainer)
+
+        expect(linkContainer.props().to).toEqual('/downloads?ee=uat')
+      })
+
+      test('does not add the ee param if the earthdataEnvironment is the deployed environment', () => {
+        const { enzymeWrapper } = setup('loggedIn')
+
+        const downloadLink = enzymeWrapper.find('.secondary-toolbar__downloads')
+        const linkContainer = downloadLink.parents(LinkContainer)
+
+        expect(linkContainer.props().to).toEqual('/downloads')
+      })
     })
   })
 

--- a/static/src/js/containers/DownloadHistoryContainer/DownloadHistoryContainer.js
+++ b/static/src/js/containers/DownloadHistoryContainer/DownloadHistoryContainer.js
@@ -2,32 +2,42 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
+import { parse } from 'qs'
 
 import actions from '../../actions'
 import { DownloadHistory } from '../../components/DownloadHistory/DownloadHistory'
 
 const mapStateToProps = state => ({
+  earthdataEnvironment: state.earthdataEnvironment,
+  location: state.router.location,
   retrievalHistory: state.retrievalHistory.history,
   retrievalHistoryLoading: state.retrievalHistory.isLoading,
   retrievalHistoryLoaded: state.retrievalHistory.isLoaded
 })
 
 const mapDispatchToProps = dispatch => ({
-  onFetchRetrievalHistory: () => dispatch(actions.fetchRetrievalHistory()),
+  onFetchRetrievalHistory: (earthdataEnvironment) => {
+    dispatch(actions.fetchRetrievalHistory(earthdataEnvironment))
+  },
   onDeleteRetrieval: retrievalId => dispatch(actions.deleteRetrieval(retrievalId))
 })
 
 export class DownloadHistoryContainer extends Component {
   componentDidMount() {
     const {
+      location,
       onFetchRetrievalHistory
     } = this.props
 
-    onFetchRetrievalHistory()
+    const { search } = location
+    const { ee: earthdataEnvironment } = parse(search, { ignoreQueryPrefix: true })
+
+    onFetchRetrievalHistory(earthdataEnvironment)
   }
 
   render() {
     const {
+      earthdataEnvironment,
       retrievalHistory,
       onDeleteRetrieval,
       retrievalHistoryLoading,
@@ -36,6 +46,7 @@ export class DownloadHistoryContainer extends Component {
 
     return (
       <DownloadHistory
+        earthdataEnvironment={earthdataEnvironment}
         retrievalHistory={retrievalHistory}
         retrievalHistoryLoading={retrievalHistoryLoading}
         retrievalHistoryLoaded={retrievalHistoryLoaded}
@@ -50,6 +61,8 @@ DownloadHistoryContainer.defaultProps = {
 }
 
 DownloadHistoryContainer.propTypes = {
+  earthdataEnvironment: PropTypes.string.isRequired,
+  location: PropTypes.shape({}).isRequired,
   retrievalHistory: PropTypes.arrayOf(
     PropTypes.shape({})
   ),

--- a/static/src/js/containers/DownloadHistoryContainer/DownloadHistoryContainer.js
+++ b/static/src/js/containers/DownloadHistoryContainer/DownloadHistoryContainer.js
@@ -2,14 +2,12 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
-import { parse } from 'qs'
 
 import actions from '../../actions'
 import { DownloadHistory } from '../../components/DownloadHistory/DownloadHistory'
 
 const mapStateToProps = state => ({
   earthdataEnvironment: state.earthdataEnvironment,
-  location: state.router.location,
   retrievalHistory: state.retrievalHistory.history,
   retrievalHistoryLoading: state.retrievalHistory.isLoading,
   retrievalHistoryLoaded: state.retrievalHistory.isLoaded
@@ -25,14 +23,10 @@ const mapDispatchToProps = dispatch => ({
 export class DownloadHistoryContainer extends Component {
   componentDidMount() {
     const {
-      location,
       onFetchRetrievalHistory
     } = this.props
 
-    const { search } = location
-    const { ee: earthdataEnvironment } = parse(search, { ignoreQueryPrefix: true })
-
-    onFetchRetrievalHistory(earthdataEnvironment)
+    onFetchRetrievalHistory()
   }
 
   render() {
@@ -62,7 +56,6 @@ DownloadHistoryContainer.defaultProps = {
 
 DownloadHistoryContainer.propTypes = {
   earthdataEnvironment: PropTypes.string.isRequired,
-  location: PropTypes.shape({}).isRequired,
   retrievalHistory: PropTypes.arrayOf(
     PropTypes.shape({})
   ),

--- a/static/src/js/containers/DownloadHistoryContainer/__tests__/DownloadHistoryContainer.test.js
+++ b/static/src/js/containers/DownloadHistoryContainer/__tests__/DownloadHistoryContainer.test.js
@@ -21,9 +21,6 @@ describe('DownloadHistoryContainer component', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
         earthdataEnvironment: 'prod',
-        location: {
-          search: ''
-        },
         retrievalHistory: [{
           id: '8069076',
           jsondata: {},

--- a/static/src/js/containers/DownloadHistoryContainer/__tests__/DownloadHistoryContainer.test.js
+++ b/static/src/js/containers/DownloadHistoryContainer/__tests__/DownloadHistoryContainer.test.js
@@ -20,6 +20,10 @@ describe('DownloadHistoryContainer component', () => {
     test('renders a table when a retrieval exists with one collection that has no title', () => {
       const { enzymeWrapper } = setup({
         authToken: 'testToken',
+        earthdataEnvironment: 'prod',
+        location: {
+          search: ''
+        },
         retrievalHistory: [{
           id: '8069076',
           jsondata: {},

--- a/static/src/js/selectors/__tests__/earthdataEnvironment.test.js
+++ b/static/src/js/selectors/__tests__/earthdataEnvironment.test.js
@@ -3,7 +3,7 @@ import * as getApplicationConfig from '../../../../../sharedUtils/config'
 import { getEarthdataEnvironment } from '../earthdataEnvironment'
 
 describe('getEarthdataEnvironment', () => {
-  describe('when the state do not contain the earthdata env key', () => {
+  describe('when the state does not contain the earthdata env key', () => {
     test('returns the value from the static config', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
         env: 'prod'
@@ -15,7 +15,7 @@ describe('getEarthdataEnvironment', () => {
     })
   })
 
-  describe('when the state do contain the earthdata env key', () => {
+  describe('when the state does contain the earthdata env key', () => {
     test('returns the value from the header', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
         env: 'prod'
@@ -24,6 +24,25 @@ describe('getEarthdataEnvironment', () => {
       const response = getEarthdataEnvironment({ earthdataEnvironment: 'uat' })
 
       expect(response).toEqual('uat')
+    })
+  })
+
+  describe('when the URL contains the earthdata env key', () => {
+    test('returns the value from the URL', () => {
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        env: 'prod'
+      }))
+
+      const response = getEarthdataEnvironment({
+        earthdataEnvironment: 'uat',
+        router: {
+          location: {
+            search: '?ee=prod'
+          }
+        }
+      })
+
+      expect(response).toEqual('prod')
     })
   })
 })

--- a/static/src/js/selectors/earthdataEnvironment.js
+++ b/static/src/js/selectors/earthdataEnvironment.js
@@ -10,7 +10,7 @@ import { getApplicationConfig } from '../../../../sharedUtils/config'
 export const getEarthdataEnvironmentFromUrl = (state) => {
   const { router = {} } = state
   const { location = {} } = router
-  const { search } = location
+  const { search = '' } = location
 
   const { ee: earthdataEnvironment } = parse(search, { ignoreQueryPrefix: true })
 

--- a/static/src/js/selectors/earthdataEnvironment.js
+++ b/static/src/js/selectors/earthdataEnvironment.js
@@ -1,10 +1,27 @@
+import { createSelector } from 'reselect'
+import { parse } from 'qs'
+
 import { getApplicationConfig } from '../../../../sharedUtils/config'
 
 /**
- * Retrieve current CMR environment from Redux
+ * Retrieve the earthdataEnvironment param from the router location in Redux
  * @param {Object} state Current state of Redux
  */
-export const getEarthdataEnvironment = (state) => {
+export const getEarthdataEnvironmentFromUrl = (state) => {
+  const { router = {} } = state
+  const { location = {} } = router
+  const { search } = location
+
+  const { ee: earthdataEnvironment } = parse(search, { ignoreQueryPrefix: true })
+
+  return earthdataEnvironment
+}
+
+/**
+ * Retrieve current Earthdata Environment from Redux
+ * @param {Object} state Current state of Redux
+ */
+export const getEarthdataEnvironmentParam = (state) => {
   // Pull the default environment from the static application config
   let { env: defaultdeployedEnvironment } = getApplicationConfig()
 
@@ -15,3 +32,17 @@ export const getEarthdataEnvironment = (state) => {
 
   return earthdataEnvironment
 }
+
+/**
+ * Retrieve Earthdata Environment from Redux favoring the URL over the value stored in earthdataEnvironment reducer
+ */
+export const getEarthdataEnvironment = createSelector(
+  [getEarthdataEnvironmentParam, getEarthdataEnvironmentFromUrl],
+  (eeParam, eeFromUrl) => {
+    if (eeFromUrl) {
+      return eeFromUrl
+    }
+
+    return eeParam
+  }
+)

--- a/static/src/js/util/url/url.js
+++ b/static/src/js/util/url/url.js
@@ -237,7 +237,6 @@ export const encodeUrlQuery = (props) => {
  * because it shares the base url with the projects page.
  */
 export const urlPathsWithoutUrlParams = [
-  /^\/downloads/,
   /^\/contact_info/,
   /^\/auth_callback/,
   /^\/admin/


### PR DESCRIPTION
# Overview

### What is the feature?

Adds support for earthdata environment on /downloads

### What areas of the application does this impact?

Download status page, download history page

# Testing

### Reproduction steps

View the downloads page with the `ee` param

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
