### PR TITLE
EDSC-2977: Use 'Echo-Token' header for tagging calls

### DIFF
--- a/serverless/src/fetchOptionDefinitions/__tests__/handler.test.js
+++ b/serverless/src/fetchOptionDefinitions/__tests__/handler.test.js
@@ -46,6 +46,7 @@ describe('fetchOptionDefinitions', () => {
     jest.spyOn(getSingleGranule, 'getSingleGranule').mockImplementationOnce(() => ({ id: 'G10000001-EDSC' }))
 
     nock(/echorest/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .post(/order_information/)
       .reply(200, [{
         order_information: {
@@ -124,6 +125,7 @@ describe('fetchOptionDefinitions', () => {
     jest.spyOn(getSingleGranule, 'getSingleGranule').mockImplementationOnce(() => ({ id: 'G10000001-EDSC' }))
 
     nock(/echorest/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .post(/order_information/)
       .reply(200, [{
         order_information: {}
@@ -179,6 +181,7 @@ describe('fetchOptionDefinitions', () => {
     jest.spyOn(getSingleGranule, 'getSingleGranule').mockImplementationOnce(() => ({ id: 'G10000001-EDSC' }))
 
     nock(/echorest/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .post(/order_information/)
       .reply(200, [])
 
@@ -228,6 +231,7 @@ describe('fetchOptionDefinitions', () => {
     jest.spyOn(getSingleGranule, 'getSingleGranule').mockImplementationOnce(() => ({ id: 'G10000001-EDSC' }))
 
     nock(/echorest/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .post(/order_information/)
       .reply(200, [{
         order_information: {
@@ -288,6 +292,7 @@ describe('fetchOptionDefinitions', () => {
     jest.spyOn(getSingleGranule, 'getSingleGranule').mockImplementationOnce(() => ({ id: 'G10000001-EDSC' }))
 
     nock(/echorest/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .post(/order_information/)
       .reply(500, {
         errors: [

--- a/serverless/src/fetchOptionDefinitions/handler.js
+++ b/serverless/src/fetchOptionDefinitions/handler.js
@@ -60,9 +60,9 @@ const fetchOptionDefinitions = async (event, context) => {
           'catalog_item_id[]': granuleId
         }, { indices: false, arrayFormat: 'brackets' }),
         headers: {
-          Authorization: `Bearer ${cmrToken}`,
           'Client-Id': getClientId().background,
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Echo-Token': cmrToken
         },
         json: true,
         resolveWithFullResponse: true

--- a/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
@@ -51,6 +51,7 @@ describe('generateCollectionCapabilityTags', () => {
       }))
 
       nock(/cmr/)
+        .matchHeader('Echo-Token', 'mocked-system-token')
         .post(/collections/)
         .reply(200, {
           feed: {
@@ -102,6 +103,7 @@ describe('generateCollectionCapabilityTags', () => {
       }))
 
       nock(/cmr/)
+        .matchHeader('Echo-Token', 'mocked-system-token')
         .post(/collections/)
         .reply(200, {
           feed: {

--- a/serverless/src/generateCollectionCapabilityTags/handler.js
+++ b/serverless/src/generateCollectionCapabilityTags/handler.js
@@ -48,9 +48,9 @@ const generateCollectionCapabilityTags = async (input) => {
     uri: collectionSearchUrl,
     form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
     headers: {
-      Authorization: `Bearer ${cmrToken}`,
       'Client-Id': getClientId().background,
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Echo-Token': cmrToken
     },
     json: true,
     resolveWithFullResponse: true

--- a/serverless/src/generateSubsettingTags/__tests__/handler.test.js
+++ b/serverless/src/generateSubsettingTags/__tests__/handler.test.js
@@ -32,6 +32,7 @@ describe('generateSubsettingTags', () => {
     jest.spyOn(getSystemToken, 'getSystemToken').mockImplementation(() => 'mocked-system-token')
 
     nock(/cmr/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .get(/service_option_assignments/)
       .reply(200, [
         {
@@ -46,6 +47,7 @@ describe('generateSubsettingTags', () => {
       ])
 
     nock(/cmr/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .get(/service_option_definitions/)
       .reply(200, [
         {
@@ -274,6 +276,7 @@ describe('generateSubsettingTags', () => {
 
   test('catches and logs errors from the service option assignments http request correctly', async () => {
     nock(/cmr/)
+      .matchHeader('Echo-Token', 'mocked-system-token')
       .get(/service_option_assignments/)
       .reply(500, {
         errors: [

--- a/serverless/src/generateSubsettingTags/getServiceOptionDefinitionIdNamePairs.js
+++ b/serverless/src/generateSubsettingTags/getServiceOptionDefinitionIdNamePairs.js
@@ -34,7 +34,7 @@ export const getServiceOptionDefinitionIdNamePairs = async (cmrToken, serviceOpt
         uri: `${serviceOptionDefinitionUrl}?${serviceOptionQueryParams}`,
         headers: {
           'Client-Id': getClientId().background,
-          'Echo-Client': cmrToken
+          'Echo-Token': cmrToken
         },
         json: true,
         resolveWithFullResponse: true

--- a/serverless/src/generateSubsettingTags/handler.js
+++ b/serverless/src/generateSubsettingTags/handler.js
@@ -54,7 +54,7 @@ const generateSubsettingTags = async (event, context) => {
       uri: serviceOptionAssignmentUrl,
       headers: {
         'Client-Id': getClientId().background,
-        'Echo-Client': cmrToken
+        'Echo-Token': cmrToken
       },
       json: true,
       resolveWithFullResponse: true

--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -13,6 +13,7 @@ beforeEach(() => {
 describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data existed', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -28,6 +29,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -52,6 +54,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when the tag is not already associated with the collection', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -64,6 +67,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -88,6 +92,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when the tag data already exists', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -107,6 +112,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -131,6 +137,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when new tag data is provided', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -150,6 +157,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -176,6 +184,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when append is set to false', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -195,6 +204,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -219,6 +229,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when requireGranules is set to true (and append is set to true)', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -238,6 +249,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -264,6 +276,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))
@@ -290,6 +303,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when no tag data is provided but granules are required', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -309,6 +323,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC'
@@ -328,6 +343,7 @@ describe('addTag', () => {
 
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -349,6 +365,7 @@ describe('addTag', () => {
 
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -368,6 +385,7 @@ describe('addTag', () => {
       })
 
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -396,6 +414,7 @@ describe('addTag', () => {
 
   test('does not call the cmr endpoint when tag data is provided but no collections are returned from the collection search endpoint', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -419,6 +438,7 @@ describe('addTag', () => {
 
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
+      .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))

--- a/serverless/src/processTag/__tests__/removeTag.test.js
+++ b/serverless/src/processTag/__tests__/removeTag.test.js
@@ -24,8 +24,8 @@ describe('removeTag', () => {
     expect(cmrDeleteMock).toBeCalledWith({
       uri: 'http://example.com/search/tags/edsc.extra.gibs/associations/by_query',
       headers: {
-        Authorization: 'Bearer 1234-abcd-5678-efgh',
-        'Client-Id': 'eed-edsc-test-serverless-background'
+        'Client-Id': 'eed-edsc-test-serverless-background',
+        'Echo-Token': '1234-abcd-5678-efgh'
       },
       body: { short_name: 'MIL3MLS' },
       json: true,
@@ -55,8 +55,8 @@ describe('removeTag', () => {
     expect(cmrDeleteMock).toBeCalledWith({
       uri: 'http://example.com/search/tags/edsc.extra.gibs/associations/by_query',
       headers: {
-        Authorization: 'Bearer 1234-abcd-5678-efgh',
-        'Client-Id': 'eed-edsc-test-serverless-background'
+        'Client-Id': 'eed-edsc-test-serverless-background',
+        'Echo-Token': '1234-abcd-5678-efgh'
       },
       body: { short_name: 'MIL3MLS' },
       json: true,

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -42,8 +42,8 @@ export async function addTag({
       const collectionJsonResponse = await request.post({
         uri: `${getEarthdataConfig(deployedEnvironment()).cmrHost}/search/collections.json?${stringify(cmrParams)}`,
         headers: {
-          Authorization: `Bearer ${cmrToken}`,
-          'Client-Id': getClientId().background
+          'Client-Id': getClientId().background,
+          'Echo-Token': cmrToken
         },
         body: searchCriteria,
         json: true,
@@ -101,8 +101,8 @@ export async function addTag({
       const taggingResponse = await request.post({
         uri: addTagUrl,
         headers: {
-          Authorization: `Bearer ${cmrToken}`,
-          'Client-Id': getClientId().background
+          'Client-Id': getClientId().background,
+          'Echo-Token': cmrToken
         },
         body: castArray(associationData),
         json: true,
@@ -132,8 +132,8 @@ export async function addTag({
     await request.post({
       uri: tagRemovalUrl,
       headers: {
-        Authorization: `Bearer ${cmrToken}`,
-        'Client-Id': getClientId().background
+        'Client-Id': getClientId().background,
+        'Echo-Token': cmrToken
       },
       body: searchCriteria,
       json: true,

--- a/serverless/src/processTag/removeTag.js
+++ b/serverless/src/processTag/removeTag.js
@@ -16,8 +16,8 @@ export async function removeTag(tagName, searchCriteria, cmrToken) {
     await request.delete({
       uri: tagRemovalUrl,
       headers: {
-        Authorization: `Bearer ${cmrToken}`,
-        'Client-Id': getClientId().background
+        'Client-Id': getClientId().background,
+        'Echo-Token': cmrToken
       },
       body: searchCriteria,
       json: true,

--- a/serverless/src/util/cmr/__tests__/getSingleGranule.test.js
+++ b/serverless/src/util/cmr/__tests__/getSingleGranule.test.js
@@ -11,6 +11,7 @@ describe('getSingleGranule', () => {
     }))
 
     nock(/cmr/)
+      .matchHeader('Echo-Token', 'token')
       .post(/granules/)
       .reply(200, {
         feed: {

--- a/serverless/src/util/cmr/getSingleGranule.js
+++ b/serverless/src/util/cmr/getSingleGranule.js
@@ -29,9 +29,9 @@ export const getSingleGranule = async (cmrToken, collectionId) => {
     uri: granuleSearchUrl,
     form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
     headers: {
-      Authorization: `Bearer ${cmrToken}`,
       'Client-Id': getClientId().background,
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Echo-Token': cmrToken
     },
     json: true,
     resolveWithFullResponse: true,

--- a/serverless/src/util/cmr/pageAllCmrResults.js
+++ b/serverless/src/util/cmr/pageAllCmrResults.js
@@ -36,9 +36,9 @@ export const pageAllCmrResults = async ({
       uri: `${cmrHost}/${path}`,
       form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
       headers: {
-        Authorization: `Bearer ${cmrToken}`,
         'Client-Id': getClientId().background,
         'Content-Type': 'application/x-www-form-urlencoded',
+        'Echo-Token': cmrToken,
         ...additionalHeaders
       },
       json: true,
@@ -67,9 +67,9 @@ export const pageAllCmrResults = async ({
           uri: `${cmrHost}/${path}`,
           form: stringify(cmrParams, { indices: false, arrayFormat: 'brackets' }),
           headers: {
-            Authorization: `Bearer ${cmrToken}`,
             'Client-Id': getClientId().background,
             'Content-Type': 'application/x-www-form-urlencoded',
+            'Echo-Token': cmrToken,
             ...additionalHeaders
           },
           json: true,


### PR DESCRIPTION
# Overview

### What is the feature?

Tagging calls use a system token, and need to use the 'Echo-Token' header instead of the 'Authorization' header

### What areas of the application does this impact?

Tagging
# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
