### PR TITLE
EDSC-2938: Removes matrix tile sets from tags

### DIFF
--- a/serverless/src/generateCollectionCapabilityTags/__tests__/getCollectionCapabilities.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/getCollectionCapabilities.test.js
@@ -1,8 +1,21 @@
 import nock from 'nock'
+import MockDate from 'mockdate'
 
 import * as getSingleGranule from '../../util/cmr/getSingleGranule'
 
 import { getCollectionCapabilities } from '../getCollectionCapabilities'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  // MockDate is used here to overwrite the js Date object. This allows us to
+  // mock changes needed to test the moment functions
+  MockDate.set('09/03/1988 10:00:00')
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
 
 describe('getCollectionCapabilities', () => {
   describe('cloud_cover', () => {
@@ -188,14 +201,14 @@ describe('getCollectionCapabilities', () => {
         ]
       })
 
-
     const response = await getCollectionCapabilities('token', { id: 'C100000-EDSC' })
 
     expect(response).toEqual({
       cloud_cover: false,
       day_night_flag: false,
       granule_online_access_flag: false,
-      orbit_calculated_spatial_domains: false
+      orbit_calculated_spatial_domains: false,
+      updated_at: '1988-09-03T14:00:00.000Z'
     })
   })
 })

--- a/serverless/src/generateCollectionCapabilityTags/__tests__/getCollectionCapabilities.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/getCollectionCapabilities.test.js
@@ -10,7 +10,7 @@ beforeEach(() => {
 
   // MockDate is used here to overwrite the js Date object. This allows us to
   // mock changes needed to test the moment functions
-  MockDate.set('09/03/1988 10:00:00')
+  MockDate.set('1988-09-03T10:00:00.000Z')
 })
 
 afterEach(() => {
@@ -208,7 +208,7 @@ describe('getCollectionCapabilities', () => {
       day_night_flag: false,
       granule_online_access_flag: false,
       orbit_calculated_spatial_domains: false,
-      updated_at: '1988-09-03T14:00:00.000Z'
+      updated_at: '1988-09-03T10:00:00.000Z'
     })
   })
 })

--- a/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
@@ -1,7 +1,8 @@
 import AWS from 'aws-sdk'
 import nock from 'nock'
-import * as getSystemToken from '../../util/urs/getSystemToken'
+import MockDate from 'mockdate'
 
+import * as getSystemToken from '../../util/urs/getSystemToken'
 import * as getSingleGranule from '../../util/cmr/getSingleGranule'
 
 import generateCollectionCapabilityTags from '../handler'
@@ -26,11 +27,17 @@ beforeEach(() => {
   jest.resetModules()
   process.env = { ...OLD_ENV }
   delete process.env.NODE_ENV
+
+  // MockDate is used here to overwrite the js Date object. This allows us to
+  // mock changes needed to test the moment functions
+  MockDate.set('09/03/1988 10:00:00')
 })
 
 afterEach(() => {
   // Restore any ENV variables overwritten in tests
   process.env = OLD_ENV
+
+  MockDate.reset()
 })
 
 describe('generateCollectionCapabilityTags', () => {
@@ -70,7 +77,8 @@ describe('generateCollectionCapabilityTags', () => {
               cloud_cover: false,
               day_night_flag: false,
               granule_online_access_flag: false,
-              orbit_calculated_spatial_domains: false
+              orbit_calculated_spatial_domains: false,
+              updated_at: '1988-09-03T14:00:00.000Z'
             }
           }]
         }),
@@ -120,7 +128,8 @@ describe('generateCollectionCapabilityTags', () => {
               cloud_cover: false,
               day_night_flag: false,
               granule_online_access_flag: false,
-              orbit_calculated_spatial_domains: false
+              orbit_calculated_spatial_domains: false,
+              updated_at: '1988-09-03T14:00:00.000Z'
             }
           }]
         }),

