### PR TITLE
EDSC-2938: Fix addTag with correct CMR response

### DIFF
--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -15,12 +15,14 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {}
-          }
-        }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {}
+            }
+          }]
+        }
       })
 
     nock(/example/)
@@ -52,9 +54,11 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC'
-        }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC'
+          }]
+        }
       })
 
     nock(/example/)
@@ -86,16 +90,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)
@@ -127,16 +133,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)
@@ -170,16 +178,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)
@@ -211,16 +221,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)
@@ -254,12 +266,14 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       }))
       .reply(200, {
-        entry: [{
-          id: 'C1234-EDSC',
-          tags: {
-            'edsc.extra.gibs': {}
-          }
-        }]
+        feed: {
+          entry: [{
+            id: 'C1234-EDSC',
+            tags: {
+              'edsc.extra.gibs': {}
+            }
+          }]
+        }
       })
 
     await addTag({
@@ -278,16 +292,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)
@@ -335,16 +351,18 @@ describe('addTag', () => {
         short_name: 'MIL3MLS'
       })
       .reply(200, {
-        entry: [{
-          id: 'C123456789-EDSC',
-          tags: {
-            'edsc.extra.gibs': {
-              data: [{
-                product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
-              }]
+        feed: {
+          entry: [{
+            id: 'C123456789-EDSC',
+            tags: {
+              'edsc.extra.gibs': {
+                data: [{
+                  product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6'
+                }]
+              }
             }
-          }
-        }]
+          }]
+        }
       })
 
     nock(/example/)

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -50,8 +50,9 @@ export async function addTag({
         resolveWithFullResponse: true
       })
 
-      const { body } = collectionJsonResponse
-      const { entry } = body
+      const { body = {} } = collectionJsonResponse
+      const { feed = {} } = body
+      const { entry = [] } = feed
       collections = entry
     } catch (e) {
       parseError(e, { reThrowError: true })


### PR DESCRIPTION
# Overview

### What is the feature?

The addTag lambda was not reading the correct CMR response for collection searches.

### What is the Solution?

Added the correct response (`body.feed.entry`)

### What areas of the application does this impact?

Tagging

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
