### PR TITLE
EDSC-2261: Displays errors generated when creating new retrievals

### DIFF
--- a/migrations/1605032948012_add-error-to-retrieval-orders.js
+++ b/migrations/1605032948012_add-error-to-retrieval-orders.js
@@ -1,0 +1,13 @@
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.addColumns('retrieval_orders', {
+    error: {
+      type: 'text'
+    }
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumns('retrieval_orders', ['error'])
+}

--- a/serverless/src/fetchCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/fetchCatalogRestOrder/__tests__/handler.test.js
@@ -259,15 +259,17 @@ describe('fetchCatalogRestOrder', () => {
 
     nock('https://n5eil09e.ecs.edsc.org')
       .get('/egi/request/10005')
-      .reply(401, {
-        error: 'HTTP Basic: Access denied.'
-      })
+      .reply(401,
+        '',
+        {
+          'content-type': 'text/html; charset=utf-8'
+        })
 
     await expect(fetchCatalogRestOrder({
       accessToken: 'fake.access.token:clientId',
       id: 1,
       orderType: 'ESI'
-    })).rejects.toThrow('HTTP Basic: Access denied.')
+    })).rejects.toThrow('Error (401):')
 
     const { queries } = dbTracker.queries
 

--- a/serverless/src/fetchCatalogRestOrder/handler.js
+++ b/serverless/src/fetchCatalogRestOrder/handler.js
@@ -1,5 +1,5 @@
 import 'array-foreach-async'
-import request from 'request-promise'
+import axios from 'axios'
 import { parse as parseXml } from 'fast-xml-parser'
 import { getDbConnection } from '../util/database/getDbConnection'
 import { getClientId } from '../../../sharedUtils/getClientId'