--- a/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
@@ -30,7 +30,7 @@ beforeEach(() => {
 
   // MockDate is used here to overwrite the js Date object. This allows us to
   // mock changes needed to test the moment functions
-  MockDate.set('09/03/1988 10:00:00')
+  MockDate.set('1988-09-03T10:00:00.000Z')
 })
 
 afterEach(() => {
@@ -78,7 +78,7 @@ describe('generateCollectionCapabilityTags', () => {
               day_night_flag: false,
               granule_online_access_flag: false,
               orbit_calculated_spatial_domains: false,
-              updated_at: '1988-09-03T14:00:00.000Z'
+              updated_at: '1988-09-03T10:00:00.000Z'
             }
           }]
         }),
@@ -129,7 +129,7 @@ describe('generateCollectionCapabilityTags', () => {
               day_night_flag: false,
               granule_online_access_flag: false,
               orbit_calculated_spatial_domains: false,
-              updated_at: '1988-09-03T14:00:00.000Z'
+              updated_at: '1988-09-03T10:00:00.000Z'
             }
           }]
         }),

--- a/serverless/src/generateCollectionCapabilityTags/getCollectionCapabilities.js
+++ b/serverless/src/generateCollectionCapabilityTags/getCollectionCapabilities.js
@@ -25,7 +25,8 @@ export const getCollectionCapabilities = async (cmrToken, collection) => {
       cloud_cover: !!cloudCover,
       day_night_flag: !!dayNightFlag && ['DAY', 'NIGHT', 'BOTH'].includes(dayNightFlag.toUpperCase()),
       granule_online_access_flag: onlineAccessFlag,
-      orbit_calculated_spatial_domains: Object.keys(orbitCalculatedSpatialDomains).length > 0
+      orbit_calculated_spatial_domains: Object.keys(orbitCalculatedSpatialDomains).length > 0,
+      updated_at: new Date().toISOString()
     }
   } catch (e) {
     parseError(e)
@@ -35,7 +36,8 @@ export const getCollectionCapabilities = async (cmrToken, collection) => {
       cloud_cover: false,
       day_night_flag: false,
       granule_online_access_flag: false,
-      orbit_calculated_spatial_domains: false
+      orbit_calculated_spatial_domains: false,
+      updated_at: new Date().toISOString()
     }
   }
 }

--- a/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
+++ b/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
@@ -8,7 +8,7 @@ beforeEach(() => {
 
   // MockDate is used here to overwrite the js Date object. This allows us to
   // mock changes needed to test the moment functions
-  MockDate.set('09/03/1988 10:00:00')
+  MockDate.set('1988-09-03T10:00:00.000Z')
 })
 
 afterEach(() => {
@@ -51,7 +51,7 @@ describe('constructLayerTagData', () => {
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
           title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-          updated_at: '1988-09-03T14:00:00.000Z'
+          updated_at: '1988-09-03T10:00:00.000Z'
         }
       }
     ])
@@ -93,7 +93,7 @@ describe('constructLayerTagData', () => {
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
           title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-          updated_at: '1988-09-03T14:00:00.000Z'
+          updated_at: '1988-09-03T10:00:00.000Z'
         }
       }
     ])
@@ -137,7 +137,7 @@ describe('constructLayerTagData', () => {
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
           title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-          updated_at: '1988-09-03T14:00:00.000Z'
+          updated_at: '1988-09-03T10:00:00.000Z'
         }
       }
     ])
@@ -187,7 +187,7 @@ describe('constructLayerTagData', () => {
         product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
         source: 'Aqua / MODIS',
         title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-        updated_at: '1988-09-03T14:00:00.000Z'
+        updated_at: '1988-09-03T10:00:00.000Z'
       }
     }
 

