### PR TITLE
EDSC-2961: Include the excludedGranuleIds when loading a project collection's granule params

### DIFF
--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -181,7 +181,6 @@ export const extractProjectCollectionGranuleParams = (state, collectionId) => {
     // Ensure that the `generic` search params are also included
     ...extractGranuleSearchParams(state, collectionId),
     addedGranuleIds,
-    excludedGranuleIds: [], // Excluded granules should not be taken into account for project granule requests
     pageNum,
     removedGranuleIds
   }


### PR DESCRIPTION
# Overview

### What is the feature?

Excluded granules are being included in projects, they should be excluded

### What is the Solution?

Include the `excludedGranuleIds` when loading a project collection's granule params

### What areas of the application does this impact?

Projects

# Testing

### Reproduction steps

Excluded a granule from search results
Add the entire collection to your project and navigate to the project page
The excluded granule should not be included in your project page granules

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
