### PR TITLE
EDSC-2970: Don't set default values for output format or projection

### DIFF
--- a/serverless/src/getAccessMethods/__tests__/handler.test.js
+++ b/serverless/src/getAccessMethods/__tests__/handler.test.js
@@ -99,16 +99,13 @@ describe('getAccessMethods', () => {
               conceptId: 'umm-s-record-1',
               type: 'Harmony',
               serviceOptions: {},
-              supportedReformattings: [
-                {
-                  supportedInputFormat: 'NETCDF-4',
-                  supportedOutputFormats: [
-                    'GEOTIFF',
-                    'PNG',
-                    'GIF'
-                  ]
-                }
-              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: ['GEOTIFF', 'PNG', 'GIF']
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: ['GEOTIFF', 'PNG', 'GIF']
+              }],
               supportedOutputProjections: [{
                 projectionAuthority: 'EPSG:4326'
               }],

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -1,5 +1,7 @@
 import parser from 'fast-xml-parser'
 
+import { uniq } from 'lodash'
+
 import { determineEarthdataEnvironment } from '../util/determineEarthdataEnvironment'
 import { generateFormDigest } from '../util/generateFormDigest'
 import { getApplicationConfig } from '../../../sharedUtils/config'
@@ -191,7 +193,7 @@ const getAccessMethods = async (event, context) => {
         keywordMappings,
         longName,
         name,
-        supportedOutputFormats: outputFormats,
+        supportedOutputFormats: uniq(outputFormats),
         supportsVariableSubsetting: supportsVariableSubsetting(fullServiceObject),
         type,
         variables
@@ -249,7 +251,7 @@ const getAccessMethods = async (event, context) => {
           keywordMappings,
           longName,
           name,
-          supportedOutputFormats: outputFormats,
+          supportedOutputFormats: uniq(outputFormats),
           supportedOutputProjections: outputProjections,
           supportsBoundingBoxSubsetting: supportsBoundingBoxSubsetting(serviceObject),
           supportsShapefileSubsetting: supportsShapefileSubsetting(serviceObject),

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -42,14 +42,12 @@ export class AccessMethod extends Component {
     const selectedMethod = accessMethods[selectedAccessMethod]
     const {
       selectedOutputFormat = '',
-      selectedOutputProjection = '',
-      supportedOutputFormats = [],
-      supportedOutputProjections = []
+      selectedOutputProjection = ''
     } = selectedMethod || {}
 
     this.state = {
-      selectedOutputFormat: selectedOutputFormat || supportedOutputFormats[0],
-      selectedOutputProjection: selectedOutputProjection || supportedOutputProjections[0]
+      selectedOutputFormat,
+      selectedOutputProjection
     }
 
     this.handleAccessMethodSelection = this.handleAccessMethodSelection.bind(this)

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -57,65 +57,6 @@ export class AccessMethod extends Component {
     this.handleOutputProjectionSelection = this.handleOutputProjectionSelection.bind(this)
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { selectedOutputFormat, selectedOutputProjection } = this.state
-    const {
-      accessMethods,
-      selectedAccessMethod
-    } = nextProps
-
-    if (
-      selectedAccessMethod
-      && (selectedAccessMethod === 'opendap'
-      || selectedAccessMethod.includes('harmony'))
-    ) {
-      const selectedMethod = accessMethods[selectedAccessMethod]
-      const {
-        selectedOutputFormat: nextSelectedOutputFormat,
-        selectedOutputProjection: nextSelectedOutputProjection,
-        supportedOutputFormats = [],
-        supportedOutputProjections = []
-      } = selectedMethod || {}
-
-      // If there is no selected option, select the first option
-      if (nextSelectedOutputFormat !== selectedOutputFormat) {
-        if (!nextSelectedOutputFormat) {
-          let defaultSelectedOutputFormat
-
-          if (selectedAccessMethod === 'opendap') {
-            // Pull out the ext value from formatMappings
-            const ousSupportedFormats = supportedOutputFormats.filter(
-              format => ousFormatMapping[format] !== undefined
-            )
-
-            defaultSelectedOutputFormat = ousFormatMapping[ousSupportedFormats[0]]
-          } else if (selectedAccessMethod.includes('harmony')) {
-            // Pull out the ext value from formatMappings
-            const harmonySupportedFormats = supportedOutputFormats.filter(
-              format => harmonyFormatMapping[format] !== undefined
-            )
-
-            defaultSelectedOutputFormat = harmonyFormatMapping[harmonySupportedFormats[0]]
-          }
-
-          this.setState({ selectedOutputFormat: defaultSelectedOutputFormat })
-        } else {
-          this.setState({ selectedOutputFormat: nextSelectedOutputFormat })
-        }
-      }
-
-      // If there is no selected option, select the first option
-      if (nextSelectedOutputProjection !== selectedOutputProjection) {
-        if (!nextSelectedOutputProjection) {
-          const defaultSelectedOutputProjection = supportedOutputProjections[0]
-          this.setState({ selectedOutputProjection: defaultSelectedOutputProjection })
-        } else {
-          this.setState({ selectedOutputProjection: nextSelectedOutputProjection })
-        }
-      }
-    }
-  }
-
   handleAccessMethodSelection(method) {
     const { metadata, onSelectAccessMethod } = this.props
 


### PR DESCRIPTION
# Overview

### What is the feature?

Prevents calling `componentWillReceiveProps` for access methods because it isn't needed now that we offer a `None` option and we don't set a 'default'.

### What is the Solution?

Removed the `componentWillReceiveProps` method.

### What areas of the application does this impact?

Changing supported output format and supported output projection.

# Testing

### Reproduction steps

See EDSC-2970 comments.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