--- a/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
+++ b/serverless/src/generateGibsTags/__tests__/constructLayerTagData.test.js
@@ -1,8 +1,18 @@
-import { gibsResponse, matrixLimits } from './mocks'
+import MockDate from 'mockdate'
+
+import { gibsResponse } from './mocks'
 import { constructLayerTagData } from '../constructLayerTagData'
 
 beforeEach(() => {
   jest.clearAllMocks()
+
+  // MockDate is used here to overwrite the js Date object. This allows us to
+  // mock changes needed to test the moment functions
+  MockDate.set('09/03/1988 10:00:00')
+})
+
+afterEach(() => {
+  MockDate.reset()
 })
 
 describe('constructLayerTagData', () => {
@@ -15,7 +25,6 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
-    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -29,14 +38,11 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
-          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
-          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
-          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT',
@@ -44,7 +50,8 @@ describe('constructLayerTagData', () => {
           },
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
-          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)'
+          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+          updated_at: '1988-09-03T14:00:00.000Z'
         }
       }
     ])
@@ -61,7 +68,6 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
-    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -75,21 +81,19 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
-          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
-          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
-          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT'
           },
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
-          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)'
+          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+          updated_at: '1988-09-03T14:00:00.000Z'
         }
       }
     ])
@@ -106,7 +110,6 @@ describe('constructLayerTagData', () => {
     const { [product]: productObject } = products
 
     testingLayer.product = productObject
-    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -120,14 +123,11 @@ describe('constructLayerTagData', () => {
         data: {
           antarctic: false,
           antarctic_resolution: null,
-          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
-          arctic_tile_matrix_limits: null,
           format: 'png',
           geographic: true,
           geographic_resolution: '2km',
-          geographic_tile_matrix_limits: matrixLimits,
           group: 'overlays',
           match: {
             day_night_flag: 'NIGHT',
@@ -136,7 +136,8 @@ describe('constructLayerTagData', () => {
           },
           product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
           source: 'Aqua / MODIS',
-          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)'
+          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+          updated_at: '1988-09-03T14:00:00.000Z'
         }
       }
     ])
@@ -161,7 +162,6 @@ describe('constructLayerTagData', () => {
       }
     }
     testingLayer.product = productObject
-    testingLayer.matrixLimits = matrixLimits
 
     const response = constructLayerTagData(testingLayer)
 
@@ -174,14 +174,11 @@ describe('constructLayerTagData', () => {
       data: {
         antarctic: false,
         antarctic_resolution: null,
-        antarctic_tile_matrix_limits: null,
         arctic: false,
         arctic_resolution: null,
-        arctic_tile_matrix_limits: null,
         format: 'png',
         geographic: true,
         geographic_resolution: '2km',
-        geographic_tile_matrix_limits: matrixLimits,
         group: 'overlays',
         match: {
           time_start: '>=2002-07-04T00:00:00Z',
@@ -189,7 +186,8 @@ describe('constructLayerTagData', () => {
         },
         product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
         source: 'Aqua / MODIS',
-        title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)'
+        title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+        updated_at: '1988-09-03T14:00:00.000Z'
       }
     }
 

--- a/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
+++ b/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
@@ -28,23 +28,6 @@ describe('getSupportedGibsLayers', () => {
 
     expect(Object.keys(response)).not.toContain('ExcludedProjection_Value')
     expect(Object.keys(response)).not.toContain('MissingProjection_Value')
-
-    expect(response.MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.matrixLimits).toEqual({
-      '2km': {
-        0: {
-          matrixHeight: 1,
-          matrixWidth: 2
-        },
-        1: {
-          matrixHeight: 2,
-          matrixWidth: 3
-        },
-        2: {
-          matrixHeight: 3,
-          matrixWidth: 5
-        }
-      }
-    })
   })
 
   test('with custom gibs layers merged', async () => {
@@ -53,23 +36,6 @@ describe('getSupportedGibsLayers', () => {
     expect(Object.keys(response)).toContain('MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily')
     expect(Object.keys(response)).toContain('MOPITT_CO_Monthly_Total_Column_Day')
     expect(Object.keys(response).length).toEqual(48)
-
-    expect(response.MOPITT_CO_Monthly_Total_Column_Day.matrixLimits).toEqual({
-      '2km': {
-        0: {
-          matrixHeight: 1,
-          matrixWidth: 2
-        },
-        1: {
-          matrixHeight: 2,
-          matrixWidth: 3
-        },
-        2: {
-          matrixHeight: 3,
-          matrixWidth: 5
-        }
-      }
-    })
   })
 
   describe('without custom gibs layers merged', () => {
@@ -77,23 +43,6 @@ describe('getSupportedGibsLayers', () => {
       const response = await getSupportedGibsLayers(false)
 
       expect(Object.keys(response)).toEqual(['MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily'])
-
-      expect(response.MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily.matrixLimits).toEqual({
-        '2km': {
-          0: {
-            matrixHeight: 1,
-            matrixWidth: 2
-          },
-          1: {
-            matrixHeight: 2,
-            matrixWidth: 3
-          },
-          2: {
-            matrixHeight: 3,
-            matrixWidth: 5
-          }
-        }
-      })
     })
   })
 })

--- a/serverless/src/generateGibsTags/__tests__/handler.test.js
+++ b/serverless/src/generateGibsTags/__tests__/handler.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
 
   // MockDate is used here to overwrite the js Date object. This allows us to
   // mock changes needed to test the moment functions
-  MockDate.set('09/03/1988 10:00:00')
+  MockDate.set('1988-09-03T10:00:00.000Z')
 })
 
 afterEach(() => {
@@ -126,7 +126,7 @@ describe('generateGibsTags', () => {
             title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
             source: 'Terra / MISR',
             format: 'png',
-            updated_at: '1988-09-03T14:00:00.000Z',
+            updated_at: '1988-09-03T10:00:00.000Z',
             antarctic: false,
             antarctic_resolution: null,
             arctic: false,
@@ -158,7 +158,7 @@ describe('generateGibsTags', () => {
           title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
           source: 'Aqua / MODIS',
           format: 'png',
-          updated_at: '1988-09-03T14:00:00.000Z',
+          updated_at: '1988-09-03T10:00:00.000Z',
           antarctic: false,
           antarctic_resolution: null,
           arctic: false,

--- a/serverless/src/generateGibsTags/__tests__/handler.test.js
+++ b/serverless/src/generateGibsTags/__tests__/handler.test.js
@@ -1,8 +1,9 @@
 import AWS from 'aws-sdk'
+import MockDate from 'mockdate'
 
 import * as getSupportedGibsLayers from '../getSupportedGibsLayers'
+
 import generateGibsTags from '../handler'
-import { matrixLimits } from './mocks'
 
 const OLD_ENV = process.env
 
@@ -14,11 +15,17 @@ beforeEach(() => {
   // jest.resetModules()
   process.env = { ...OLD_ENV }
   delete process.env.NODE_ENV
+
+  // MockDate is used here to overwrite the js Date object. This allows us to
+  // mock changes needed to test the moment functions
+  MockDate.set('09/03/1988 10:00:00')
 })
 
 afterEach(() => {
   // Restore any ENV variables overwritten in tests
   process.env = OLD_ENV
+
+  MockDate.reset()
 })
 
 describe('generateGibsTags', () => {
@@ -63,8 +70,7 @@ describe('generateGibsTags', () => {
         },
         type: 'wmts',
         id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
-        tags: 'ssc podaac PO.DAAC',
-        matrixLimits
+        tags: 'ssc podaac PO.DAAC'
       },
       'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly': {
         startDate: '2000-02-01',
@@ -83,8 +89,7 @@ describe('generateGibsTags', () => {
             source: 'GIBS:geographic',
             matrixSet: '2km'
           }
-        },
-        matrixLimits
+        }
       }
     }))
 
@@ -121,15 +126,13 @@ describe('generateGibsTags', () => {
             title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
             source: 'Terra / MISR',
             format: 'png',
+            updated_at: '1988-09-03T14:00:00.000Z',
             antarctic: false,
             antarctic_resolution: null,
-            antarctic_tile_matrix_limits: null,
             arctic: false,
             arctic_resolution: null,
-            arctic_tile_matrix_limits: null,
             geographic: true,
-            geographic_resolution: '2km',
-            geographic_tile_matrix_limits: matrixLimits
+            geographic_resolution: '2km'
           }]
         }
       })
@@ -155,15 +158,13 @@ describe('generateGibsTags', () => {
           title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
           source: 'Aqua / MODIS',
           format: 'png',
+          updated_at: '1988-09-03T14:00:00.000Z',
           antarctic: false,
           antarctic_resolution: null,
-          antarctic_tile_matrix_limits: null,
           arctic: false,
           arctic_resolution: null,
-          arctic_tile_matrix_limits: null,
           geographic: true,
-          geographic_resolution: '2km',
-          geographic_tile_matrix_limits: matrixLimits
+          geographic_resolution: '2km'
         }]
       })
     }])

