### PR TITLE
EDSC-2990: Fixing customizable tooltip positioning

### DIFF
--- a/static/src/js/components/CollectionResults/CollectionResultsItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.js
@@ -57,11 +57,21 @@ export const CollectionResultsItem = forwardRef(({
 
   const customizeBadges = []
 
+  const popperOffset = {
+    modifiers: [{
+      name: 'offset',
+      options: {
+        offset: [0, 6]
+      }
+    }]
+  }
+
   if (hasSpatialSubsetting) {
     customizeBadges.push((
       <OverlayTrigger
         key="badge-icon__spatial-subsetting"
         placement="top"
+        popperConfig={popperOffset}
         overlay={(
           <Tooltip
             id="tooltip_customize-spatial-subsetting"
@@ -81,6 +91,7 @@ export const CollectionResultsItem = forwardRef(({
       <OverlayTrigger
         key="badge-icon__variables"
         placement="top"
+        popperConfig={popperOffset}
         overlay={(
           <Tooltip
             id="tooltip_customize-variables"
@@ -100,6 +111,7 @@ export const CollectionResultsItem = forwardRef(({
       <OverlayTrigger
         key="badge-icon__transforms"
         placement="top"
+        popperConfig={popperOffset}
         overlay={(
           <Tooltip
             id="tooltip_customize-transforms"
@@ -119,6 +131,7 @@ export const CollectionResultsItem = forwardRef(({
       <OverlayTrigger
         key="badge-icon__formats"
         placement="top"
+        popperConfig={popperOffset}
         overlay={(
           <Tooltip
             id="tooltip_customize-formats"
@@ -138,6 +151,7 @@ export const CollectionResultsItem = forwardRef(({
       <OverlayTrigger
         key="badge-icon__temporal-subsetting"
         placement="top"
+        popperConfig={popperOffset}
         overlay={(
           <Tooltip
             id="tooltip_customize-temporal-subsetting"

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.scss
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.scss
@@ -201,9 +201,5 @@
 
   &__badge-tooltip {
     font-size: 0.75rem;
-
-    &--icon {
-      top: -0.35rem!important;
-    }
   }
 }

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
@@ -328,7 +328,7 @@ describe('CollectionResultsList component', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Spatial customizable options available')
         })
 
-        test('renders a tooltip the correct popperConfig', () => {
+        test('renders a tooltip with the correct popperConfig', () => {
           expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
@@ -355,7 +355,7 @@ describe('CollectionResultsList component', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Variable customizable options available')
         })
 
-        test('renders a tooltip the correct popperConfig', () => {
+        test('renders a tooltip with the correct popperConfig', () => {
           expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
@@ -382,7 +382,7 @@ describe('CollectionResultsList component', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Data transformation options available')
         })
 
-        test('renders a tooltip the correct popperConfig', () => {
+        test('renders a tooltip with the correct popperConfig', () => {
           expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
@@ -409,7 +409,7 @@ describe('CollectionResultsList component', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Reformatting options available')
         })
 
-        test('renders a tooltip the correct popperConfig', () => {
+        test('renders a tooltip with the correct popperConfig', () => {
           expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
@@ -436,7 +436,7 @@ describe('CollectionResultsList component', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Temporal subsetting options available')
         })
 
-        test('renders a tooltip the correct popperConfig', () => {
+        test('renders a tooltip with the correct popperConfig', () => {
           expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import { OverlayTrigger, Tooltip } from 'react-bootstrap'
+import { OverlayTrigger, Overlay, Tooltip } from 'react-bootstrap'
 
 import CollectionResultsItem from '../CollectionResultsItem'
 import SplitBadge from '../../SplitBadge/SplitBadge'
@@ -9,6 +9,13 @@ import { collectionListItemProps } from './mocks'
 import PortalFeatureContainer from '../../../containers/PortalFeatureContainer/PortalFeatureContainer'
 
 Enzyme.configure({ adapter: new Adapter() })
+
+const popperOffset = {
+  name: 'offset',
+  options: {
+    offset: [0, 6]
+  }
+}
 
 function setup(propsOverride) {
   const props = {
@@ -320,6 +327,10 @@ describe('CollectionResultsList component', () => {
         test('renders a tooltip with the correct text', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Spatial customizable options available')
         })
+
+        test('renders a tooltip the correct popperConfig', () => {
+          expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
+        })
       })
 
       describe('variables icon', () => {
@@ -342,6 +353,10 @@ describe('CollectionResultsList component', () => {
 
         test('renders a tooltip with the correct text', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Variable customizable options available')
+        })
+
+        test('renders a tooltip the correct popperConfig', () => {
+          expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
 
@@ -366,6 +381,10 @@ describe('CollectionResultsList component', () => {
         test('renders a tooltip with the correct text', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Data transformation options available')
         })
+
+        test('renders a tooltip the correct popperConfig', () => {
+          expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
+        })
       })
 
       describe('formats icon', () => {
@@ -389,6 +408,10 @@ describe('CollectionResultsList component', () => {
         test('renders a tooltip with the correct text', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Reformatting options available')
         })
+
+        test('renders a tooltip the correct popperConfig', () => {
+          expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
+        })
       })
 
       describe('temporal subsetting icon', () => {
@@ -411,6 +434,10 @@ describe('CollectionResultsList component', () => {
 
         test('renders a tooltip with the correct text', () => {
           expect(tooltip.find(Tooltip).text()).toEqual('Temporal subsetting options available')
+        })
+
+        test('renders a tooltip the correct popperConfig', () => {
+          expect(tooltip.find(Overlay).props().popperConfig.modifiers[1]).toEqual(popperOffset)
         })
       })
     })


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes bug where customizable tooltips on collection search results were positioned incorrectly.

### What is the Solution?

Removed css override in favor of using the popperConfig on the OverlayTrigger component to override default positioning.

### What areas of the application does this impact?

- Collection results list items

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** Any that support customization

1. Load search results containing the "customizable" tag
2. Confirm tooltip is positioned correctly when the icon is hovered

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
