### PR TITLE
EDSC-2978: Keeps project collection parameters through EDL login redirects

### DIFF
--- a/serverless/src/edlLogin/__tests__/handler.test.js
+++ b/serverless/src/edlLogin/__tests__/handler.test.js
@@ -30,4 +30,31 @@ describe('edlLogin', () => {
       }
     })
   })
+
+  test('successfully keeps array values in order during the redirect to earthdata login', async () => {
+    jest.spyOn(getEdlConfig, 'getEdlConfig').mockImplementationOnce(() => ({
+      client: {
+        id: 'edlClientId'
+      }
+    }))
+
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementationOnce(() => ({
+      edlHost: 'http://edl.example.com',
+      redirectUriPath: '/search'
+    }))
+
+    const response = await edlLogin({
+      queryStringParameters: {
+        ee: 'prod',
+        state: 'http://edsc-state.nasa.gov?p=!C12345-EDSC&p[1][v]=t'
+      }
+    })
+
+    expect(response).toEqual({
+      statusCode: 307,
+      headers: {
+        Location: 'http://edl.example.com/oauth/authorize?response_type=code&client_id=edlClientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsearch&state=http%3A%2F%2Fedsc-state.nasa.gov%3Fp%255B0%255D%3D%2521C12345-EDSC%26p%255B1%255D%255B1%255D%255Bv%255D%3Dt%26ee%3Dprod'
+      }
+    })
+  })
 })

--- a/serverless/src/edlLogin/handler.js
+++ b/serverless/src/edlLogin/handler.js
@@ -31,7 +31,7 @@ const edlLogin = async (event) => {
   const [path, queryParams] = state.split('?')
 
   // Parse the query string into an object
-  const paramsObj = parse(queryParams)
+  const paramsObj = parse(queryParams, { parseArrays: false })
 
   // If the earthdata environment variable
   if (!Object.keys(paramsObj).includes('ee')) {


### PR DESCRIPTION
# Overview

### What is the feature?

The edlLogin lambda was parsing arrays when examining the `state` parameter, causing the array indices to be lost

### What is the Solution?

Added the `parseArrays: false` option to the `parse` command in edlLogin

### What areas of the application does this impact?

Projects

# Testing

### Reproduction steps

While logged out, add a single granule to your project.
Click the Earthdata Login button, or Download button.
When redirected back to EDSC, you should only see the single granule in your project

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