--- a/serverless/src/generateGibsTags/__tests__/mocks.js
+++ b/serverless/src/generateGibsTags/__tests__/mocks.js
@@ -233,20 +233,3 @@ export const capabilitiesResponse = `<Capabilities
   </Contents>
   <ServiceMetadataURL xlink:href="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/WMTSCapabilities.xml"/>
 </Capabilities>`
-
-export const matrixLimits = {
-  '2km': {
-    0: {
-      matrixHeight: 1,
-      matrixWidth: 2
-    },
-    1: {
-      matrixHeight: 2,
-      matrixWidth: 3
-    },
-    2: {
-      matrixHeight: 3,
-      matrixWidth: 5
-    }
-  }
-}

--- a/serverless/src/generateGibsTags/constructLayerTagData.js
+++ b/serverless/src/generateGibsTags/constructLayerTagData.js
@@ -12,7 +12,6 @@ export const constructLayerTagData = (layer) => {
     format,
     group,
     id,
-    matrixLimits,
     product,
     projections,
     subtitle,
@@ -40,7 +39,8 @@ export const constructLayerTagData = (layer) => {
     // maxNativeZoom: 5,
     title,
     source: subtitle,
-    format: format.split('/').pop()
+    format: format.split('/').pop(),
+    updated_at: new Date().toISOString()
   }
 
   const supportedProjections = ['antarctic', 'arctic', 'geographic']
@@ -51,11 +51,9 @@ export const constructLayerTagData = (layer) => {
 
       tagData[projection] = true
       tagData[`${projection}_resolution`] = resolution
-      tagData[`${projection}_tile_matrix_limits`] = matrixLimits
     } else {
       tagData[projection] = false
       tagData[`${projection}_resolution`] = null
-      tagData[`${projection}_tile_matrix_limits`] = null
     }
   })
 

