### PR TITLE
EDSC-2966: Fixes bug in selecting a new spatial drawing after downloading project

### DIFF
--- a/static/src/js/components/SpatialSelection/SpatialSelection.js
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.js
@@ -321,7 +321,7 @@ class SpatialSelection extends Component {
 
   onSpatialDropdownClick(event) {
     const { type } = event
-    if (this.drawControl) {
+    if (this.drawControl && this.drawControl._toolbars.draw._modes[type]) {
       this.drawControl._toolbars.draw._modes[type].handler.enable()
     }
   }

--- a/static/src/js/components/SpatialSelection/SpatialSelection.js
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.js
@@ -130,6 +130,9 @@ class SpatialSelection extends Component {
       const bounds = featureGroup.getBounds() || false
       panFeatureGroupToCenter(map, bounds)
     }
+
+    eventEmitter.on('map.drawStart', this.onSpatialDropdownClick)
+    eventEmitter.on('map.drawCancel', this.onDrawCancel)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -314,14 +317,11 @@ class SpatialSelection extends Component {
   // Callback from EditControl, called when the controls are mounted
   onMounted(drawControl) {
     this.drawControl = drawControl
-
-    eventEmitter.on('map.drawStart', this.onSpatialDropdownClick)
-    eventEmitter.on('map.drawCancel', this.onDrawCancel)
   }
 
   onSpatialDropdownClick(event) {
     const { type } = event
-    if (this.drawControl && this.drawControl._toolbars.draw._modes[type]) {
+    if (this.drawControl) {
       this.drawControl._toolbars.draw._modes[type].handler.enable()
     }
   }

--- a/static/src/js/components/SpatialSelection/__tests__/SpatialSelection.test.js
+++ b/static/src/js/components/SpatialSelection/__tests__/SpatialSelection.test.js
@@ -212,6 +212,22 @@ describe('SpatialSelection component', () => {
 
       expect(enableMock).toHaveBeenCalledTimes(1)
     })
+
+    test('does not try to enable the drawControl if the mode doesn\'t exist', () => {
+      const enableMock = jest.fn()
+      const { enzymeWrapper } = setup(defaultProps)
+
+      enzymeWrapper.instance().drawControl = {
+        _toolbars: {
+          draw: {
+            _modes: {}
+          }
+        }
+      }
+      enzymeWrapper.instance().onSpatialDropdownClick({ type: 'circle' })
+
+      expect(enableMock).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('onDrawStart', () => {

--- a/static/src/js/components/SpatialSelection/__tests__/SpatialSelection.test.js
+++ b/static/src/js/components/SpatialSelection/__tests__/SpatialSelection.test.js
@@ -212,22 +212,6 @@ describe('SpatialSelection component', () => {
 
       expect(enableMock).toHaveBeenCalledTimes(1)
     })
-
-    test('does not try to enable the drawControl if the mode doesn\'t exist', () => {
-      const enableMock = jest.fn()
-      const { enzymeWrapper } = setup(defaultProps)
-
-      enzymeWrapper.instance().drawControl = {
-        _toolbars: {
-          draw: {
-            _modes: {}
-          }
-        }
-      }
-      enzymeWrapper.instance().onSpatialDropdownClick({ type: 'circle' })
-
-      expect(enableMock).toHaveBeenCalledTimes(0)
-    })
   })
 
   describe('onDrawStart', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

After downloading data when spatial drawn, if the `Back to Project` & `Back to Search` buttons are used, selecting a new drawing from the spatial selection dropdown under the search bar throws an error and doesn't allow drawing a new spatial selection.

### What is the Solution?

The code that triggers the leaflet.draw toolbar should check that the right draw mode exists before trying to enable it

### What areas of the application does this impact?

Map

# Testing

### Reproduction steps

Search for any dataset and load granules
Draw a rectangle over your study area. (Mine was between West Palm Beach and Fort Lauderdale Florida but I think any location should work)
Add a couple of granules
Click on Download X granules button
Click on green download the data button.
Click "Back to Project"
Click "Back to search"
Click on the same data originally selected
Move to another study area. This time I am looking near Cape Cod but any area would work.
Click on the crop icon again and click on rectangle. Try to draw a rectangle over the new area. This is where I get stuck. Point also does not work.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
