### PR TITLE
EDSC-2987: Fixes view all facets

### DIFF
--- a/static/src/js/actions/__tests__/viewAllFacets.test.js
+++ b/static/src/js/actions/__tests__/viewAllFacets.test.js
@@ -206,7 +206,7 @@ describe('getViewAllFacets', () => {
 
   const facetsPayload = {
     hits: 1,
-    selectedCategory: undefined,
+    selectedCategory: 'Instruments',
     facets: {
       instrument: {
         applied: true,
@@ -503,7 +503,10 @@ describe('changeViewAllFacet', () => {
 
     // call the dispatch
     const newFacets = { instrument_h: ['1 Test facet', 'Test facet 2', 'And another'] }
-    store.dispatch(changeViewAllFacet(newFacets))
+    store.dispatch(changeViewAllFacet({
+      params: newFacets,
+      selectedCategory: 'Instruments'
+    }))
 
     const storeActions = store.getActions()
     expect(storeActions[0]).toEqual({
@@ -520,7 +523,7 @@ describe('changeViewAllFacet', () => {
     expect(storeActions[1]).toEqual({
       type: LOADING_VIEW_ALL_FACETS,
       payload: {
-        selectedCategory: ''
+        selectedCategory: 'Instruments'
       }
     })
   })

--- a/static/src/js/actions/viewAllFacets.js
+++ b/static/src/js/actions/viewAllFacets.js
@@ -75,7 +75,9 @@ export const getViewAllFacets = (category = '') => (dispatch, getState) => {
   dispatch(onViewAllFacetsLoading(category))
   dispatch(toggleFacetsModal(true))
 
-  const collectionParams = prepareCollectionParams(state)
+  // onViewAllFacetsLoading changes the state, use getState() again here to ensure the
+  // collection request has the updated state
+  const collectionParams = prepareCollectionParams(getState())
 
   const requestObject = new CollectionRequest(authToken, earthdataEnvironment)
 
@@ -83,7 +85,7 @@ export const getViewAllFacets = (category = '') => (dispatch, getState) => {
     .then((response) => {
       const payload = {}
 
-      payload.selectedCategory = collectionParams.viewAllFacetsCategory
+      payload.selectedCategory = category
       payload.facets = response.data.feed.facets.children || []
       payload.hits = parseInt(response.headers['cmr-hits'], 10)
 
@@ -115,7 +117,8 @@ export const triggerViewAllFacets = category => (dispatch) => {
   dispatch(getViewAllFacets(category))
 }
 
-export const changeViewAllFacet = newParams => (dispatch) => {
-  dispatch(updateViewAllFacet(newParams))
-  dispatch(getViewAllFacets())
+export const changeViewAllFacet = data => (dispatch) => {
+  const { params, selectedCategory } = data
+  dispatch(updateViewAllFacet(params))
+  dispatch(getViewAllFacets(selectedCategory))
 }

--- a/static/src/js/components/Facets/FacetsModal.js
+++ b/static/src/js/components/Facets/FacetsModal.js
@@ -45,7 +45,10 @@ export class FacetsModal extends Component {
     const isFirstLoad = isLoading && !viewAllFacets.allIds.length
 
     const viewAllFacetHandler = (e, facetLinkInfo) => {
-      changeViewAllFacet(e, facetLinkInfo, onChangeViewAllFacet)
+      changeViewAllFacet(e, {
+        params: facetLinkInfo,
+        selectedCategory
+      }, onChangeViewAllFacet)
     }
 
     if (!selectedCategory) return null

--- a/static/src/js/util/facets.js
+++ b/static/src/js/util/facets.js
@@ -105,7 +105,8 @@ export const changeCmrFacet = (e, facetLinkInfo, onChangeHandler, facet, applied
  * @param {object} onChangeHandler - The change handler to call.
  */
 export const changeViewAllFacet = (e, facetLinkInfo, onChangeHandler) => {
-  const newParams = qs.parse(queryParamsFromUrlString(facetLinkInfo.destination))
+  const { params, selectedCategory } = facetLinkInfo
+  const newParams = qs.parse(queryParamsFromUrlString(params.destination))
 
   const paramsToSend = {
     data_center_h: newParams.data_center_h,
@@ -118,7 +119,10 @@ export const changeViewAllFacet = (e, facetLinkInfo, onChangeHandler) => {
     horizontal_data_resolution_range: newParams.horizontal_data_resolution_range
   }
 
-  onChangeHandler(paramsToSend)
+  onChangeHandler({
+    params: paramsToSend,
+    selectedCategory
+  })
 }
 
 /**


### PR DESCRIPTION
# Overview

### What is the feature?

The `View All Facets` modal is not being populated with facets results

### What is the Solution?

The View All request was not happening with the correct parameters because the request was using outdated redux state to build the parameters, and we were not populating the modal with the values return. Also some additional cleanup of the view all facets logic

### What areas of the application does this impact?

View All Facets

# Testing

### Reproduction steps

Expand the `Platforms` facet group and click the `View All` link. You should see significantly more facets than the expanded group shows.
Additionally test selecting and deselecting the facets from the modal

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