--- a/serverless/src/generateGibsTags/getSupportedGibsLayers.js
+++ b/serverless/src/generateGibsTags/getSupportedGibsLayers.js
@@ -1,6 +1,5 @@
 import 'array-foreach-async'
 import request from 'request-promise'
-import { parse as parseXml } from 'fast-xml-parser'
 
 import customGibsProducts from '../static/gibs'
 import { getClientId } from '../../../sharedUtils/getClientId'
@@ -24,52 +23,6 @@ export const getSupportedGibsLayers = async (mergeCustomProducts = true) => {
     epsg3413: 'GIBS:arctic',
     epsg3031: 'GIBS:antarctic'
   }
-
-  const capabilitiesMatrixSets = {}
-
-  // For each projection, parse the capabilities document and pull out TileMatrixSet for each resolution
-  await Object.keys(projectionMap).forEachAsync(async (projection) => {
-    const capabilitiesUrl = `https://gibs.earthdata.nasa.gov/wmts/${projection}/best/wmts.cgi?SERVICE=WMTS&request=GetCapabilities`
-    const capabilitiesResponse = await request.get({
-      uri: capabilitiesUrl,
-      resolveWithFullResponse: true
-    })
-
-    const parsedCapabilities = parseXml(capabilitiesResponse.body, {
-      ignoreAttributes: false,
-      attributeNamePrefix: ''
-    })
-
-    const { Capabilities: capabilities = {} } = parsedCapabilities
-    const { Contents: contents = {} } = capabilities
-    let { TileMatrixSet: capabilityTileMatrixSets = [] } = contents
-    capabilityTileMatrixSets = [].concat(capabilityTileMatrixSets).filter(Boolean)
-
-    const matrixLimits = {}
-    capabilityTileMatrixSets.forEach((matrixSet) => {
-      const { 'ows:Identifier': resolution } = matrixSet
-      let { TileMatrix: tileMatrix = [] } = matrixSet
-      tileMatrix = [].concat(tileMatrix).filter(Boolean)
-
-      const resolutionMap = {}
-      tileMatrix.forEach((matrix) => {
-        const {
-          'ows:Identifier': id,
-          MatrixWidth: matrixWidth,
-          MatrixHeight: matrixHeight
-        } = matrix
-
-        resolutionMap[id] = {
-          matrixWidth,
-          matrixHeight
-        }
-      })
-
-      matrixLimits[resolution] = resolutionMap
-    })
-
-    capabilitiesMatrixSets[projectionMap[projection]] = matrixLimits
-  })
 
   const supportedProjections = Object.values(projectionMap)
 
