### PR TITLE
EDSC-2986: Fixes axios param name

### DIFF
--- a/serverless/src/getAccessMethods/getServiceOptionDefinitions.js
+++ b/serverless/src/getAccessMethods/getServiceOptionDefinitions.js
@@ -33,7 +33,7 @@ export const getServiceOptionDefinitions = async (
       const response = await wrappedAxios({
         method: 'get',
         url,
-        qs: {
+        params: {
           name,
           provider_guid: providerId
         },


### PR DESCRIPTION
Missed one of the param name changes from `qs` to `params` when switching from request-promise to axios