### PR TITLE
EDSC-2975: Fixes the autocomplete facet behavior

### DIFF
--- a/static/src/js/reducers/__tests__/facetsParams.test.js
+++ b/static/src/js/reducers/__tests__/facetsParams.test.js
@@ -78,6 +78,24 @@ describe('cmrFacetsReducer', () => {
         }
       }
 
+      const initial = initialState
+
+      const expectedState = {
+        ...initialState,
+        platform_h: ['Terra']
+      }
+
+      expect(cmrFacetsReducer(initial, action)).toEqual(expectedState)
+    })
+
+    test('returns the correct state when the initial state already has the key', () => {
+      const action = {
+        type: ADD_CMR_FACET,
+        payload: {
+          platform_h: 'Terra'
+        }
+      }
+
       const initial = {
         ...initialState,
         platform_h: ['Aqua']

--- a/static/src/js/reducers/facetsParams.js
+++ b/static/src/js/reducers/facetsParams.js
@@ -43,10 +43,12 @@ export const cmrFacetsReducer = (state = initialCmrState, action) => {
     case ADD_CMR_FACET: {
       const [key] = Object.keys(payload)
 
+      const prevKeyState = state[key] || []
+
       return {
         ...state,
         [key]: [
-          ...state[key],
+          ...prevKeyState,
           payload[key]
         ]
       }


### PR DESCRIPTION
# Overview

### What is the feature?

Selecting an autocomplete suggestion was selecting the value as a facet or adding the selected facet below the search field

### What is the Solution?

Fixed the reducer to handle spreading out the previous state when that state is undefined

### What areas of the application does this impact?

Autocomplete, Facets

# Testing

### Reproduction steps

Type `MODI` into the search field
Select `Instrument: MODIS`
The autocomplete should be selected and the Instrument facet for MODIS should be applied

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
