### PR TITLE
EDSC-2867: Encodes facets before writing them to the URL

### DIFF
--- a/static/src/js/util/url/__tests__/facetEncoders.test.js
+++ b/static/src/js/util/url/__tests__/facetEncoders.test.js
@@ -1,0 +1,35 @@
+const { encodeFacets, decodeFacets } = require('../facetEncoders')
+
+describe('encodeFacets', () => {
+  test('encodes facets array into a string', () => {
+    const facets = [
+      'Facet 1',
+      'Facet & Facet'
+    ]
+
+    const expectedResult = 'Facet%201!Facet%20%26%20Facet'
+
+    expect(encodeFacets(facets)).toEqual(expectedResult)
+  })
+
+  test('returns an empty string if no facets exist', () => {
+    expect(encodeFacets()).toEqual('')
+  })
+})
+
+describe('decodeFacets', () => {
+  test('decodes facet string into an array', () => {
+    const string = 'Facet%201!Facet%20%26%20Facet'
+
+    const expectedResult = [
+      'Facet 1',
+      'Facet & Facet'
+    ]
+
+    expect(decodeFacets(string)).toEqual(expectedResult)
+  })
+
+  test('returns undefined if passed an empty string', () => {
+    expect(decodeFacets('')).toEqual(undefined)
+  })
+})

--- a/static/src/js/util/url/facetEncoders.js
+++ b/static/src/js/util/url/facetEncoders.js
@@ -9,7 +9,7 @@ export const encodeFacets = (facets) => {
   const encoded = []
 
   facets.forEach((facet) => {
-    encoded.push(facet)
+    encoded.push(encodeURIComponent(facet))
   })
 
   return encoded.join('!')
@@ -26,7 +26,7 @@ export const decodeFacets = (string) => {
     return undefined
   }
 
-  const decodedValues = string.split('!')
+  const decodedValues = string.split('!').map(value => decodeURIComponent(value))
 
   return decodedValues
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Facets with `&` in the name were not being encoded before written to the URL. Refreshing the page (or sharing the URL) would result in incorrect results

### What is the Solution?

Encode/decode facet names when writing/reading them from the URL

### What areas of the application does this impact?

Facets

# Testing

### Reproduction steps

Select a facet with a `&` in the name. In prod the organization `Level-1 and Atmosphere Archive & Distribution System (LAADS)` works
Refresh the page and note the facet is still applied and results are returned correctly

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