@@ -123,8 +76,6 @@ export const getSupportedGibsLayers = async (mergeCustomProducts = true) => {
       if (!supportedProjections.includes(projection.source)) {
         delete projections[key]
       }
-
-      currentLayer.matrixLimits = capabilitiesMatrixSets[projection.source]
     })
 
     // Ensure the layer has projections that we support

--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -36,7 +36,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -72,7 +72,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -115,7 +115,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -160,7 +160,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -203,7 +203,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -248,7 +248,7 @@ describe('addTag', () => {
           ]
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',
@@ -312,7 +312,7 @@ describe('addTag', () => {
           'concept-id': 'C123456789-EDSC'
         }
       ]))
-      .reply(200)
+      .reply(200, [])
 
     await addTag({
       tagName: 'edsc.extra.gibs',

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -98,7 +98,7 @@ export async function addTag({
   if (associationData) {
     try {
       const addTagUrl = `${getEarthdataConfig(deployedEnvironment()).cmrHost}/search/tags/${tagName}/associations`
-      await request.post({
+      const taggingResponse = await request.post({
         uri: addTagUrl,
         headers: {
           'Client-Id': getClientId().background,
@@ -107,6 +107,15 @@ export async function addTag({
         body: castArray(associationData),
         json: true,
         resolveWithFullResponse: true
+      })
+
+      const { body = [] } = taggingResponse
+
+      Array.from(body).forEach((tagResponse) => {
+        const { errors = [] } = tagResponse
+
+        // Log each (potential) error
+        errors.forEach(error => console.log(error))
       })
     } catch (e) {
       parseError(e, { reThrowError: true })

--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -219,6 +219,11 @@ export class GranuleGridLayerExtended extends L.GridLayer {
   }
 
   getTileUrl(tilePoint, granule) {
+    // ***
+    // * Storing TileMatrixLimits in CMR tags is not a viable option, the payload is
+    // * too large. This tag data will be replaced with the efforts associated with EDSC-2972.
+    // ***
+
     if (!this.multiOptions) return null
     const date = granule.timeStart != null ? granule.timeStart.substring(0, 10) : undefined
 
@@ -227,7 +232,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       const newOptionSet = optionSet
       if (this.matches(granule, newOptionSet.match)) {
         let newResolution
-        let tileMatrixLimits
+        // let tileMatrixLimits
 
         const oldResolution = newOptionSet.resolution
 
@@ -235,47 +240,47 @@ export class GranuleGridLayerExtended extends L.GridLayer {
         if ((this.projection === projections.geographic) && newOptionSet.geographic) {
           matched = true
           newResolution = newOptionSet.geographic_resolution
-          tileMatrixLimits = newOptionSet.geographic_tile_matrix_limits
+          // tileMatrixLimits = newOptionSet.geographic_tile_matrix_limits
         } else if ((this.projection === projections.arctic) && newOptionSet.arctic) {
           matched = true
           newResolution = newOptionSet.arctic_resolution
-          tileMatrixLimits = newOptionSet.arctic_tile_matrix_limits
+          // tileMatrixLimits = newOptionSet.arctic_tile_matrix_limits
         } else if ((this.projection === projections.antarctic) && newOptionSet.antarctic) {
           matched = true
           newResolution = newOptionSet.antarctic_resolution
-          tileMatrixLimits = newOptionSet.antarctic_tile_matrix_limits
+          // tileMatrixLimits = newOptionSet.antarctic_tile_matrix_limits
         }
 
         // Use default resolution unless newResolution exists
         if (newResolution == null) { newResolution = oldResolution }
         newOptionSet.resolution = newResolution
-        newOptionSet.tileMatrixLimits = tileMatrixLimits
+        // newOptionSet.tileMatrixLimits = tileMatrixLimits
 
         this.options = L.extend({}, this.originalOptions, newOptionSet)
       }
     })
 
-    const { resolution, tileMatrixLimits = {} } = this.options
-    const { [resolution]: tileMatrixLimitsByResolution = {} } = tileMatrixLimits
+    // const { resolution, tileMatrixLimits = {} } = this.options
+    // const { [resolution]: tileMatrixLimitsByResolution = {} } = tileMatrixLimits
 
     // If the z point is not included in the tile matrix limits, return null
-    if (!Object.keys(tileMatrixLimitsByResolution).includes(tilePoint.z.toString())) {
-      return null
-    }
+    // if (!Object.keys(tileMatrixLimitsByResolution).includes(tilePoint.z.toString())) {
+    //   return null
+    // }
 
-    const {
-      matrixHeight,
-      matrixWidth
-    } = tileMatrixLimitsByResolution[tilePoint.z]
+    // const {
+    //   matrixHeight,
+    //   matrixWidth
+    // } = tileMatrixLimitsByResolution[tilePoint.z]
 
     // If the x or y points are less than 0 or greater than the width - 1 or height - 1 return null
     // Subtract 1 because the tilePoints start at 0 instead of 1
-    if (
-      tilePoint.x < 0 || tilePoint.x > matrixWidth - 1
-      || tilePoint.y < 0 || tilePoint.y > matrixHeight - 1
-    ) {
-      return null
-    }
+    // if (
+    //   tilePoint.x < 0 || tilePoint.x > matrixWidth - 1
+    //   || tilePoint.y < 0 || tilePoint.y > matrixHeight - 1
+    // ) {
+    //   return null
+    // }
 
     if (!matched) { return false }
 

--- a/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
+++ b/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
@@ -141,32 +141,6 @@ describe('GranuleGridLayerExtended class', () => {
       const result = layer.getTileUrl(tilePoint, updateProps.granules[0])
       expect(result).toEqual('https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_NDVI_16Day/default/2020-09-29/250m/0/0/0.png')
     })
-
-    test('does not return a URL for a zoom level that is not support by tile matrix limits', () => {
-      const layer = setup()
-      layer.setResults(updateProps)
-      const tilePoint = {
-        x: 0,
-        y: 0,
-        z: 6
-      }
-
-      const result = layer.getTileUrl(tilePoint, updateProps.granules[0])
-      expect(result).toBeNull()
-    })
-
-    test('does not return a URL for a tile that is not support by tile matrix limits', () => {
-      const layer = setup()
-      layer.setResults(updateProps)
-      const tilePoint = {
-        x: 2,
-        y: 0,
-        z: 0
-      }
-
-      const result = layer.getTileUrl(tilePoint, updateProps.granules[0])
-      expect(result).toBeNull()
-    })
   })
 
   describe('drawTile', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

Matrix Tile Sets are too big for CMR tags, so we're removing it and adding new endpoints to the visualization app.

### What is the Solution?

Removed the injection of matrix tile sets into the gibs tag.

### What areas of the application does this impact?

GIBS Imagery.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
