### PR TITLE
EDSC-2864: Make requests to CMR using Authorization header instead of Echo-Token

### DIFF
--- a/serverless/src/conceptMetadata/__tests__/handler.test.js
+++ b/serverless/src/conceptMetadata/__tests__/handler.test.js
@@ -1,4 +1,5 @@
 import conceptMetadata from '../handler'
+
 import * as getAccessTokenFromJwtToken from '../../util/urs/getAccessTokenFromJwtToken'
 import * as getEdlConfig from '../../util/getEdlConfig'
 

--- a/serverless/src/conceptMetadata/handler.js
+++ b/serverless/src/conceptMetadata/handler.js
@@ -26,6 +26,7 @@ const conceptMetadata = async (event) => {
   const { client } = edlConfig
   const { id: clientId } = client
 
+  // Access tokens used in the URL still require the client id
   const conceptUrl = `${desiredPath}?${stringify({ ...parsedQueryParams, token: `${accessToken}:${clientId}` }, { encode: false })}`
 
   return {

--- a/serverless/src/edlAdminAuthorizer/__tests__/handler.test.js
+++ b/serverless/src/edlAdminAuthorizer/__tests__/handler.test.js
@@ -14,7 +14,7 @@ describe('edlAdminAuthorizer', () => {
       const event = {
         headers: {
           'Earthdata-ENV': 'test',
-          Authorization: `Bearer: ${jwtToken}`
+          Authorization: `Bearer ${jwtToken}`
         }
       }
 
@@ -48,7 +48,7 @@ describe('edlAdminAuthorizer', () => {
       const { jwtToken } = getEnvironmentConfig('test')
 
       const event = {
-        authorizationToken: `Bearer: ${jwtToken}`
+        authorizationToken: `Bearer ${jwtToken}`
       }
 
       await expect(
@@ -67,7 +67,7 @@ describe('edlAdminAuthorizer', () => {
       const { jwtToken } = getEnvironmentConfig('test')
 
       const event = {
-        authorizationToken: `Bearer: ${jwtToken}`
+        authorizationToken: `Bearer ${jwtToken}`
       }
 
       await expect(

--- a/serverless/src/edlAdminAuthorizer/handler.js
+++ b/serverless/src/edlAdminAuthorizer/handler.js
@@ -22,7 +22,7 @@ const edlAdminAuthorizer = async (event, context) => {
 
   const { Authorization: authorizationToken = '' } = headers
 
-  // authorizationToken comes in as `Bearer: asdf.qwer.hjkl` but we only need the actual token
+  // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')
   const jwtToken = tokenParts[1]
 

--- a/serverless/src/edlAuthorizer/__tests__/handler.test.js
+++ b/serverless/src/edlAuthorizer/__tests__/handler.test.js
@@ -12,7 +12,7 @@ describe('edlAuthorizer', () => {
       const event = {
         headers: {
           'Earthdata-ENV': 'test',
-          Authorization: `Bearer: ${jwtToken}`
+          Authorization: `Bearer ${jwtToken}`
         }
       }
 

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -17,7 +17,7 @@ const edlAuthorizer = async (event) => {
 
   const { Authorization: authorizationToken = '' } = headers
 
-  // authorizationToken comes in as `Bearer: asdf.qwer.hjkl` but we only need the actual token
+  // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')
   const jwtToken = tokenParts[1]
 

--- a/serverless/src/edlOptionalAuthorizer/__tests__/handler.test.js
+++ b/serverless/src/edlOptionalAuthorizer/__tests__/handler.test.js
@@ -13,7 +13,7 @@ describe('edlOptionalAuthorizer', () => {
 
       const event = {
         headers: {
-          Authorization: `Bearer: ${jwtToken}`
+          Authorization: `Bearer ${jwtToken}`
         }
       }
 
@@ -76,7 +76,7 @@ describe('edlOptionalAuthorizer', () => {
 
       const event = {
         headers: {
-          Authorization: `Bearer: ${jwtToken}`
+          Authorization: `Bearer ${jwtToken}`
         }
       }
 

--- a/serverless/src/edlOptionalAuthorizer/handler.js
+++ b/serverless/src/edlOptionalAuthorizer/handler.js
@@ -21,12 +21,12 @@ const edlOptionalAuthorizer = async (event) => {
   // resourcePath contains the path assigned to the lambda being requested
   const { resourcePath } = requestContext
 
-  // authorizationToken comes in as `Bearer: asdf.qwer.hjkl` but we only need the actual token
+  // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')
   const jwtToken = tokenParts[1]
 
   // Authorization header must exist for API Gateway to execute this authorizer, but if the user isn't logged in,
-  // the header will be `Bearer: `
+  // the header will be `Bearer `
   if (!jwtToken || jwtToken === '') {
     const authOptionalPaths = [
       '/autocomplete',

--- a/serverless/src/fetchCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/fetchCatalogRestOrder/__tests__/handler.test.js
@@ -71,7 +71,7 @@ describe('fetchCatalogRestOrder', () => {
         </eesi:agentResponse>`)
 
     const catalogRestResponse = await fetchCatalogRestOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ESI'
     })
@@ -82,7 +82,7 @@ describe('fetchCatalogRestOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(catalogRestResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'in_progress',
       orderType: 'ESI'
@@ -125,7 +125,7 @@ describe('fetchCatalogRestOrder', () => {
         </eesi:agentResponse>`)
 
     const catalogRestResponse = await fetchCatalogRestOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ESI'
     })
@@ -136,7 +136,7 @@ describe('fetchCatalogRestOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(catalogRestResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'complete',
       orderType: 'ESI'
@@ -179,7 +179,7 @@ describe('fetchCatalogRestOrder', () => {
         </eesi:agentResponse>`)
 
     const catalogRestResponse = await fetchCatalogRestOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ESI'
     })
@@ -190,7 +190,7 @@ describe('fetchCatalogRestOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(catalogRestResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'failed',
       orderType: 'ESI'
@@ -207,7 +207,7 @@ describe('fetchCatalogRestOrder', () => {
     })
 
     const catalogRestResponse = await fetchCatalogRestOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ESI'
     })
@@ -217,7 +217,7 @@ describe('fetchCatalogRestOrder', () => {
     expect(queries[0].method).toEqual('first')
 
     expect(catalogRestResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'not_found',
       orderType: 'ESI'

--- a/serverless/src/fetchCatalogRestOrder/handler.js
+++ b/serverless/src/fetchCatalogRestOrder/handler.js
@@ -52,7 +52,7 @@ const fetchCatalogRestOrder = async (input) => {
       url: `${url}/${orderNumber}`,
       method: 'get',
       headers: {
-        'Echo-Token': accessToken,
+        Authorization: `Bearer ${accessToken}`,
         'Client-Id': getClientId().background
       }
     })

--- a/serverless/src/fetchHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/fetchHarmonyOrder/__tests__/handler.test.js
@@ -80,7 +80,7 @@ describe('fetchHarmonyOrder', () => {
       })
 
     const harmonyResponse = await fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })
@@ -91,7 +91,7 @@ describe('fetchHarmonyOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(harmonyResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'in_progress',
       orderType: 'Harmony'
@@ -170,7 +170,7 @@ describe('fetchHarmonyOrder', () => {
       })
 
     const harmonyResponse = await fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })
@@ -181,7 +181,7 @@ describe('fetchHarmonyOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(harmonyResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'complete',
       orderType: 'Harmony'
@@ -238,7 +238,7 @@ describe('fetchHarmonyOrder', () => {
       })
 
     const harmonyResponse = await fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })
@@ -249,7 +249,7 @@ describe('fetchHarmonyOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(harmonyResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'failed',
       orderType: 'Harmony'
@@ -266,7 +266,7 @@ describe('fetchHarmonyOrder', () => {
     })
 
     const harmonyResponse = await fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })
@@ -276,7 +276,7 @@ describe('fetchHarmonyOrder', () => {
     expect(queries[0].method).toEqual('first')
 
     expect(harmonyResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'not_found',
       orderType: 'Harmony'
@@ -291,7 +291,7 @@ describe('fetchHarmonyOrder', () => {
     // Exclude an error message from the `toThrow` matcher because its
     // a specific sql statement and not necessary
     await expect(fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })).rejects.toThrow()
@@ -337,7 +337,7 @@ describe('fetchHarmonyOrder', () => {
       })
 
     await expect(fetchHarmonyOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'Harmony'
     })).rejects.toThrow('Error: Invalid format for Job ID \'ABCD-1234-EFGH-5678\'. Job ID must be a UUID.')

--- a/serverless/src/fetchLegacyServicesOrder/__tests__/handler.test.js
+++ b/serverless/src/fetchLegacyServicesOrder/__tests__/handler.test.js
@@ -79,7 +79,7 @@ describe('fetchLegacyServicesOrder', () => {
       ])
 
     const legacyServicesResponse = await fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })
@@ -90,7 +90,7 @@ describe('fetchLegacyServicesOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(legacyServicesResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'in_progress',
       orderType: 'ECHO ORDERS'
@@ -139,7 +139,7 @@ describe('fetchLegacyServicesOrder', () => {
       ])
 
     const legacyServicesResponse = await fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })
@@ -150,7 +150,7 @@ describe('fetchLegacyServicesOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(legacyServicesResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'complete',
       orderType: 'ECHO ORDERS'
@@ -199,7 +199,7 @@ describe('fetchLegacyServicesOrder', () => {
       ])
 
     const legacyServicesResponse = await fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })
@@ -210,7 +210,7 @@ describe('fetchLegacyServicesOrder', () => {
     expect(queries[1].method).toEqual('update')
 
     expect(legacyServicesResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'failed',
       orderType: 'ECHO ORDERS'
@@ -227,7 +227,7 @@ describe('fetchLegacyServicesOrder', () => {
     })
 
     const legacyServicesResponse = await fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })
@@ -237,7 +237,7 @@ describe('fetchLegacyServicesOrder', () => {
     expect(queries[0].method).toEqual('first')
 
     expect(legacyServicesResponse).toEqual({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderStatus: 'not_found',
       orderType: 'ECHO ORDERS'
@@ -252,7 +252,7 @@ describe('fetchLegacyServicesOrder', () => {
     // Exclude an error message from the `toThrow` matcher because its
     // a specific sql statement and not necessary
     await expect(fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })).rejects.toThrow()
@@ -283,7 +283,7 @@ describe('fetchLegacyServicesOrder', () => {
       })
 
     await expect(fetchLegacyServicesOrder({
-      accessToken: 'fake.access.token:clientId',
+      accessToken: 'fake.access.token',
       id: 1,
       orderType: 'ECHO ORDERS'
     })).rejects.toThrow('Test error message')

--- a/serverless/src/fetchLegacyServicesOrder/handler.js
+++ b/serverless/src/fetchLegacyServicesOrder/handler.js
@@ -51,7 +51,7 @@ const fetchLegacyServicesOrder = async (input) => {
     const orderResponse = await request.get({
       uri: `${getEarthdataConfig(environment).echoRestRoot}/orders.json`,
       headers: {
-        'Echo-Token': accessToken,
+        Authorization: `Bearer ${accessToken}`,
         'Client-Id': getClientId().background
       },
       qs: { id: orderNumber },

--- a/serverless/src/fetchOptionDefinitions/handler.js
+++ b/serverless/src/fetchOptionDefinitions/handler.js
@@ -60,9 +60,9 @@ const fetchOptionDefinitions = async (event, context) => {
           'catalog_item_id[]': granuleId
         }, { indices: false, arrayFormat: 'brackets' }),
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Echo-Token': cmrToken,
-          'Client-Id': getClientId().background
+          Authorization: `Bearer ${cmrToken}`,
+          'Client-Id': getClientId().background,
+          'Content-Type': 'application/x-www-form-urlencoded'
         },
         json: true,
         resolveWithFullResponse: true

--- a/serverless/src/generateCollectionCapabilityTags/handler.js
+++ b/serverless/src/generateCollectionCapabilityTags/handler.js
@@ -48,9 +48,9 @@ const generateCollectionCapabilityTags = async (input) => {
     uri: collectionSearchUrl,
     form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
     headers: {
+      Authorization: `Bearer ${cmrToken}`,
       'Client-Id': getClientId().background,
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Echo-Token': cmrToken
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
     json: true,
     resolveWithFullResponse: true

--- a/serverless/src/getAccessMethods/getOptionDefinitions.js
+++ b/serverless/src/getAccessMethods/getOptionDefinitions.js
@@ -18,6 +18,8 @@ export const getOptionDefinitions = async (
   const { provider } = collectionProvider
   const { id: providerId, organization_name: organizationName } = provider
 
+  const accessToken = await getEchoToken(jwtToken, earthdataEnvironment)
+
   await optionDefinitions.forEachAsync(async (optionDefinition, index) => {
     const { name } = optionDefinition
 
@@ -32,8 +34,8 @@ export const getOptionDefinitions = async (
           provider: providerId
         },
         headers: {
-          'Client-Id': getClientId().lambda,
-          'Echo-Token': await getEchoToken(jwtToken, earthdataEnvironment)
+          Authorization: `Bearer ${accessToken}`,
+          'Client-Id': getClientId().lambda
         },
         json: true,
         resolveWithFullResponse: true

--- a/serverless/src/getAccessMethods/getServiceOptionDefinitions.js
+++ b/serverless/src/getAccessMethods/getServiceOptionDefinitions.js
@@ -18,6 +18,8 @@ export const getServiceOptionDefinitions = async (
   const { provider } = collectionProvider
   const { id: providerId, organization_name: organizationName } = provider
 
+  const accessToken = await getEchoToken(jwtToken, earthdataEnvironment)
+
   await serviceOptionDefinitions.forEachAsync(async (serviceOptionDefinition, index) => {
     const { name } = serviceOptionDefinition
 
@@ -32,8 +34,8 @@ export const getServiceOptionDefinitions = async (
           provider_guid: providerId
         },
         headers: {
-          'Client-Id': getClientId().lambda,
-          'Echo-Token': await getEchoToken(jwtToken, earthdataEnvironment)
+          Authorization: `Bearer ${accessToken}`,
+          'Client-Id': getClientId().lambda
         },
         json: true,
         resolveWithFullResponse: true

--- a/serverless/src/getDataQualitySummaries/handler.js
+++ b/serverless/src/getDataQualitySummaries/handler.js
@@ -40,7 +40,7 @@ const getDataQualitySummaries = async (event) => {
         catalog_item_id: catalogItemId
       },
       headers: {
-        'Echo-Token': echoToken,
+        Authorization: `Bearer ${echoToken}`,
         'Client-Id': getClientId().background,
         'CMR-Request-Id': requestId
       },
@@ -74,7 +74,7 @@ const getDataQualitySummaries = async (event) => {
         dqsResponse = await request.get({
           uri: `${echoRestRoot}/data_quality_summary_definitions/${dqsId}.json`,
           headers: {
-            'Echo-Token': echoToken,
+            Authorization: `Bearer ${echoToken}`,
             'Client-Id': getClientId().background,
             'CMR-Request-Id': dataQualitySummaryRequestId
           },

--- a/serverless/src/getProviders/handler.js
+++ b/serverless/src/getProviders/handler.js
@@ -29,8 +29,8 @@ const getProviders = async (event) => {
       uri: url,
       resolveWithFullResponse: true,
       headers: {
-        'Client-Id': getClientId().lambda,
-        'Echo-Token': accessToken
+        Authorization: `Bearer ${accessToken}`,
+        'Client-Id': getClientId().lambda
       },
       json: true
     })

--- a/serverless/src/graphQl/handler.js
+++ b/serverless/src/graphQl/handler.js
@@ -44,8 +44,8 @@ const graphQl = async (event, context) => {
         variables
       },
       headers: {
-        'X-Request-Id': requestId,
-        'Echo-Token': echoToken
+        Authorization: `Bearer ${echoToken}`,
+        'X-Request-Id': requestId
       }
     })
 

--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -1,5 +1,7 @@
 import nock from 'nock'
+
 import * as getEarthdataConfig from '../../../../sharedUtils/config'
+
 import { addTag } from '../addTag'
 
 beforeEach(() => {

--- a/serverless/src/processTag/__tests__/removeTag.test.js
+++ b/serverless/src/processTag/__tests__/removeTag.test.js
@@ -24,8 +24,8 @@ describe('removeTag', () => {
     expect(cmrDeleteMock).toBeCalledWith({
       uri: 'http://example.com/search/tags/edsc.extra.gibs/associations/by_query',
       headers: {
-        'Client-Id': 'eed-edsc-test-serverless-background',
-        'Echo-Token': '1234-abcd-5678-efgh'
+        Authorization: 'Bearer 1234-abcd-5678-efgh',
+        'Client-Id': 'eed-edsc-test-serverless-background'
       },
       body: { short_name: 'MIL3MLS' },
       json: true,
@@ -55,8 +55,8 @@ describe('removeTag', () => {
     expect(cmrDeleteMock).toBeCalledWith({
       uri: 'http://example.com/search/tags/edsc.extra.gibs/associations/by_query',
       headers: {
-        'Client-Id': 'eed-edsc-test-serverless-background',
-        'Echo-Token': '1234-abcd-5678-efgh'
+        Authorization: 'Bearer 1234-abcd-5678-efgh',
+        'Client-Id': 'eed-edsc-test-serverless-background'
       },
       body: { short_name: 'MIL3MLS' },
       json: true,

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -42,8 +42,8 @@ export async function addTag({
       const collectionJsonResponse = await request.post({
         uri: `${getEarthdataConfig(deployedEnvironment()).cmrHost}/search/collections.json?${stringify(cmrParams)}`,
         headers: {
-          'Client-Id': getClientId().background,
-          'Echo-Token': cmrToken
+          Authorization: `Bearer ${cmrToken}`,
+          'Client-Id': getClientId().background
         },
         body: searchCriteria,
         json: true,
@@ -101,8 +101,8 @@ export async function addTag({
       const taggingResponse = await request.post({
         uri: addTagUrl,
         headers: {
-          'Client-Id': getClientId().background,
-          'Echo-Token': cmrToken
+          Authorization: `Bearer ${cmrToken}`,
+          'Client-Id': getClientId().background
         },
         body: castArray(associationData),
         json: true,
@@ -132,8 +132,8 @@ export async function addTag({
     await request.post({
       uri: tagRemovalUrl,
       headers: {
-        'Client-Id': getClientId().background,
-        'Echo-Token': cmrToken
+        Authorization: `Bearer ${cmrToken}`,
+        'Client-Id': getClientId().background
       },
       body: searchCriteria,
       json: true,

--- a/serverless/src/processTag/removeTag.js
+++ b/serverless/src/processTag/removeTag.js
@@ -16,8 +16,8 @@ export async function removeTag(tagName, searchCriteria, cmrToken) {
     await request.delete({
       uri: tagRemovalUrl,
       headers: {
-        'Client-Id': getClientId().background,
-        'Echo-Token': cmrToken
+        Authorization: `Bearer ${cmrToken}`,
+        'Client-Id': getClientId().background
       },
       body: searchCriteria,
       json: true,

--- a/serverless/src/saveContactInfo/handler.js
+++ b/serverless/src/saveContactInfo/handler.js
@@ -58,8 +58,8 @@ const saveContactInfo = async (event) => {
     const response = await request.put({
       uri: url,
       headers: {
-        'Client-Id': getClientId().lambda,
-        'Echo-Token': echoToken
+        Authorization: `Bearer ${echoToken}`,
+        'Client-Id': getClientId().lambda
       },
       body: params,
       json: true,

--- a/serverless/src/storeUserData/__tests__/getEchoPreferencesData.test.js
+++ b/serverless/src/storeUserData/__tests__/getEchoPreferencesData.test.js
@@ -31,7 +31,7 @@ describe('getEchoPreferencesData', () => {
     expect(ursGetMock).toBeCalledWith({
       uri: 'http://echorest.example.com/users/test_user/preferences.json',
       headers: {
-        'Echo-Token': 'fake.access.token:clientId',
+        Authorization: 'Bearer fake.access.token',
         'Client-Id': 'eed-edsc-test-serverless-lambda'
       },
       json: true,

--- a/serverless/src/storeUserData/__tests__/getEchoProfileData.test.js
+++ b/serverless/src/storeUserData/__tests__/getEchoProfileData.test.js
@@ -30,7 +30,7 @@ describe('getEchoProfileData', () => {
     expect(ursGetMock).toBeCalledWith({
       uri: 'http://echorest.example.com/users/current.json',
       headers: {
-        'Echo-Token': 'fake.access.token:clientId',
+        Authorization: 'Bearer fake.access.token',
         'Client-Id': 'eed-edsc-test-serverless-lambda'
       },
       json: true,

--- a/serverless/src/storeUserData/getEchoPreferencesData.js
+++ b/serverless/src/storeUserData/getEchoPreferencesData.js
@@ -1,6 +1,6 @@
 import request from 'request-promise'
+
 import { getEarthdataConfig } from '../../../sharedUtils/config'
-import { getEdlConfig } from '../util/getEdlConfig'
 import { getClientId } from '../../../sharedUtils/getClientId'
 
 /**
@@ -9,11 +9,6 @@ import { getClientId } from '../../../sharedUtils/getClientId'
  * @param {String} token A valid URS access token
  */
 export const getEchoPreferencesData = async (username, token, environment) => {
-  // The client id is part of our Earthdata Login credentials
-  const edlConfig = await getEdlConfig(environment)
-  const { client } = edlConfig
-  const { id: clientId } = client
-
   const { echoRestRoot } = getEarthdataConfig(environment)
 
   const echoRestPreferencesUrl = `${echoRestRoot}/users/${username}/preferences.json`
@@ -21,8 +16,8 @@ export const getEchoPreferencesData = async (username, token, environment) => {
   const echoRestPreferencesResponse = await request.get({
     uri: echoRestPreferencesUrl,
     headers: {
-      'Client-Id': getClientId().lambda,
-      'Echo-Token': `${token}:${clientId}`
+      Authorization: `Bearer ${token}`,
+      'Client-Id': getClientId().lambda
     },
     json: true,
     resolveWithFullResponse: true

--- a/serverless/src/storeUserData/getEchoProfileData.js
+++ b/serverless/src/storeUserData/getEchoProfileData.js
@@ -1,18 +1,13 @@
 import request from 'request-promise'
+
 import { getEarthdataConfig } from '../../../sharedUtils/config'
-import { getEdlConfig } from '../util/getEdlConfig'
 import { getClientId } from '../../../sharedUtils/getClientId'
 
 /**
  * Retrieve ECHO profile data for the provided username
- * @param {String} token A valid URS access token
+ * @param {String} accessToken A valid URS access accessToken
  */
-export const getEchoProfileData = async (token, environment) => {
-  // The client id is part of our Earthdata Login credentials
-  const edlConfig = await getEdlConfig(environment)
-  const { client } = edlConfig
-  const { id: clientId } = client
-
+export const getEchoProfileData = async (accessToken, environment) => {
   const { echoRestRoot } = getEarthdataConfig(environment)
 
   const echoRestProfileUrl = `${echoRestRoot}/users/current.json`
@@ -20,8 +15,8 @@ export const getEchoProfileData = async (token, environment) => {
   const echoRestProfileResponse = await request.get({
     uri: echoRestProfileUrl,
     headers: {
-      'Client-Id': getClientId().lambda,
-      'Echo-Token': `${token}:${clientId}`
+      Authorization: `Bearer ${accessToken}`,
+      'Client-Id': getClientId().lambda
     },
     json: true,
     resolveWithFullResponse: true

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -119,7 +119,7 @@ describe('submitCatalogRestOrder', () => {
     expect(queries[0].method).toEqual('first')
     expect(queries[1].method).toEqual('first')
     expect(queries[2].method).toEqual('update')
-    expect(startOrderStatusUpdateWorkflowMock).toBeCalledWith(12, 'access-token:clientId', 'ESI')
+    expect(startOrderStatusUpdateWorkflowMock).toBeCalledWith(12, 'access-token', 'ESI')
   })
 
   test('prepares granule access params', async () => {

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -32,12 +32,12 @@ describe('constructOrderPayload', () => {
           selectedOutputFormat: 'image/png'
         }
         const granuleParams = {}
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.get('format')).toEqual('image/png')
@@ -60,12 +60,12 @@ describe('constructOrderPayload', () => {
 
         const accessMethod = {}
         const granuleParams = {}
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.get('format')).toEqual(null)
@@ -92,12 +92,12 @@ describe('constructOrderPayload', () => {
           selectedOutputProjection: 'EPSG:4326'
         }
         const granuleParams = {}
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.get('outputCrs')).toEqual('EPSG:4326')
@@ -121,12 +121,12 @@ describe('constructOrderPayload', () => {
 
       const accessMethod = {}
       const granuleParams = {}
-      const accessTokenWithClient = ''
+      const accessToken = ''
 
       const response = await constructOrderPayload({
         accessMethod,
         granuleParams,
-        accessTokenWithClient
+        accessToken
       })
 
       expect(response.get('granuleId')).toEqual('G10000001-EDSC,G10000005-EDSC')
@@ -152,12 +152,12 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: '2020-01-01T01:36:52.273Z,2020-01-01T06:18:19.482Z'
         }
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.getAll('subset')).toEqual(['time("2020-01-01T01:36:52.273Z":"2020-01-01T06:18:19.482Z")'])
@@ -182,12 +182,12 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: '2020-01-01T01:36:52.273Z,'
         }
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.getAll('subset')).toEqual(['time("2020-01-01T01:36:52.273Z":"*")'])
@@ -212,12 +212,12 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: ',2020-01-01T06:18:19.482Z'
         }
-        const accessTokenWithClient = ''
+        const accessToken = ''
 
         const response = await constructOrderPayload({
           accessMethod,
           granuleParams,
-          accessTokenWithClient
+          accessToken
         })
 
         expect(response.getAll('subset')).toEqual(['time("*":"2020-01-01T06:18:19.482Z")'])
@@ -245,13 +245,13 @@ describe('constructOrderPayload', () => {
             supportsShapefileSubsetting: true
           }
           const granuleParams = {}
-          const accessTokenWithClient = ''
+          const accessToken = ''
           const shapefile = mockCcwShapefile
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient,
+            accessToken,
             shapefile
           })
 
@@ -279,12 +279,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             point: ['-77, 34']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -311,12 +311,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             bounding_box: ['0,5,10,15']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -343,12 +343,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             circle: ['-77, 34, 20000']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -375,12 +375,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             polygon: ['-29.8125,39.86484,-23.0625,-19.74405,15.75,20.745,-29.8125,39.86484']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -415,12 +415,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             point: ['-77, 34']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -450,12 +450,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             bounding_box: ['5,0,15,10']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -491,12 +491,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             circle: ['-77, 34, 20000']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -532,12 +532,12 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             polygon: ['-29.8125,39.86484,-23.0625,-19.74405,15.75,20.745,-29.8125,39.86484']
           }
-          const accessTokenWithClient = ''
+          const accessToken = ''
 
           const response = await constructOrderPayload({
             accessMethod,
             granuleParams,
-            accessTokenWithClient
+            accessToken
           })
 
           expect(response.getAll('subset')).toEqual([

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -18,7 +18,7 @@ import { readCmrResults } from '../util/cmr/readCmrResults'
 export const constructOrderPayload = async ({
   accessMethod,
   granuleParams,
-  accessTokenWithClient,
+  accessToken,
   shapefile,
   environment
 }) => {
@@ -31,7 +31,7 @@ export const constructOrderPayload = async ({
       arrayFormat: 'brackets'
     },
     headers: {
-      'Echo-Token': accessTokenWithClient,
+      Authorization: accessToken,
       'Client-Id': getClientId().background
     },
     json: true,

--- a/serverless/src/submitHarmonyOrder/handler.js
+++ b/serverless/src/submitHarmonyOrder/handler.js
@@ -4,7 +4,6 @@ import axios from 'axios'
 import { constructOrderPayload } from './constructOrderPayload'
 import { constructOrderUrl } from './constructOrderUrl'
 import { getDbConnection } from '../util/database/getDbConnection'
-import { getEdlConfig } from '../util/getEdlConfig'
 import { parseError } from '../../../sharedUtils/parseError'
 import { processPartialShapefile } from '../util/processPartialShapefile'
 import { startOrderStatusUpdateWorkflow } from '../util/startOrderStatusUpdateWorkflow'
@@ -63,12 +62,6 @@ const submitHarmonyOrder = async (event, context) => {
       user_id: userId
     } = retrievalRecord
 
-    const edlConfig = await getEdlConfig(environment)
-    const { client } = edlConfig
-    const { id: clientId } = client
-
-    const accessTokenWithClient = `${accessToken}:${clientId}`
-
     const {
       type
     } = accessMethod
@@ -97,7 +90,7 @@ const submitHarmonyOrder = async (event, context) => {
       const orderPayload = await constructOrderPayload({
         accessMethod,
         granuleParams,
-        accessTokenWithClient,
+        accessToken,
         shapefile,
         environment
       })

--- a/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
@@ -54,13 +54,13 @@ describe('constructOrderPayload', () => {
       collection_concept_id: 'C100000-EDSC'
     }
 
-    const accessTokenWithClient = 'accessToken:clientId'
+    const accessToken = 'accessToken'
     const earthdataEnvironment = 'prod'
 
     const response = await constructOrderPayload(
       accessMethod,
       granuleParams,
-      accessTokenWithClient,
+      accessToken,
       earthdataEnvironment
     )
 

--- a/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
@@ -173,7 +173,7 @@ describe('submitLegacyServicesOrder', () => {
 
     expect(queries[0].method).toEqual('first')
     expect(queries[1].method).toEqual('update')
-    expect(startOrderStatusUpdateWorkflowMock).toBeCalledWith(12, 'access-token:clientId', 'ECHO ORDERS')
+    expect(startOrderStatusUpdateWorkflowMock).toBeCalledWith(12, 'access-token', 'ECHO ORDERS')
   })
 
   test('saves an error message if the create fails', async () => {

--- a/serverless/src/submitLegacyServicesOrder/constructOrderPayload.js
+++ b/serverless/src/submitLegacyServicesOrder/constructOrderPayload.js
@@ -10,7 +10,7 @@ import { readCmrResults } from '../util/cmr/readCmrResults'
 export const constructOrderPayload = async (
   accessMethod,
   granuleParams,
-  accessTokenWithClient,
+  accessToken,
   earthdataEnvironment
 ) => {
   const {
@@ -37,7 +37,7 @@ export const constructOrderPayload = async (
       arrayFormat: 'brackets'
     },
     headers: {
-      'Echo-Token': accessTokenWithClient,
+      Authorization: `Bearer ${accessToken}`,
       'Client-Id': getClientId().background
     },
     json: true,
@@ -63,7 +63,7 @@ export const constructOrderPayload = async (
     }),
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Echo-Token': accessTokenWithClient,
+      Authorization: `Bearer ${accessToken}`,
       'Client-Id': getClientId().background
     },
     json: true,

--- a/serverless/src/util/cmr/doSearchRequest.js
+++ b/serverless/src/util/cmr/doSearchRequest.js
@@ -38,7 +38,9 @@ export const doSearchRequest = async ({
 
     if (jwtToken) {
       // Support endpoints that have optional authentication
-      requestHeaders['Echo-Token'] = await getEchoToken(jwtToken, earthdataEnvironment)
+      const token = await getEchoToken(jwtToken, earthdataEnvironment)
+
+      requestHeaders.Authorization = `Bearer ${token}`
     }
 
     if (requestId) {

--- a/serverless/src/util/cmr/getSingleGranule.js
+++ b/serverless/src/util/cmr/getSingleGranule.js
@@ -29,9 +29,9 @@ export const getSingleGranule = async (cmrToken, collectionId) => {
     uri: granuleSearchUrl,
     form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
     headers: {
+      Authorization: `Bearer ${cmrToken}`,
       'Client-Id': getClientId().background,
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Echo-Token': cmrToken
+      'Content-Type': 'application/x-www-form-urlencoded'
     },
     json: true,
     resolveWithFullResponse: true,

--- a/serverless/src/util/cmr/pageAllCmrResults.js
+++ b/serverless/src/util/cmr/pageAllCmrResults.js
@@ -36,9 +36,9 @@ export const pageAllCmrResults = async ({
       uri: `${cmrHost}/${path}`,
       form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
       headers: {
+        Authorization: `Bearer ${cmrToken}`,
         'Client-Id': getClientId().background,
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Echo-Token': cmrToken,
         ...additionalHeaders
       },
       json: true,
@@ -67,9 +67,9 @@ export const pageAllCmrResults = async ({
           uri: `${cmrHost}/${path}`,
           form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
           headers: {
+            Authorization: `Bearer ${cmrToken}`,
             'Client-Id': getClientId().background,
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Echo-Token': cmrToken,
             ...additionalHeaders
           },
           json: true,

--- a/serverless/src/util/urs/__tests__/getEchoToken.test.js
+++ b/serverless/src/util/urs/__tests__/getEchoToken.test.js
@@ -19,6 +19,6 @@ describe('getEchoToken', () => {
   test('returns an echo token with environment specific client id', async () => {
     const response = await getEchoToken()
 
-    expect(response).toEqual('access_token:clientId')
+    expect(response).toEqual('access_token')
   })
 })

--- a/serverless/src/util/urs/getEchoToken.js
+++ b/serverless/src/util/urs/getEchoToken.js
@@ -1,8 +1,7 @@
 import { getAccessTokenFromJwtToken } from './getAccessTokenFromJwtToken'
-import { getEdlConfig } from '../getEdlConfig'
 
 /**
- * Returns the Echo-Token header for requests to CMR
+ * Returns and EDL access token
  * @param {String} jwtToken
  */
 export const getEchoToken = async (jwtToken, earthdataEnvironment) => {
@@ -10,9 +9,5 @@ export const getEchoToken = async (jwtToken, earthdataEnvironment) => {
     access_token: accessToken
   } = await getAccessTokenFromJwtToken(jwtToken, earthdataEnvironment)
 
-  const edlConfig = await getEdlConfig(earthdataEnvironment)
-  const { client } = edlConfig
-  const { id: clientId } = client
-
-  return `${accessToken}:${clientId}`
+  return accessToken
 }

--- a/static/src/js/util/request/__tests__/cmrRequest.test.js
+++ b/static/src/js/util/request/__tests__/cmrRequest.test.js
@@ -73,7 +73,7 @@ describe('CmrRequest#transformRequest', () => {
     request.transformRequest(data, headers)
 
     expect(headers).toEqual(expect.objectContaining({
-      Authorization: 'Bearer: 123'
+      Authorization: 'Bearer 123'
     }))
   })
 

--- a/static/src/js/util/request/__tests__/preferencesRequest.test.js
+++ b/static/src/js/util/request/__tests__/preferencesRequest.test.js
@@ -46,7 +46,7 @@ describe('PreferencesRequest#transformRequest', () => {
     const result = request.transformRequest(data, headers)
 
     expect(headers).toEqual(expect.objectContaining({
-      Authorization: 'Bearer: 123'
+      Authorization: 'Bearer 123'
     }))
 
     const parsedData = JSON.parse(result)

--- a/static/src/js/util/request/__tests__/request.test.js
+++ b/static/src/js/util/request/__tests__/request.test.js
@@ -55,7 +55,7 @@ describe('Request#transformRequest', () => {
     request.transformRequest(data, headers)
 
     expect(headers).toEqual(expect.objectContaining({
-      Authorization: 'Bearer: 123'
+      Authorization: 'Bearer 123'
     }))
   })
 })

--- a/static/src/js/util/request/graphQlRequest.js
+++ b/static/src/js/util/request/graphQlRequest.js
@@ -38,7 +38,7 @@ export default class GraphQlRequest extends Request {
 
     if (this.authenticated || this.optionallyAuthenticated) {
       // eslint-disable-next-line no-param-reassign
-      headers.Authorization = `Bearer: ${this.getAuthToken()}`
+      headers.Authorization = `Bearer ${this.getAuthToken()}`
     }
 
     if (data) {

--- a/static/src/js/util/request/request.js
+++ b/static/src/js/util/request/request.js
@@ -82,7 +82,7 @@ export default class Request {
 
     if (this.authenticated || this.optionallyAuthenticated) {
       // eslint-disable-next-line no-param-reassign
-      headers.Authorization = `Bearer: ${this.getAuthToken()}`
+      headers.Authorization = `Bearer ${this.getAuthToken()}`
     }
 
     if (data) {
@@ -171,7 +171,7 @@ export default class Request {
       requestOptions = {
         ...requestOptions,
         headers: {
-          Authorization: `Bearer: ${this.getAuthToken()}`
+          Authorization: `Bearer ${this.getAuthToken()}`
         }
       }
     }
@@ -215,7 +215,7 @@ export default class Request {
       requestOptions = {
         ...requestOptions,
         headers: {
-          Authorization: `Bearer: ${this.getAuthToken()}`
+          Authorization: `Bearer ${this.getAuthToken()}`
         }
       }
     }


### PR DESCRIPTION
# Overview

### What is the feature?

Replaces calls to CMR using `Echo-Token` header to using `Authorization` header.

### What is the Solution?

All `Echo-Token` headers have been replaced and all (except when its used in a query param) uses of tokens have stopped using the URS Client Id.

### What areas of the application does this impact?

All HTTP calls to CMR and Legacy Services.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