@@ -48,18 +48,18 @@ const fetchCatalogRestOrder = async (input) => {
 
     console.log(`Requesting order data from EGI at ${url}/${orderNumber}`)
 
-    const orderResponse = await request.get({
-      uri: `${url}/${orderNumber}`,
+    const orderResponse = await axios({
+      url: `${url}/${orderNumber}`,
+      method: 'get',
       headers: {
         'Echo-Token': accessToken,
         'Client-Id': getClientId().background
-      },
-      resolveWithFullResponse: true
+      }
     })
 
-    console.log('Order Response Body', orderResponse.body)
+    console.log('Order Response Body', orderResponse.data)
 
-    const orderResponseBody = parseXml(orderResponse.body, {
+    const orderResponseBody = parseXml(orderResponse.data, {
       ignoreAttributes: false,
       attributeNamePrefix: ''
     })

--- a/serverless/src/fetchCatalogRestOrder/handler.js
+++ b/serverless/src/fetchCatalogRestOrder/handler.js
@@ -4,6 +4,7 @@ import { parse as parseXml } from 'fast-xml-parser'
 import { getDbConnection } from '../util/database/getDbConnection'
 import { getClientId } from '../../../sharedUtils/getClientId'
 import { getStateFromOrderStatus } from '../../../sharedUtils/orderStatus'
+import { parseError } from '../../../sharedUtils/parseError'
 
 const fetchCatalogRestOrder = async (input) => {
   // Retrieve a connection to the database
@@ -16,74 +17,83 @@ const fetchCatalogRestOrder = async (input) => {
     orderType
   } = input
 
-  // Fetch the retrieval id that the order belongs to so that we can provide a link to the status page
-  const retrievalOrderRecord = await dbConnection('retrieval_orders')
-    .first(
-      'retrieval_collections.access_method',
-      'retrieval_orders.order_number'
-    )
-    .join('retrieval_collections', { 'retrieval_orders.retrieval_collection_id': 'retrieval_collections.id' })
-    .where({
-      'retrieval_orders.id': id
+  try {
+    // Fetch the retrieval id that the order belongs to so that we can provide a link to the status page
+    const retrievalOrderRecord = await dbConnection('retrieval_orders')
+      .first(
+        'retrieval_collections.access_method',
+        'retrieval_orders.order_number'
+      )
+      .join('retrieval_collections', { 'retrieval_orders.retrieval_collection_id': 'retrieval_collections.id' })
+      .where({
+        'retrieval_orders.id': id
+      })
+
+    // If there is not record in the database prevent taking any additional actions
+    if (!retrievalOrderRecord) {
+      return {
+        accessToken,
+        id,
+        orderStatus: 'not_found',
+        orderType
+      }
+    }
+
+    const {
+      access_method: accessMethod,
+      order_number: orderNumber
+    } = retrievalOrderRecord
+
+    const { url } = accessMethod
+
+    console.log(`Requesting order data from EGI at ${url}/${orderNumber}`)
+
+    const orderResponse = await request.get({
+      uri: `${url}/${orderNumber}`,
+      headers: {
+        'Echo-Token': accessToken,
+        'Client-Id': getClientId().background
+      },
+      resolveWithFullResponse: true
     })
 
-  // If there is not record in the database prevent taking any additional actions
-  if (!retrievalOrderRecord) {
+    console.log('Order Response Body', orderResponse.body)
+
+    const orderResponseBody = parseXml(orderResponse.body, {
+      ignoreAttributes: false,
+      attributeNamePrefix: ''
+    })
+
+    console.log('Parsed Order Response Body', JSON.stringify(orderResponseBody, null, 4))
+
+    const { 'eesi:agentResponse': order } = orderResponseBody
+
+    const { requestStatus } = order
+    const { status } = requestStatus
+
+    // Updates the database with current order data
+    await dbConnection('retrieval_orders')
+      .update({
+        order_information: order,
+        state: status
+      })
+      .where({
+        id
+      })
+
     return {
       accessToken,
       id,
-      orderStatus: 'not_found',
+      orderStatus: getStateFromOrderStatus(status),
       orderType
     }
-  }
+  } catch (e) {
+    const parsedErrorMessage = parseError(e, { asJSON: false })
 
-  const {
-    access_method: accessMethod,
-    order_number: orderNumber
-  } = retrievalOrderRecord
+    const [errorMessage] = parsedErrorMessage
 
-  const { url } = accessMethod
-
-  console.log(`Requesting order data from EGI at ${url}/${orderNumber}`)
-
-  const orderResponse = await request.get({
-    uri: `${url}/${orderNumber}`,
-    headers: {
-      'Echo-Token': accessToken,
-      'Client-Id': getClientId().background
-    },
-    resolveWithFullResponse: true
-  })
-
-  console.log('Order Response Body', orderResponse.body)
-
-  const orderResponseBody = parseXml(orderResponse.body, {
-    ignoreAttributes: false,
-    attributeNamePrefix: ''
-  })
-
-  console.log('Parsed Order Response Body', JSON.stringify(orderResponseBody, null, 4))
-
-  const { 'eesi:agentResponse': order } = orderResponseBody
-
-  const { requestStatus } = order
-  const { status } = requestStatus
-
-  // Updates the database with current order data
-  await dbConnection('retrieval_orders')
-    .update({
-      order_information: order,
-      state: status
-    })
-    .where({
-      id
-    })
-
-  return {
-    accessToken,
-    id,
-    orderStatus: getStateFromOrderStatus(status),
-    orderType
+    // Re-throw the error so the state machine handles the error correctly
+    throw Error(errorMessage)
   }
 }
 

--- a/serverless/src/getRetrievalCollection/handler.js
+++ b/serverless/src/getRetrievalCollection/handler.js
@@ -50,6 +50,7 @@ const getRetrievalCollection = async (event, context) => {
         'retrieval_orders.order_number',
         'retrieval_orders.order_information',
         'retrieval_orders.state',
+        'retrieval_orders.error',
         'users.urs_id'
       )
       .leftJoin('retrieval_orders', { 'retrieval_collections.id': 'retrieval_orders.retrieval_collection_id' })
@@ -87,13 +88,15 @@ const getRetrievalCollection = async (event, context) => {
           type,
           order_number: orderNumber,
           order_information: orderInformation,
-          state
+          state,
+          error
         }) => ({
           id,
           type,
           order_number: orderNumber,
           order_information: orderInformation,
-          state
+          state,
+          error
         }))
       }
 

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -349,4 +349,78 @@ describe('submitCatalogRestOrder', () => {
     expect(createLimitedShapefileMock).toHaveBeenCalledTimes(1)
     expect(prepareGranuleAccessParams.prepareGranuleAccessParams).toHaveBeenCalledTimes(1)
   })
+
+  test('saves an error message if the create fails', async () => {
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+      cmrHost: 'https://cmr.earthdata.nasa.gov',
+      edscHost: 'http://localhost:8080'
+    }))
+
+    nock(/cmr/)
+      .get('/search/granules.json?collection_concept_id=C100000-EDSC')
+      .reply(200, {
+        feed: {
+          entry: [{
+            id: 'G10000005-EDSC',
+            title: 'GRANULE_SHORT_NAME'
+          }]
+        }
+      })
+
+    nock('https://n5eil09e.ecs.edsc.org')
+      .post('/egi/request', stringify({
+        FILE_IDS: 'GRANULE_SHORT_NAME',
+        CLIENT_STRING:
+          'To view the status of your request, please see: http://localhost:8080/downloads/4517239960',
+        CLIENT: 'ESI',
+        FORMAT: 'HDF-EOS',
+        INCLUDE_META: 'Y',
+        INTERPOLATION: 'CC',
+        PROJECTION: 'LAMBERT AZIMUTHAL',
+        REQUEST_MODE: 'async',
+        SUBAGENT_ID: 'HEG',
+        PROJECTION_PARAMETERS: 'Sphere:45,FE:54',
+        RESAMPLE: 'PERCENT:100',
+        SUBSET_DATA_LAYERS:
+          '/MI1B2E/BlueBand,/MI1B2E/BRF Conversion Factors,/MI1B2E/GeometricParameters,/MI1B2E/NIRBand,/MI1B2E/RedBand',
+        BBOX: '-180,-90,180,90'
+      }))
+      .reply(500, {
+        errorType: 'Error',
+        errorMessage: 'Unknown Error',
+        stack: [
+          'Error: Unknown Error'
+        ]
+      })
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          id: '1',
+          environment: 'prod',
+          jsondata: { source: '?sf=1' },
+          access_method: {
+            type: 'ESI',
+            model: '<ecs:options xmlns:ecs="http://ecs.nasa.gov/options"><ecs:distribution xmlns="http://ecs.nasa.gov/options"><ecs:mediatype><ecs:value>HTTPS</ecs:value></ecs:mediatype><ecs:mediaformat><ecs:ftppull-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppull-format><ecs:ftppush-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppush-format></ecs:mediaformat></ecs:distribution><ecs:ancillary xmlns="http://ecs.nasa.gov/options"><ecs:orderPH>false</ecs:orderPH><ecs:orderQA>false</ecs:orderQA><ecs:orderHDF_MAP>false</ecs:orderHDF_MAP><ecs:orderBrowse>false</ecs:orderBrowse></ecs:ancillary><ecs:esi-xml><!--NOTE: elements in caps losely match the ESI API, those in lowercase are helper elements --><!--Dataset ID will be injected by Reverb--><ecs:CLIENT>ESI</ecs:CLIENT><!--First SubsetAgent in the input capabilities XML is used as the default.--><ecs:SUBAGENT_ID><ecs:value>HEG</ecs:value></ecs:SUBAGENT_ID><!-- hardcode to async for Reverb services --><ecs:REQUEST_MODE>async</ecs:REQUEST_MODE><ecs:SPATIAL_MSG>Click the checkbox to enable spatial subsetting.</ecs:SPATIAL_MSG><ecs:PROJ_MSG_1>CAUTION: Re-projection parameters may alter results.</ecs:PROJ_MSG_1><ecs:PROJ_MSG_2>Leave blank to choose default values for each re-projected granule.</ecs:PROJ_MSG_2><ecs:INTRPL_MSG_1>Used to calculate data of resampled and reprojected pixels.</ecs:INTRPL_MSG_1><ecs:HEG-request><!--Need to populate BBOX in final ESI request as follows: "&BBOX=ullon,lrlat,lrlon,ullat"--><ecs:spatial_subsetting><ecs:boundingbox><ecs:ullat>90</ecs:ullat><ecs:ullon>-180</ecs:ullon><ecs:lrlat>-90</ecs:lrlat><ecs:lrlon>180</ecs:lrlon></ecs:boundingbox></ecs:spatial_subsetting><ecs:band_subsetting><ecs:SUBSET_DATA_LAYERS style="tree"><ecs:MI1B2E><ecs:dataset>/MI1B2E/BlueBand</ecs:dataset><ecs:dataset>/MI1B2E/BRF Conversion Factors</ecs:dataset><ecs:dataset>/MI1B2E/GeometricParameters</ecs:dataset><ecs:dataset>/MI1B2E/NIRBand</ecs:dataset><ecs:dataset>/MI1B2E/RedBand</ecs:dataset></ecs:MI1B2E></ecs:SUBSET_DATA_LAYERS></ecs:band_subsetting><!--First Format in the input XML is used as the default.--><ecs:FORMAT><ecs:value>HDF-EOS</ecs:value></ecs:FORMAT><!-- OUTPUT_GRID is never used in ESI (but should be enabled for SSW)--><!-- FILE_IDS must be injected by Reverb --><!-- FILE_URLS is not used in requests from ECHO, Use FILE_IDS instead --><ecs:projection_options><ecs:PROJECTION><ecs:value>LAMBERT AZIMUTHAL</ecs:value></ecs:PROJECTION><!--In final ESI request, projection parameters should be included as follows: "&PROJECTION_PARAMETERS=param1:value1,param2:value2,...paramn:valuen"--><ecs:PROJECTION_PARAMETERS><ecs:LAMBERT_AZIMUTHAL_projection><ecs:Sphere>45</ecs:Sphere><ecs:FE>54</ecs:FE></ecs:LAMBERT_AZIMUTHAL_projection></ecs:PROJECTION_PARAMETERS></ecs:projection_options><ecs:advanced_file_options><!--In final ESI request, resample options should be formatted like: "&RESAMPLE=dimension:value"--><ecs:RESAMPLE><ecs:GEOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:GEOGRAPHIC-dimension><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:STATE_PLANE-dimension><ecs:value>PERCENT</ecs:value></ecs:STATE_PLANE-dimension><ecs:ALBERS-dimension><ecs:value>PERCENT</ecs:value></ecs:ALBERS-dimension><ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:MERCATOR-dimension><ecs:POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:POLAR_STEREOGRAPHIC-dimension><ecs:TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:TRANSVERSE_MERCATOR-dimension><ecs:LAMBERT_AZIMUTHAL-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_AZIMUTHAL-dimension><ecs:SINUSOIDAL-dimension><ecs:value>PERCENT</ecs:value></ecs:SINUSOIDAL-dimension><ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:value>PERCENT</ecs:value></ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:NO_CHANGE-dimension><ecs:value>PERCENT</ecs:value></ecs:NO_CHANGE-dimension><ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:GEOGRAPHIC-PERCENT-value>100</ecs:GEOGRAPHIC-PERCENT-value><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value><ecs:STATE_PLANE-PERCENT-value>100</ecs:STATE_PLANE-PERCENT-value><ecs:ALBERS-PERCENT-value>100</ecs:ALBERS-PERCENT-value><ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value>100</ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value><ecs:MERCATOR-PERCENT-value>100</ecs:MERCATOR-PERCENT-value><ecs:POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:POLAR_STEREOGRAPHIC-PERCENT-value><ecs:TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:TRANSVERSE_MERCATOR-PERCENT-value><ecs:LAMBERT_AZIMUTHAL-PERCENT-value>100</ecs:LAMBERT_AZIMUTHAL-PERCENT-value><ecs:SINUSOIDAL-PERCENT-value>100</ecs:SINUSOIDAL-PERCENT-value><ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value>100</ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value><ecs:NO_CHANGE-PERCENT-value>100</ecs:NO_CHANGE-PERCENT-value><ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value><ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value></ecs:RESAMPLE><ecs:INTERPOLATION><ecs:value>CC</ecs:value></ecs:INTERPOLATION><!--INCLUDE_META needs to be converted from true/false here to Y/N in the request.--><ecs:INCLUDE_META>true</ecs:INCLUDE_META></ecs:advanced_file_options><ecs:spatial_subset_flag>true</ecs:spatial_subset_flag><ecs:band_subset_flag>true</ecs:band_subset_flag><ecs:temporal_subset_flag>false</ecs:temporal_subset_flag></ecs:HEG-request></ecs:esi-xml></ecs:options>',
+            url: 'https://n5eil09e.ecs.edsc.org/egi/request'
+          },
+          granule_params: {
+            collection_concept_id: 'C100000-EDSC'
+          }
+        }])
+      } else {
+        query.response([])
+      }
+    })
+
+    const context = {}
+
+    await expect(submitCatalogRestOrder(mockCatalogRestOrder, context)).rejects.toEqual(new Error('Unknown Error'))
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toEqual('first')
+    expect(queries[1].method).toEqual('update')
+    expect(queries[1].bindings).toEqual(['create_failed', 'Unknown Error', 12])
+  })
 })

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -350,6 +350,47 @@ describe('submitCatalogRestOrder', () => {
     expect(prepareGranuleAccessParams.prepareGranuleAccessParams).toHaveBeenCalledTimes(1)
   })
 
