### PR TITLE
EDSC-2962: Adds 'canceled' to list of failed order statuses

### DIFF
--- a/sharedUtils/__tests__/orderStatus.test.js
+++ b/sharedUtils/__tests__/orderStatus.test.js
@@ -8,8 +8,14 @@ describe('aggregatedOrderStatus', () => {
 
     test('returns the correct state for failed', () => {
       expect(aggregatedOrderStatus([{
-        state: 'cancelled'
+        state: 'not_found'
       }])).toEqual('failed')
+    })
+
+    test('returns the correct state for canceled', () => {
+      expect(aggregatedOrderStatus([{
+        state: 'cancelled'
+      }])).toEqual('canceled')
     })
 
     test('returns the correct state for in progress', () => {

--- a/sharedUtils/orderStatus.js
+++ b/sharedUtils/orderStatus.js
@@ -1,6 +1,11 @@
 import { upperFirst } from 'lodash'
 
 export const orderStates = {
+  canceled: [
+    'canceled',
+    'cancelled',
+    'cancelling'
+  ],
   complete: [
     'closed',
     'complete_with_errors',
@@ -8,9 +13,6 @@ export const orderStates = {
     'successful'
   ],
   failed: [
-    'canceled',
-    'cancelled',
-    'cancelling',
     'closed_with_exceptions',
     'create_failed', // Custom EDSC status for orders that failed to create
     'failed',
@@ -59,6 +61,7 @@ export const getStateFromOrderStatus = (status) => {
   if (orderStates.complete.indexOf(status.toLowerCase()) > -1) return 'complete'
   if (orderStates.in_progress.indexOf(status.toLowerCase()) > -1) return 'in_progress'
   if (orderStates.creating.indexOf(status.toLowerCase()) > -1) return 'creating'
+  if (orderStates.canceled.indexOf(status.toLowerCase()) > -1) return 'canceled'
 
   return false
 }
@@ -83,6 +86,10 @@ export const aggregatedOrderStatus = (orders = []) => {
 
   if (orders.every(order => getStateFromOrderStatus(order.state) === 'complete')) {
     orderStatus = 'complete'
+  }
+
+  if (orders.every(order => getStateFromOrderStatus(order.state) === 'canceled')) {
+    orderStatus = 'canceled'
   }
 
   return orderStatus

--- a/sharedUtils/orderStatus.js
+++ b/sharedUtils/orderStatus.js
@@ -8,6 +8,7 @@ export const orderStates = {
     'successful'
   ],
   failed: [
+    'canceled',
     'cancelled',
     'cancelling',
     'closed_with_exceptions',

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -313,7 +313,7 @@ export class OrderStatusItem extends PureComponent {
     const orderStatus = aggregatedOrderStatus(orders)
 
     // If the order is in a terminal state stop asking for order status
-    if (['complete', 'failed'].includes(orderStatus)) {
+    if (['complete', 'failed', 'canceled'].includes(orderStatus)) {
       clearInterval(this.intervalId)
     } else {
       onFetchRetrievalCollection(id)
@@ -367,7 +367,8 @@ export class OrderStatusItem extends PureComponent {
           'order-status-item--is-opened': opened,
           'order-status-item--complete': !hasStatus || (hasStatus && stateFromOrderStatus === 'complete'),
           'order-status-item--in_progress': hasStatus && stateFromOrderStatus === 'in_progress',
-          'order-status-item--failed': hasStatus && stateFromOrderStatus === 'failed'
+          'order-status-item--failed': hasStatus && stateFromOrderStatus === 'failed',
+          'order-status-item--canceled': hasStatus && stateFromOrderStatus === 'canceled'
         }
       )
 
@@ -440,6 +441,11 @@ export class OrderStatusItem extends PureComponent {
           orderInfo = 'The order has failed processing.'
         }
 
+        if (stateFromOrderStatus === 'canceled') {
+          progressPercentage = 0
+          orderInfo = 'The order has been canceled.'
+        }
+
         if (isEsi) {
           let totalNumber = 0
           let totalProcessed = 0
@@ -510,7 +516,7 @@ export class OrderStatusItem extends PureComponent {
               jobId = false
             } = orderInformation
 
-            if (status === 'successful' || status === 'failed') {
+            if (status === 'successful' || status === 'failed' || status === 'canceled') {
               totalCompleteOrders += 1
             }
 
@@ -521,6 +527,10 @@ export class OrderStatusItem extends PureComponent {
             if (status === 'failed' && harmonyMessage) {
               messages.push(harmonyMessage)
               messageIsError = messageIsError || true
+            }
+
+            if (status === 'canceled' && harmonyMessage) {
+              messages.push(harmonyMessage)
             }
 
             downloadUrls.push(...links

--- a/static/src/js/components/OrderStatus/OrderStatusItem.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.scss
@@ -113,7 +113,8 @@ $item-height: 3rem;
 
     .order-status-item--in_progress &,
     .order-status-item--complete &,
-    .order-status-item--failed & {
+    .order-status-item--failed &,
+    .order-status-item--canceled & {
       .progress-ring__circle-back {
         animation: none;
       }


### PR DESCRIPTION
# Overview

### What is the feature?

Harmony jobs can come back with a status of `canceled`, which we account for `cancelled`. EDSC also didn't have a canceled state (previously was `failed`)

### What is the Solution?

Adds a `canceled` order status and moves canceled status to it instead of `failed`

### What areas of the application does this impact?

Harmony orders

# Testing

### Reproduction steps

Have a Harmony order canceled.
View order status page for that order

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
