### PR TITLE
EDSC-2864: Corrects bearer token usage when submitting harmony orders

### DIFF
--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -59,7 +59,11 @@ describe('submitCatalogRestOrder', () => {
     const startOrderStatusUpdateWorkflowMock = jest.spyOn(startOrderStatusUpdateWorkflow, 'startOrderStatusUpdateWorkflow')
       .mockImplementation(() => (jest.fn()))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -133,7 +137,11 @@ describe('submitCatalogRestOrder', () => {
 
     jest.spyOn(prepareGranuleAccessParams, 'prepareGranuleAccessParams')
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {
@@ -202,7 +210,11 @@ describe('submitCatalogRestOrder', () => {
 
     jest.spyOn(prepareGranuleAccessParams, 'prepareGranuleAccessParams')
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {
@@ -273,7 +285,11 @@ describe('submitCatalogRestOrder', () => {
     const createLimitedShapefileMock = jest.spyOn(createLimitedShapefile, 'createLimitedShapefile')
       .mockImplementation(() => ('limited mock shapefile'))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -359,7 +375,11 @@ describe('submitCatalogRestOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(500)
 
@@ -400,7 +420,11 @@ describe('submitCatalogRestOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -59,11 +59,8 @@ describe('submitCatalogRestOrder', () => {
     const startOrderStatusUpdateWorkflowMock = jest.spyOn(startOrderStatusUpdateWorkflow, 'startOrderStatusUpdateWorkflow')
       .mockImplementation(() => (jest.fn()))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -137,11 +134,8 @@ describe('submitCatalogRestOrder', () => {
 
     jest.spyOn(prepareGranuleAccessParams, 'prepareGranuleAccessParams')
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {
@@ -210,11 +204,8 @@ describe('submitCatalogRestOrder', () => {
 
     jest.spyOn(prepareGranuleAccessParams, 'prepareGranuleAccessParams')
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {
@@ -285,11 +276,8 @@ describe('submitCatalogRestOrder', () => {
     const createLimitedShapefileMock = jest.spyOn(createLimitedShapefile, 'createLimitedShapefile')
       .mockImplementation(() => ('limited mock shapefile'))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -375,11 +363,8 @@ describe('submitCatalogRestOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(500)
 
@@ -420,11 +405,8 @@ describe('submitCatalogRestOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -16,11 +16,8 @@ describe('constructOrderPayload', () => {
   describe('format', () => {
     describe('with a known format', () => {
       test('constructs a payload with a format', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -50,11 +47,8 @@ describe('constructOrderPayload', () => {
 
     describe('with an unknown format', () => {
       test('constructs a payload without a format', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -84,11 +78,8 @@ describe('constructOrderPayload', () => {
   describe('projection', () => {
     describe('with a known projection', () => {
       test('constructs a payload with a projection', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -119,11 +110,8 @@ describe('constructOrderPayload', () => {
 
   describe('granules', () => {
     test('constructs a payload with granule ids', async () => {
-      nock(/cmr/, {
-        reqheaders: {
-          Authorization: 'Bearer access-token'
-        }
-      })
+      nock(/cmr/)
+        .matchHeader('Authorization', 'Bearer access-token')
         .get('/search/granules.json')
         .reply(200, {
           feed: {
@@ -152,11 +140,8 @@ describe('constructOrderPayload', () => {
   describe('temporal', () => {
     describe('with a start and end date', () => {
       test('constructs a payload with a start and end subsetting', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json?temporal=2020-01-01T01%3A36%3A52.273Z%2C2020-01-01T06%3A18%3A19.482Z')
           .reply(200, {
             feed: {
@@ -186,11 +171,8 @@ describe('constructOrderPayload', () => {
 
     describe('with only a start date', () => {
       test('constructs a payload with an open ended start date', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json?temporal=2020-01-01T01%3A36%3A52.273Z%2C')
           .reply(200, {
             feed: {
@@ -220,11 +202,8 @@ describe('constructOrderPayload', () => {
 
     describe('with only a end date', () => {
       test('constructs a payload with an open ended end date', async () => {
-        nock(/cmr/, {
-          reqheaders: {
-            Authorization: 'Bearer access-token'
-          }
-        })
+        nock(/cmr/)
+          .matchHeader('Authorization', 'Bearer access-token')
           .get('/search/granules.json?temporal=%2C2020-01-01T06%3A18%3A19.482Z')
           .reply(200, {
             feed: {
@@ -257,11 +236,8 @@ describe('constructOrderPayload', () => {
     describe('when shapefile subsetting is supported', () => {
       describe('with a shapefile', () => {
         test('constructs a payload with a shapefile', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json')
             .reply(200, {
               feed: {
@@ -293,11 +269,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a point', () => {
         test('constructs a payload containing a shapefile representing the point', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?point%5B%5D=-77%2C%2034')
             .reply(200, {
               feed: {
@@ -329,11 +302,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a bounding box', () => {
         test('constructs a payload containing the bounding box', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?bounding_box%5B%5D=0%2C5%2C10%2C15')
             .reply(200, {
               feed: {
@@ -365,11 +335,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a circle', () => {
         test('constructs a payload containing a shapefile representing the circle', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?circle%5B%5D=-77%2C%2034%2C%2020000')
             .reply(200, {
               feed: {
@@ -401,11 +368,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a polygon', () => {
         test('constructs a payload containing a shapefile representing the polygon', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?polygon%5B%5D=-29.8125%2C39.86484%2C-23.0625%2C-19.74405%2C15.75%2C20.745%2C-29.8125%2C39.86484')
             .reply(200, {
               feed: {
@@ -439,11 +403,8 @@ describe('constructOrderPayload', () => {
     describe('when only bounding subsetting is supported', () => {
       describe('with a point', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the point', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?point%5B%5D=-77%2C%2034')
             .reply(200, {
               feed: {
@@ -484,11 +445,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a bounding box', () => {
         test('constructs a payload containing the bounding box', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?bounding_box%5B%5D=5%2C0%2C15%2C10')
             .reply(200, {
               feed: {
@@ -523,11 +481,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a circle', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the circle', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?circle%5B%5D=-77%2C%2034%2C%2020000')
             .reply(200, {
               feed: {
@@ -568,11 +523,8 @@ describe('constructOrderPayload', () => {
 
       describe('with a polygon', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the polygon', async () => {
-          nock(/cmr/, {
-            reqheaders: {
-              Authorization: 'Bearer access-token'
-            }
-          })
+          nock(/cmr/)
+            .matchHeader('Authorization', 'Bearer access-token')
             .get('/search/granules.json?polygon%5B%5D=-29.8125%2C39.86484%2C-23.0625%2C-19.74405%2C15.75%2C20.745%2C-29.8125%2C39.86484')
             .reply(200, {
               feed: {

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -16,7 +16,11 @@ describe('constructOrderPayload', () => {
   describe('format', () => {
     describe('with a known format', () => {
       test('constructs a payload with a format', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -32,7 +36,7 @@ describe('constructOrderPayload', () => {
           selectedOutputFormat: 'image/png'
         }
         const granuleParams = {}
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -46,7 +50,11 @@ describe('constructOrderPayload', () => {
 
     describe('with an unknown format', () => {
       test('constructs a payload without a format', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -60,7 +68,7 @@ describe('constructOrderPayload', () => {
 
         const accessMethod = {}
         const granuleParams = {}
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -76,7 +84,11 @@ describe('constructOrderPayload', () => {
   describe('projection', () => {
     describe('with a known projection', () => {
       test('constructs a payload with a projection', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json')
           .reply(200, {
             feed: {
@@ -92,7 +104,7 @@ describe('constructOrderPayload', () => {
           selectedOutputProjection: 'EPSG:4326'
         }
         const granuleParams = {}
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -107,7 +119,11 @@ describe('constructOrderPayload', () => {
 
   describe('granules', () => {
     test('constructs a payload with granule ids', async () => {
-      nock(/cmr/)
+      nock(/cmr/, {
+        reqheaders: {
+          Authorization: 'Bearer access-token'
+        }
+      })
         .get('/search/granules.json')
         .reply(200, {
           feed: {
@@ -121,7 +137,7 @@ describe('constructOrderPayload', () => {
 
       const accessMethod = {}
       const granuleParams = {}
-      const accessToken = ''
+      const accessToken = 'access-token'
 
       const response = await constructOrderPayload({
         accessMethod,
@@ -136,7 +152,11 @@ describe('constructOrderPayload', () => {
   describe('temporal', () => {
     describe('with a start and end date', () => {
       test('constructs a payload with a start and end subsetting', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json?temporal=2020-01-01T01%3A36%3A52.273Z%2C2020-01-01T06%3A18%3A19.482Z')
           .reply(200, {
             feed: {
@@ -152,7 +172,7 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: '2020-01-01T01:36:52.273Z,2020-01-01T06:18:19.482Z'
         }
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -166,7 +186,11 @@ describe('constructOrderPayload', () => {
 
     describe('with only a start date', () => {
       test('constructs a payload with an open ended start date', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json?temporal=2020-01-01T01%3A36%3A52.273Z%2C')
           .reply(200, {
             feed: {
@@ -182,7 +206,7 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: '2020-01-01T01:36:52.273Z,'
         }
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -196,7 +220,11 @@ describe('constructOrderPayload', () => {
 
     describe('with only a end date', () => {
       test('constructs a payload with an open ended end date', async () => {
-        nock(/cmr/)
+        nock(/cmr/, {
+          reqheaders: {
+            Authorization: 'Bearer access-token'
+          }
+        })
           .get('/search/granules.json?temporal=%2C2020-01-01T06%3A18%3A19.482Z')
           .reply(200, {
             feed: {
@@ -212,7 +240,7 @@ describe('constructOrderPayload', () => {
         const granuleParams = {
           temporal: ',2020-01-01T06:18:19.482Z'
         }
-        const accessToken = ''
+        const accessToken = 'access-token'
 
         const response = await constructOrderPayload({
           accessMethod,
@@ -229,7 +257,11 @@ describe('constructOrderPayload', () => {
     describe('when shapefile subsetting is supported', () => {
       describe('with a shapefile', () => {
         test('constructs a payload with a shapefile', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json')
             .reply(200, {
               feed: {
@@ -245,7 +277,7 @@ describe('constructOrderPayload', () => {
             supportsShapefileSubsetting: true
           }
           const granuleParams = {}
-          const accessToken = ''
+          const accessToken = 'access-token'
           const shapefile = mockCcwShapefile
 
           const response = await constructOrderPayload({
@@ -261,7 +293,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a point', () => {
         test('constructs a payload containing a shapefile representing the point', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?point%5B%5D=-77%2C%2034')
             .reply(200, {
               feed: {
@@ -279,7 +315,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             point: ['-77, 34']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -293,7 +329,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a bounding box', () => {
         test('constructs a payload containing the bounding box', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?bounding_box%5B%5D=0%2C5%2C10%2C15')
             .reply(200, {
               feed: {
@@ -311,7 +351,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             bounding_box: ['0,5,10,15']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -325,7 +365,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a circle', () => {
         test('constructs a payload containing a shapefile representing the circle', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?circle%5B%5D=-77%2C%2034%2C%2020000')
             .reply(200, {
               feed: {
@@ -343,7 +387,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             circle: ['-77, 34, 20000']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -357,7 +401,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a polygon', () => {
         test('constructs a payload containing a shapefile representing the polygon', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?polygon%5B%5D=-29.8125%2C39.86484%2C-23.0625%2C-19.74405%2C15.75%2C20.745%2C-29.8125%2C39.86484')
             .reply(200, {
               feed: {
@@ -375,7 +423,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             polygon: ['-29.8125,39.86484,-23.0625,-19.74405,15.75,20.745,-29.8125,39.86484']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -391,7 +439,11 @@ describe('constructOrderPayload', () => {
     describe('when only bounding subsetting is supported', () => {
       describe('with a point', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the point', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?point%5B%5D=-77%2C%2034')
             .reply(200, {
               feed: {
@@ -415,7 +467,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             point: ['-77, 34']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -432,7 +484,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a bounding box', () => {
         test('constructs a payload containing the bounding box', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?bounding_box%5B%5D=5%2C0%2C15%2C10')
             .reply(200, {
               feed: {
@@ -450,7 +506,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             bounding_box: ['5,0,15,10']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -467,7 +523,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a circle', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the circle', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?circle%5B%5D=-77%2C%2034%2C%2020000')
             .reply(200, {
               feed: {
@@ -491,7 +551,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             circle: ['-77, 34, 20000']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,
@@ -508,7 +568,11 @@ describe('constructOrderPayload', () => {
 
       describe('with a polygon', () => {
         test('constructs a payload containing a bounding box representing the minimum bounding rectangle of the polygon', async () => {
-          nock(/cmr/)
+          nock(/cmr/, {
+            reqheaders: {
+              Authorization: 'Bearer access-token'
+            }
+          })
             .get('/search/granules.json?polygon%5B%5D=-29.8125%2C39.86484%2C-23.0625%2C-19.74405%2C15.75%2C20.745%2C-29.8125%2C39.86484')
             .reply(200, {
               feed: {
@@ -532,7 +596,7 @@ describe('constructOrderPayload', () => {
           const granuleParams = {
             polygon: ['-29.8125,39.86484,-23.0625,-19.74405,15.75,20.745,-29.8125,39.86484']
           }
-          const accessToken = ''
+          const accessToken = 'access-token'
 
           const response = await constructOrderPayload({
             accessMethod,

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -58,11 +58,8 @@ describe('submitHarmonyOrder', () => {
     const startOrderStatusUpdateWorkflowMock = jest.spyOn(startOrderStatusUpdateWorkflow, 'startOrderStatusUpdateWorkflow')
       .mockImplementation(() => (jest.fn()))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get(/search\/granules/)
       .reply(200, {
         feed: {
@@ -152,11 +149,8 @@ describe('submitHarmonyOrder', () => {
     const createLimitedShapefileMock = jest.spyOn(createLimitedShapefile, 'createLimitedShapefile')
       .mockImplementation(() => ('limited mock shapefile'))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get(/search\/granules/)
       .reply(200, {
         feed: {
@@ -256,11 +250,8 @@ describe('submitHarmonyOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get(/search\/granules/)
       .reply(200, {
         feed: {

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -58,7 +58,11 @@ describe('submitHarmonyOrder', () => {
     const startOrderStatusUpdateWorkflowMock = jest.spyOn(startOrderStatusUpdateWorkflow, 'startOrderStatusUpdateWorkflow')
       .mockImplementation(() => (jest.fn()))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get(/search\/granules/)
       .reply(200, {
         feed: {
@@ -148,7 +152,11 @@ describe('submitHarmonyOrder', () => {
     const createLimitedShapefileMock = jest.spyOn(createLimitedShapefile, 'createLimitedShapefile')
       .mockImplementation(() => ('limited mock shapefile'))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get(/search\/granules/)
       .reply(200, {
         feed: {
@@ -248,7 +256,11 @@ describe('submitHarmonyOrder', () => {
       edscHost: 'http://localhost:8080'
     }))
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get(/search\/granules/)
       .reply(200, {
         feed: {

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -31,7 +31,7 @@ export const constructOrderPayload = async ({
       arrayFormat: 'brackets'
     },
     headers: {
-      Authorization: accessToken,
+      Authorization: `Bearer ${accessToken}`,
       'Client-Id': getClientId().background
     },
     json: true,

--- a/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
@@ -13,7 +13,11 @@ describe('constructOrderPayload', () => {
   })
 
   test('constructs an order payload', async () => {
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -54,7 +58,7 @@ describe('constructOrderPayload', () => {
       collection_concept_id: 'C100000-EDSC'
     }
 
-    const accessToken = 'accessToken'
+    const accessToken = 'access-token'
     const earthdataEnvironment = 'prod'
 
     const response = await constructOrderPayload(
@@ -78,7 +82,11 @@ describe('constructOrderPayload', () => {
   })
 
   test('constructs an order payload with added granule params', async () => {
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {
@@ -119,13 +127,13 @@ describe('constructOrderPayload', () => {
       concept_id: ['G10000005-EDSC']
     }
 
-    const accessTokenWithClient = 'accessToken:clientId'
+    const accessToken = 'access-token'
     const earthdataEnvironment = 'prod'
 
     const response = await constructOrderPayload(
       accessMethod,
       granuleParams,
-      accessTokenWithClient,
+      accessToken,
       earthdataEnvironment
     )
 

--- a/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
@@ -13,11 +13,8 @@ describe('constructOrderPayload', () => {
   })
 
   test('constructs an order payload', async () => {
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?collection_concept_id=C100000-EDSC')
       .reply(200, {
         feed: {
@@ -82,11 +79,8 @@ describe('constructOrderPayload', () => {
   })
 
   test('constructs an order payload with added granule params', async () => {
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
       .reply(200, {
         feed: {

--- a/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
@@ -85,7 +85,11 @@ describe('submitLegacyServicesOrder', () => {
       role: 'Order Contact'
     }
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .post(/orders\.json/)
       .reply(201, {
         order: {
@@ -93,7 +97,11 @@ describe('submitLegacyServicesOrder', () => {
         }
       })
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .get(/granules/)
       .reply(200, {
         feed: {
@@ -103,7 +111,11 @@ describe('submitLegacyServicesOrder', () => {
         }
       })
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .post(/order_information/)
       .reply(200, [
         {
@@ -121,7 +133,11 @@ describe('submitLegacyServicesOrder', () => {
         }
       ])
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .post(/orders\/100005\/order_items\/bulk_action/, [{
         order_item: {
           quantity: 1,
@@ -135,7 +151,11 @@ describe('submitLegacyServicesOrder', () => {
       }])
       .reply(201)
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .put(/orders\/100005\/user_information/, {
         user_information: {
           shipping_contact: contactInformation,
@@ -147,7 +167,11 @@ describe('submitLegacyServicesOrder', () => {
       })
       .reply(201)
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .post(/orders\/100005\/submit/)
       .reply(201)
 
@@ -202,7 +226,11 @@ describe('submitLegacyServicesOrder', () => {
       organization: 'Earthdadta Search'
     }
 
-    nock(/cmr/)
+    nock(/cmr/, {
+      reqheaders: {
+        Authorization: 'Bearer access-token'
+      }
+    })
       .post(/orders\.json/)
       .reply(500, {
         errorType: 'Error',

--- a/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/handler.test.js
@@ -85,11 +85,8 @@ describe('submitLegacyServicesOrder', () => {
       role: 'Order Contact'
     }
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .post(/orders\.json/)
       .reply(201, {
         order: {
@@ -97,11 +94,8 @@ describe('submitLegacyServicesOrder', () => {
         }
       })
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .get(/granules/)
       .reply(200, {
         feed: {
@@ -111,11 +105,8 @@ describe('submitLegacyServicesOrder', () => {
         }
       })
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .post(/order_information/)
       .reply(200, [
         {
@@ -133,11 +124,8 @@ describe('submitLegacyServicesOrder', () => {
         }
       ])
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .post(/orders\/100005\/order_items\/bulk_action/, [{
         order_item: {
           quantity: 1,
@@ -151,11 +139,8 @@ describe('submitLegacyServicesOrder', () => {
       }])
       .reply(201)
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .put(/orders\/100005\/user_information/, {
         user_information: {
           shipping_contact: contactInformation,
@@ -167,11 +152,8 @@ describe('submitLegacyServicesOrder', () => {
       })
       .reply(201)
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .post(/orders\/100005\/submit/)
       .reply(201)
 
@@ -226,11 +208,8 @@ describe('submitLegacyServicesOrder', () => {
       organization: 'Earthdadta Search'
     }
 
-    nock(/cmr/, {
-      reqheaders: {
-        Authorization: 'Bearer access-token'
-      }
-    })
+    nock(/cmr/)
+      .matchHeader('Authorization', 'Bearer access-token')
       .post(/orders\.json/)
       .reply(500, {
         errorType: 'Error',


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes granule request that is made as part of the harmony order submission.

### What is the Solution?

The Authorization header was missing the `Bearer ` prefix, I've added that.

### What areas of the application does this impact?

Harmony order submissions.

# Testing

Submitting harmony orders should now work.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