+  test('saves an error message if the granule request fails', async () => {
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+      cmrHost: 'https://cmr.earthdata.nasa.gov',
+      edscHost: 'http://localhost:8080'
+    }))
+
+    nock(/cmr/)
+      .get('/search/granules.json?collection_concept_id=C100000-EDSC')
+      .reply(500)
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          id: '1',
+          environment: 'prod',
+          jsondata: { source: '?sf=1' },
+          access_method: {
+            type: 'ESI',
+            model: '<ecs:options xmlns:ecs="http://ecs.nasa.gov/options"><ecs:distribution xmlns="http://ecs.nasa.gov/options"><ecs:mediatype><ecs:value>HTTPS</ecs:value></ecs:mediatype><ecs:mediaformat><ecs:ftppull-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppull-format><ecs:ftppush-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppush-format></ecs:mediaformat></ecs:distribution><ecs:ancillary xmlns="http://ecs.nasa.gov/options"><ecs:orderPH>false</ecs:orderPH><ecs:orderQA>false</ecs:orderQA><ecs:orderHDF_MAP>false</ecs:orderHDF_MAP><ecs:orderBrowse>false</ecs:orderBrowse></ecs:ancillary><ecs:esi-xml><!--NOTE: elements in caps losely match the ESI API, those in lowercase are helper elements --><!--Dataset ID will be injected by Reverb--><ecs:CLIENT>ESI</ecs:CLIENT><!--First SubsetAgent in the input capabilities XML is used as the default.--><ecs:SUBAGENT_ID><ecs:value>HEG</ecs:value></ecs:SUBAGENT_ID><!-- hardcode to async for Reverb services --><ecs:REQUEST_MODE>async</ecs:REQUEST_MODE><ecs:SPATIAL_MSG>Click the checkbox to enable spatial subsetting.</ecs:SPATIAL_MSG><ecs:PROJ_MSG_1>CAUTION: Re-projection parameters may alter results.</ecs:PROJ_MSG_1><ecs:PROJ_MSG_2>Leave blank to choose default values for each re-projected granule.</ecs:PROJ_MSG_2><ecs:INTRPL_MSG_1>Used to calculate data of resampled and reprojected pixels.</ecs:INTRPL_MSG_1><ecs:HEG-request><!--Need to populate BBOX in final ESI request as follows: "&BBOX=ullon,lrlat,lrlon,ullat"--><ecs:spatial_subsetting><ecs:boundingbox><ecs:ullat>90</ecs:ullat><ecs:ullon>-180</ecs:ullon><ecs:lrlat>-90</ecs:lrlat><ecs:lrlon>180</ecs:lrlon></ecs:boundingbox></ecs:spatial_subsetting><ecs:band_subsetting><ecs:SUBSET_DATA_LAYERS style="tree"><ecs:MI1B2E><ecs:dataset>/MI1B2E/BlueBand</ecs:dataset><ecs:dataset>/MI1B2E/BRF Conversion Factors</ecs:dataset><ecs:dataset>/MI1B2E/GeometricParameters</ecs:dataset><ecs:dataset>/MI1B2E/NIRBand</ecs:dataset><ecs:dataset>/MI1B2E/RedBand</ecs:dataset></ecs:MI1B2E></ecs:SUBSET_DATA_LAYERS></ecs:band_subsetting><!--First Format in the input XML is used as the default.--><ecs:FORMAT><ecs:value>HDF-EOS</ecs:value></ecs:FORMAT><!-- OUTPUT_GRID is never used in ESI (but should be enabled for SSW)--><!-- FILE_IDS must be injected by Reverb --><!-- FILE_URLS is not used in requests from ECHO, Use FILE_IDS instead --><ecs:projection_options><ecs:PROJECTION><ecs:value>LAMBERT AZIMUTHAL</ecs:value></ecs:PROJECTION><!--In final ESI request, projection parameters should be included as follows: "&PROJECTION_PARAMETERS=param1:value1,param2:value2,...paramn:valuen"--><ecs:PROJECTION_PARAMETERS><ecs:LAMBERT_AZIMUTHAL_projection><ecs:Sphere>45</ecs:Sphere><ecs:FE>54</ecs:FE></ecs:LAMBERT_AZIMUTHAL_projection></ecs:PROJECTION_PARAMETERS></ecs:projection_options><ecs:advanced_file_options><!--In final ESI request, resample options should be formatted like: "&RESAMPLE=dimension:value"--><ecs:RESAMPLE><ecs:GEOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:GEOGRAPHIC-dimension><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:STATE_PLANE-dimension><ecs:value>PERCENT</ecs:value></ecs:STATE_PLANE-dimension><ecs:ALBERS-dimension><ecs:value>PERCENT</ecs:value></ecs:ALBERS-dimension><ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:MERCATOR-dimension><ecs:POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:POLAR_STEREOGRAPHIC-dimension><ecs:TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:TRANSVERSE_MERCATOR-dimension><ecs:LAMBERT_AZIMUTHAL-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_AZIMUTHAL-dimension><ecs:SINUSOIDAL-dimension><ecs:value>PERCENT</ecs:value></ecs:SINUSOIDAL-dimension><ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:value>PERCENT</ecs:value></ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:NO_CHANGE-dimension><ecs:value>PERCENT</ecs:value></ecs:NO_CHANGE-dimension><ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:GEOGRAPHIC-PERCENT-value>100</ecs:GEOGRAPHIC-PERCENT-value><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value><ecs:STATE_PLANE-PERCENT-value>100</ecs:STATE_PLANE-PERCENT-value><ecs:ALBERS-PERCENT-value>100</ecs:ALBERS-PERCENT-value><ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value>100</ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value><ecs:MERCATOR-PERCENT-value>100</ecs:MERCATOR-PERCENT-value><ecs:POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:POLAR_STEREOGRAPHIC-PERCENT-value><ecs:TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:TRANSVERSE_MERCATOR-PERCENT-value><ecs:LAMBERT_AZIMUTHAL-PERCENT-value>100</ecs:LAMBERT_AZIMUTHAL-PERCENT-value><ecs:SINUSOIDAL-PERCENT-value>100</ecs:SINUSOIDAL-PERCENT-value><ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value>100</ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value><ecs:NO_CHANGE-PERCENT-value>100</ecs:NO_CHANGE-PERCENT-value><ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value><ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value></ecs:RESAMPLE><ecs:INTERPOLATION><ecs:value>CC</ecs:value></ecs:INTERPOLATION><!--INCLUDE_META needs to be converted from true/false here to Y/N in the request.--><ecs:INCLUDE_META>true</ecs:INCLUDE_META></ecs:advanced_file_options><ecs:spatial_subset_flag>true</ecs:spatial_subset_flag><ecs:band_subset_flag>true</ecs:band_subset_flag><ecs:temporal_subset_flag>false</ecs:temporal_subset_flag></ecs:HEG-request></ecs:esi-xml></ecs:options>',
+            url: 'https://n5eil09e.ecs.edsc.org/egi/request'
+          },
+          granule_params: {
+            collection_concept_id: 'C100000-EDSC'
+          }
+        }])
+      } else {
+        query.response([])
+      }
+    })
+
+    const context = {}
+
+    await expect(submitCatalogRestOrder(mockCatalogRestOrder, context)).rejects.toEqual(new Error('Unknown Error'))
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toEqual('first')
+    expect(queries[1].method).toEqual('update')
+    expect(queries[1].bindings).toEqual(['create_failed', 'Unknown Error', 12])
+  })
+
   test('saves an error message if the create fails', async () => {
     jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
       cmrHost: 'https://cmr.earthdata.nasa.gov',

--- a/serverless/src/submitCatalogRestOrder/handler.js
+++ b/serverless/src/submitCatalogRestOrder/handler.js
@@ -190,7 +190,8 @@ const submitCatalogRestOrder = async (event, context) => {
       const [errorMessage] = parsedErrorMessage
 
       await dbConnection('retrieval_orders').update({
-        state: 'create_failed'
+        state: 'create_failed',
+        error: errorMessage
       }).where({ id })
 
       // Re-throw the error so the state machine handles the error correctly

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -318,6 +318,7 @@ describe('submitHarmonyOrder', () => {
     expect(queries[0].method).toEqual('first')
     expect(queries[1].method).toEqual('first')
     expect(queries[2].method).toEqual('update')
+    expect(queries[2].bindings).toEqual(['create_failed', 'Error: You are not authorized to access the requested resource', 12])
 
     expect(consoleMock).toBeCalledTimes(2)
     expect(consoleMock.mock.calls[0]).toEqual(['Processing 1 order(s)'])

--- a/serverless/src/submitHarmonyOrder/handler.js
+++ b/serverless/src/submitHarmonyOrder/handler.js
@@ -132,7 +132,8 @@ const submitHarmonyOrder = async (event, context) => {
       const [errorMessage] = parsedErrorMessage
 
       await dbConnection('retrieval_orders').update({
-        state: 'create_failed'
+        state: 'create_failed',
+        error: errorMessage
       }).where({ id })
 
       // Re-throw the error so the state machine handles the error correctly

--- a/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
@@ -175,4 +175,65 @@ describe('submitLegacyServicesOrder', () => {
     expect(queries[1].method).toEqual('update')
     expect(startOrderStatusUpdateWorkflowMock).toBeCalledWith(12, 'access-token:clientId', 'ECHO ORDERS')
   })
+
+  test('saves an error message if the create fails', async () => {
+    const accessMethodModel = '<ecs:options xmlns:ecs="http://ecs.nasa.gov/options"><ecs:distribution xmlns="http://ecs.nasa.gov/options"><ecs:mediatype><ecs:value>HTTPS</ecs:value></ecs:mediatype><ecs:mediaformat><ecs:ftppull-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppull-format><ecs:ftppush-format><ecs:value>FILEFORMAT</ecs:value></ecs:ftppush-format></ecs:mediaformat></ecs:distribution><ecs:ancillary xmlns="http://ecs.nasa.gov/options"><ecs:orderPH>false</ecs:orderPH><ecs:orderQA>false</ecs:orderQA><ecs:orderHDF_MAP>false</ecs:orderHDF_MAP><ecs:orderBrowse>false</ecs:orderBrowse></ecs:ancillary><ecs:esi-xml><!--NOTE: elements in caps losely match the ESI API, those in lowercase are helper elements --><!--Dataset ID will be injected by Reverb--><ecs:CLIENT>ESI</ecs:CLIENT><!--First SubsetAgent in the input capabilities XML is used as the default.--><ecs:SUBAGENT_ID><ecs:value>HEG</ecs:value></ecs:SUBAGENT_ID><!-- hardcode to async for Reverb services --><ecs:REQUEST_MODE>async</ecs:REQUEST_MODE><ecs:SPATIAL_MSG>Click the checkbox to enable spatial subsetting.</ecs:SPATIAL_MSG><ecs:PROJ_MSG_1>CAUTION: Re-projection parameters may alter results.</ecs:PROJ_MSG_1><ecs:PROJ_MSG_2>Leave blank to choose default values for each re-projected granule.</ecs:PROJ_MSG_2><ecs:INTRPL_MSG_1>Used to calculate data of resampled and reprojected pixels.</ecs:INTRPL_MSG_1><ecs:HEG-request><!--Need to populate BBOX in final ESI request as follows: "&BBOX=ullon,lrlat,lrlon,ullat"--><ecs:spatial_subsetting><ecs:boundingbox><ecs:ullat>90</ecs:ullat><ecs:ullon>-180</ecs:ullon><ecs:lrlat>-90</ecs:lrlat><ecs:lrlon>180</ecs:lrlon></ecs:boundingbox></ecs:spatial_subsetting><ecs:band_subsetting><ecs:SUBSET_DATA_LAYERS style="tree"><ecs:MI1B2E><ecs:dataset>/MI1B2E/BlueBand</ecs:dataset><ecs:dataset>/MI1B2E/BRF Conversion Factors</ecs:dataset><ecs:dataset>/MI1B2E/GeometricParameters</ecs:dataset><ecs:dataset>/MI1B2E/NIRBand</ecs:dataset><ecs:dataset>/MI1B2E/RedBand</ecs:dataset></ecs:MI1B2E></ecs:SUBSET_DATA_LAYERS></ecs:band_subsetting><!--First Format in the input XML is used as the default.--><ecs:FORMAT><ecs:value>HDF-EOS</ecs:value></ecs:FORMAT><!-- OUTPUT_GRID is never used in ESI (but should be enabled for SSW)--><!-- FILE_IDS must be injected by Reverb --><!-- FILE_URLS is not used in requests from ECHO, Use FILE_IDS instead --><ecs:projection_options><ecs:PROJECTION><ecs:value>LAMBERT AZIMUTHAL</ecs:value></ecs:PROJECTION><!--In final ESI request, projection parameters should be included as follows: "&PROJECTION_PARAMETERS=param1:value1,param2:value2,...paramn:valuen"--><ecs:PROJECTION_PARAMETERS><ecs:LAMBERT_AZIMUTHAL_projection><ecs:Sphere>45</ecs:Sphere><ecs:FE>54</ecs:FE></ecs:LAMBERT_AZIMUTHAL_projection></ecs:PROJECTION_PARAMETERS></ecs:projection_options><ecs:advanced_file_options><!--In final ESI request, resample options should be formatted like: "&RESAMPLE=dimension:value"--><ecs:RESAMPLE><ecs:GEOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:GEOGRAPHIC-dimension><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:UNIVERSAL_TRANSVERSE_MERCATOR-dimension><ecs:STATE_PLANE-dimension><ecs:value>PERCENT</ecs:value></ecs:STATE_PLANE-dimension><ecs:ALBERS-dimension><ecs:value>PERCENT</ecs:value></ecs:ALBERS-dimension><ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_CONFORMAL_CONIC-dimension><ecs:MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:MERCATOR-dimension><ecs:POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:POLAR_STEREOGRAPHIC-dimension><ecs:TRANSVERSE_MERCATOR-dimension><ecs:value>PERCENT</ecs:value></ecs:TRANSVERSE_MERCATOR-dimension><ecs:LAMBERT_AZIMUTHAL-dimension><ecs:value>PERCENT</ecs:value></ecs:LAMBERT_AZIMUTHAL-dimension><ecs:SINUSOIDAL-dimension><ecs:value>PERCENT</ecs:value></ecs:SINUSOIDAL-dimension><ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:value>PERCENT</ecs:value></ecs:CYLINDRICAL_EQUAL_AREA-dimension><ecs:NO_CHANGE-dimension><ecs:value>PERCENT</ecs:value></ecs:NO_CHANGE-dimension><ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:NORTH_POLAR_STEREOGRAPHIC-dimension><ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:value>PERCENT</ecs:value></ecs:SOUTH_POLAR_STEREOGRAPHIC-dimension><ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_NORTHERN_HEMISPHERE-dimension><ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:value>PERCENT</ecs:value></ecs:UTM_SOUTHERN_HEMISPHERE-dimension><ecs:GEOGRAPHIC-PERCENT-value>100</ecs:GEOGRAPHIC-PERCENT-value><ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:UNIVERSAL_TRANSVERSE_MERCATOR-PERCENT-value><ecs:STATE_PLANE-PERCENT-value>100</ecs:STATE_PLANE-PERCENT-value><ecs:ALBERS-PERCENT-value>100</ecs:ALBERS-PERCENT-value><ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value>100</ecs:LAMBERT_CONFORMAL_CONIC-PERCENT-value><ecs:MERCATOR-PERCENT-value>100</ecs:MERCATOR-PERCENT-value><ecs:POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:POLAR_STEREOGRAPHIC-PERCENT-value><ecs:TRANSVERSE_MERCATOR-PERCENT-value>100</ecs:TRANSVERSE_MERCATOR-PERCENT-value><ecs:LAMBERT_AZIMUTHAL-PERCENT-value>100</ecs:LAMBERT_AZIMUTHAL-PERCENT-value><ecs:SINUSOIDAL-PERCENT-value>100</ecs:SINUSOIDAL-PERCENT-value><ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value>100</ecs:CYLINDRICAL_EQUAL_AREA-PERCENT-value><ecs:NO_CHANGE-PERCENT-value>100</ecs:NO_CHANGE-PERCENT-value><ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:NORTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value>100</ecs:SOUTH_POLAR_STEREOGRAPHIC-PERCENT-value><ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_NORTHERN_HEMISPHERE-PERCENT-value><ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value>100</ecs:UTM_SOUTHERN_HEMISPHERE-PERCENT-value></ecs:RESAMPLE><ecs:INTERPOLATION><ecs:value>CC</ecs:value></ecs:INTERPOLATION><!--INCLUDE_META needs to be converted from true/false here to Y/N in the request.--><ecs:INCLUDE_META>true</ecs:INCLUDE_META></ecs:advanced_file_options><ecs:spatial_subset_flag>true</ecs:spatial_subset_flag><ecs:band_subset_flag>true</ecs:band_subset_flag><ecs:temporal_subset_flag>false</ecs:temporal_subset_flag></ecs:HEG-request></ecs:esi-xml></ecs:options>'
+    const accessMethod = {
+      option_definition: {
+        id: '1234-asdf-5678-hjkl',
+        name: 'Delivery Option'
+      },
+      type: 'ECHO ORDERS',
+      model: accessMethodModel,
+      url: 'https://n5eil09e.ecs.edsc.org/egi/request'
+    }
+
+    const echoProfile = {
+      user_domain: 'OTHER',
+      user_region: 'USA'
+    }
+
+    const ursProfile = {
+      uid: 'edsc-user',
+      country: 'United States',
+      last_name: 'User',
+      first_name: 'EDSC',
+      email_address: 'edsc@search.earthdata.nasa.gov',
+      organization: 'Earthdadta Search'
+    }
+
+    nock(/cmr/)
+      .post(/orders\.json/)
+      .reply(500, {
+        errorType: 'Error',
+        errorMessage: 'Unknown Error',
+        stack: [
+          'Error: Unknown Error'
+        ]
+      })
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response({
+          id: 2,
+          access_method: accessMethod,
+          environment: 'prod',
+          granule_params: {},
+          echo_profile: echoProfile,
+          urs_profile: ursProfile
+        })
+      } else if (step === 2) {
+        query.response([])
+      }
+    })
+
+    const context = {}
+    await expect(submitLegacyServicesOrder(mockLegacyServicesOrder, context)).rejects.toEqual(new Error('Unknown Error'))
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toEqual('first')
+    expect(queries[1].method).toEqual('update')
+    expect(queries[1].bindings).toEqual(['create_failed', 'Unknown Error', 12])
+  })
 })

--- a/serverless/src/submitLegacyServicesOrder/handler.js
+++ b/serverless/src/submitLegacyServicesOrder/handler.js
@@ -142,7 +142,8 @@ const submitLegacyServicesOrder = async (event, context) => {
       const [errorMessage] = parsedErrorMessage
 
       await dbConnection('retrieval_orders').update({
-        state: 'create_failed'
+        state: 'create_failed',
+        error: errorMessage
       }).where({ id })
 
       // Re-throw the error so the state machine handles the error correctly

--- a/sharedUtils/__tests__/parseError.test.js
+++ b/sharedUtils/__tests__/parseError.test.js
@@ -440,5 +440,37 @@ describe('parseError', () => {
         })
       })
     })
