### PR TITLE
EDSC-3009: Adds page_size parameter to additive retrieval requests

### DIFF
--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -136,7 +136,7 @@ describe('submitCatalogRestOrder', () => {
 
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
       .reply(200, {
         feed: {
           entry: [{
@@ -206,7 +206,7 @@ describe('submitCatalogRestOrder', () => {
 
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
       .reply(200, {
         feed: {
           entry: [{

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -136,7 +136,7 @@ describe('submitCatalogRestOrder', () => {
 
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=1')
       .reply(200, {
         feed: {
           entry: [{
@@ -206,7 +206,7 @@ describe('submitCatalogRestOrder', () => {
 
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=1')
       .reply(200, {
         feed: {
           entry: [{

--- a/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
@@ -81,7 +81,7 @@ describe('constructOrderPayload', () => {
   test('constructs an order payload with added granule params', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=1')
       .reply(200, {
         feed: {
           entry: [{

--- a/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitLegacyServicesOrder/__tests__/constructOrderPayload.test.js
@@ -81,7 +81,7 @@ describe('constructOrderPayload', () => {
   test('constructs an order payload with added granule params', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC')
+      .get('/search/granules.json?concept_id%5B%5D=G10000005-EDSC&page_size=2000')
       .reply(200, {
         feed: {
           entry: [{

--- a/sharedUtils/__tests__/prepareGranuleAccessParams.test.js
+++ b/sharedUtils/__tests__/prepareGranuleAccessParams.test.js
@@ -13,7 +13,7 @@ const paramsWithAddedGranulesArr = {
 
 const returnParamsWithAddedGranulesArr = {
   concept_id: ['1', '2', '3', '4'],
-  page_size: 2000
+  page_size: 4
 }
 
 describe('prepareGranuleAccessParams', () => {

--- a/sharedUtils/__tests__/prepareGranuleAccessParams.test.js
+++ b/sharedUtils/__tests__/prepareGranuleAccessParams.test.js
@@ -12,7 +12,8 @@ const paramsWithAddedGranulesArr = {
 }
 
 const returnParamsWithAddedGranulesArr = {
-  concept_id: ['1', '2', '3', '4']
+  concept_id: ['1', '2', '3', '4'],
+  page_size: 2000
 }
 
 describe('prepareGranuleAccessParams', () => {

--- a/sharedUtils/prepareGranuleAccessParams.js
+++ b/sharedUtils/prepareGranuleAccessParams.js
@@ -1,5 +1,3 @@
-import { getApplicationConfig } from './config'
-
 /**
  * Takes granule params and returns the params to be used in a CMR request
  * @param {Object} params Queue messages from SQS
@@ -11,11 +9,9 @@ export const prepareGranuleAccessParams = (params = {}) => {
   // If there are added granules, return only the added granules. Otherwise, send
   // all of the granules params.
   if (conceptIdsFromParams.length) {
-    const { defaultGranulesPerOrder } = getApplicationConfig()
-
     return {
       concept_id: conceptIdsFromParams,
-      page_size: defaultGranulesPerOrder
+      page_size: conceptIdsFromParams.length
     }
   }
 

--- a/sharedUtils/prepareGranuleAccessParams.js
+++ b/sharedUtils/prepareGranuleAccessParams.js
@@ -1,3 +1,5 @@
+import { getApplicationConfig } from './config'
+
 /**
  * Takes granule params and returns the params to be used in a CMR request
  * @param {Object} params Queue messages from SQS
@@ -9,8 +11,11 @@ export const prepareGranuleAccessParams = (params = {}) => {
   // If there are added granules, return only the added granules. Otherwise, send
   // all of the granules params.
   if (conceptIdsFromParams.length) {
+    const { defaultGranulesPerOrder } = getApplicationConfig()
+
     return {
-      concept_id: conceptIdsFromParams
+      concept_id: conceptIdsFromParams,
+      page_size: defaultGranulesPerOrder
     }
   }
 


### PR DESCRIPTION
# Overview

### What is the feature?

When using additive granules for a retrieval, we only send the `concept_id` parameter to retrieval those granules. CMR has a default page size of 10, so only the first 10 granules are added to the request if the user added more than 10.

### What is the Solution?

Include `page_size=2000` (the max page size for CMR) to granule requests when building a retrieval payload

### What areas of the application does this impact?

Retrievals

# Testing

### Reproduction steps

Using the additive model, add more than 10 granules to a retrieval
Submit the retrieval and ensure all granules are processed

11 granules have been added here https://search.earthdata.nasa.gov/search/granules?p=C190733714-LPDAAC_ECS!C190733714-LPDAAC_ECS&pg[1][a]=1982455090!1982456259!1982455395!1982455802!1982456179!1982456277!1982456652!1982455235!1982455888!1982456347!1982455758!LPDAAC_ECS&pg[1][v]=t&pg[1][gsk]=-start_date&q=C190733714-LPDAAC_ECS&tl=1592504642!4!!

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
