### PR TITLE
EDSC-2977: Prevent tag associations when no collections results are returned

### DIFF
--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -392,6 +392,29 @@ describe('addTag', () => {
     })).rejects.toThrow('Test error message')
   })
 
+  test('does not call the cmr endpoint when tag data is provided but no collections are returned from the collection search endpoint', async () => {
+    nock(/example/)
+      .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
+        short_name: 'MIL3MLS'
+      })
+      .reply(200, {
+        feed: {
+          entry: []
+        }
+      })
+
+    const result = await addTag({
+      tagName: 'edsc.extra.gibs',
+      tagData: { product: 'AMSUA_NOAA15_Brightness_Temp_Channel_6' },
+      searchCriteria: { short_name: 'MIL3MLS' },
+      requireGranules: false,
+      append: true,
+      cmrToken: '1234-abcd-5678-efgh'
+    })
+
+    expect(result).toBeFalsy()
+  })
+
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -60,7 +60,7 @@ export async function addTag({
 
     // If collections were returned from the search, examine their metadata and
     // construct appropriate tag data to be assigned to them
-    if (!collections) return false
+    if (!collections.length) return false
 
     // If `append` is true, the tagData provided will be appended to previous tag data
     // already assigned to the provided collections


### PR DESCRIPTION
# Overview

### What is the feature?

The addTag job was throwing errors because it was trying to add tag associations when there were no collections matching the search criteria

### What is the Solution?

Change ```if (!collections) return false``` to ```if (!collections.length) return false```

### What areas of the application does this impact?

Tagging

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