+
+    describe('when the content type is text/html', () => {
+      test('returns an error string with the status code and status text', () => {
+        const consoleMock = jest.spyOn(console, 'log')
+
+        const response = parseError({
+          isAxiosError: true,
+          response: {
+            headers: {
+              'content-type': 'text/html; charset=utf-8'
+            },
+            data: {
+              errors: [
+                '400 Bad Request'
+              ]
+            },
+            status: 401,
+            statusText: 'Unauthorized'
+          },
+          name: 'Error'
+        }, {
+          asJSON: false,
+          shouldLog: false
+        })
+
+        expect(consoleMock).toBeCalledTimes(0)
+
+        expect(response).toEqual([
+          'Error (401): Unauthorized'
+        ])
+      })
+    })
   })
 })

--- a/sharedUtils/parseError.js
+++ b/sharedUtils/parseError.js
@@ -12,8 +12,10 @@ export const parseError = (errorObj, {
 } = {}) => {
   const {
     name = 'Error',
-    response = {}
+    response = {},
+    options = {}
   } = errorObj
+  const { uri = '' } = options
 
   let errorArray = []
   let code = 500
@@ -68,6 +70,10 @@ export const parseError = (errorObj, {
     } else if (description) {
       // Harmony uses code/description object in the response
       errorArray = [description]
+    } else if (uri.includes('egi')) {
+      // EGI errors need to be parsed
+      const { error: egiError = 'Unknown Error' } = JSON.parse(responseBody)
+      errorArray = [egiError]
     } else {
       // Default to CMR error response body
       ({ errors: errorArray = ['Unknown Error'] } = responseBody)

--- a/sharedUtils/parseError.js
+++ b/sharedUtils/parseError.js
@@ -13,9 +13,8 @@ export const parseError = (errorObj, {
   const {
     name = 'Error',
     response = {},
-    options = {}
+    isAxiosError
   } = errorObj
-  const { uri = '' } = options
 
   let errorArray = []
   let code = 500
@@ -26,7 +25,8 @@ export const parseError = (errorObj, {
       data = {},
       headers = {},
       status,
-      statusCode
+      statusCode,
+      statusText
     } = response
 
     // The request-promise library uses `body` for the response body
@@ -70,10 +70,9 @@ export const parseError = (errorObj, {
     } else if (description) {
       // Harmony uses code/description object in the response
       errorArray = [description]
-    } else if (uri.includes('egi')) {
-      // EGI errors need to be parsed
-      const { error: egiError = 'Unknown Error' } = JSON.parse(responseBody)
-      errorArray = [egiError]
+    } else if (isAxiosError && contentType.indexOf('text/html') > -1) {
+      // If the error is from Axios and the content type is html, build a string error using the status code and status text
+      errorArray = [`${name} (${code}): ${statusText}`]
     } else {
       // Default to CMR error response body
       ({ errors: errorArray = ['Unknown Error'] } = responseBody)

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -378,7 +378,7 @@ export class OrderStatusItem extends PureComponent {
       const isEchoOrders = typeToLower === 'echo orders'
       const isEsi = typeToLower === 'esi'
 
-      const message = []
+      const messages = []
       let messageIsError = false
       let orderInfo = null
 
@@ -455,8 +455,15 @@ export class OrderStatusItem extends PureComponent {
 
             const {
               downloadUrls: currentDownloadUrlsObject = {},
+              // processInfo = {},
               requestStatus = {}
             } = orderInformation
+
+            // processInfo will be where the info messages from EGI are stored
+            // This will implemented in EDSC-2983
+            // const { message } = processInfo
+
+            // messages.push([...Array.from(message)])
 
             const { downloadUrl: currentDownloadUrls = [] } = currentDownloadUrlsObject
 
@@ -503,11 +510,11 @@ export class OrderStatusItem extends PureComponent {
             }
 
             if (status === 'successful' && !jobId) {
-              message.push(harmonyMessage)
+              messages.push(harmonyMessage)
             }
 
             if (status === 'failed' && harmonyMessage) {
-              message.push(harmonyMessage)
+              messages.push(harmonyMessage)
               messageIsError = messageIsError || true
             }
 
@@ -669,12 +676,12 @@ export class OrderStatusItem extends PureComponent {
                   </div>
                   <div className="order-status-item__additional-info">
                     {
-                      message.length > 0 && (
+                      messages.length > 0 && (
                         <div className={`order-status-item__message${messageIsError ? ' order-status-item__message--is-error' : ''}`}>
                           <h3 className="order-status-item__message-heading">Service has responded with message:</h3>
                           <ul className="order-status-item__message-body">
                             {
-                              message.map((message, i) => {
+                              messages.map((message, i) => {
                                 const key = `message-${i}`
                                 return (
                                   <li key={key}>{message}</li>

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -451,7 +451,12 @@ export class OrderStatusItem extends PureComponent {
           }
 
           orders.forEach((order) => {
-            const { order_information: orderInformation = {} } = order
+            const {
+              error,
+              order_information: orderInformation = {}
+            } = order
+
+            if (error) messages.push(error)
 
             const {
               downloadUrls: currentDownloadUrlsObject = {},

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -493,7 +493,7 @@ describe('OrderStatusItem', () => {
     describe('when the order created', () => {
       test('renders creating state', () => {
         const { enzymeWrapper } = setup({
-          type: 'harmony',
+          type: 'esi',
           collection: {
             id: 1,
             collection_id: 'TEST_COLLECTION_111',


### PR DESCRIPTION
# Overview

### What is the feature?

EDSC Order Status should reveal full error message

### What is the Solution?

Save errors generated when an order is created, display that error on the order status page

### What areas of the application does this impact?

Orders

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
