### PR TITLE
EDSC-2859: Allow pasting spatial coordinates that exceed the decimal limit

### DIFF
--- a/static/src/js/components/SpatialDisplay/SpatialDisplay.js
+++ b/static/src/js/components/SpatialDisplay/SpatialDisplay.js
@@ -322,7 +322,9 @@ class SpatialDisplay extends Component {
 
     let errorMessage = ''
 
-    const regex = new RegExp(`^(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}}),?\\s?(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}})$`)
+    // Checks if the coordinates are two positive or negitive numbers separated by a comma,
+    // each number optionally followed by up to defaultSpatialDecimalSize decimal points
+    const regex = new RegExp(`^(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}}),\\s?(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}})$`)
     const validCoordinates = coordinates.trim().match(regex)
 
     if (validCoordinates == null) {
@@ -416,6 +418,8 @@ class SpatialDisplay extends Component {
    */
   trimCoordinate(coordinateString) {
     const coordinates = coordinateString.replace(/\s/g, '').split(',').map((coordinate) => {
+      // Checks if the coordinate is a positive or negitive number,
+      // optionally followed by up to defaultSpatialDecimalSize decimal points
       const regex = new RegExp(`^(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}})`)
 
       const matchedCoordinate = coordinate.match(regex)

--- a/static/src/js/components/SpatialDisplay/SpatialDisplay.js
+++ b/static/src/js/components/SpatialDisplay/SpatialDisplay.js
@@ -155,7 +155,7 @@ class SpatialDisplay extends Component {
 
     this.setState({
       pointSearch: point,
-      error: this.validateCoordinate(point)
+      error: this.validateCoordinate(trimmedValue)
     })
   }
 
@@ -207,7 +207,7 @@ class SpatialDisplay extends Component {
 
     this.setState({
       boundingBoxSearch: newSearch,
-      error: this.validateCoordinate(trimmedValue)
+      error: this.validateBoundingBoxCoordinates(newSearch)
     })
   }
 
@@ -322,7 +322,7 @@ class SpatialDisplay extends Component {
 
     let errorMessage = ''
 
-    const regex = new RegExp(`^-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}},?\\s?-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}}$`)
+    const regex = new RegExp(`^(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}}),?\\s?(-?\\d*\\.?\\d{0,${defaultSpatialDecimalSize}})$`)
     const validCoordinates = coordinates.trim().match(regex)
 
     if (validCoordinates == null) {
@@ -335,7 +335,7 @@ class SpatialDisplay extends Component {
       const [, lat, lon] = validCoordinates
 
       if (lat < -90 || lat > 90) {
-        errorMessage = `Lattitude (${lat}) must be between -90 and 90.`
+        errorMessage = `Latitude (${lat}) must be between -90 and 90.`
       }
 
       if (lon < -180 || lon > 180) {
@@ -344,6 +344,15 @@ class SpatialDisplay extends Component {
     }
 
     return errorMessage
+  }
+
+  /**
+   * Validate the provided bounding box points
+   * @param {Array} boundingBox Array with [swPoint, nePoint] values
+   */
+  validateBoundingBoxCoordinates(boundingBox) {
+    const [swPoint, nePoint] = boundingBox
+    return this.validateCoordinate(swPoint) + this.validateCoordinate(nePoint)
   }
 
   /**
@@ -379,11 +388,11 @@ class SpatialDisplay extends Component {
   }
 
   /**
-   * Turns '1,2,3' into '2,1,3' for leaflet
+   * Turns '1,2,3' into ['2,1', '3'] for leaflet
    * @param {String} circleCoordinates A center point and radius
    */
   transformCircleCoordinates(circleCoordinates) {
-    if (!circleCoordinates) return ['', '', '']
+    if (!circleCoordinates) return ['', '']
 
     const points = circleCoordinates.split(',')
 
@@ -398,7 +407,7 @@ class SpatialDisplay extends Component {
       return [this.transformSingleCoordinate(coordinate.join(',')), radius]
     }
 
-    return ['', '', '']
+    return ['', '']
   }
 
   /**
@@ -742,7 +751,7 @@ class SpatialDisplay extends Component {
           icon={FaCrop}
           title="Spatial"
           secondaryTitle={secondaryTitle}
-          error={drawingNewLayer ? '' : spatialError}
+          error={drawingNewLayer && !manuallyEntering ? '' : spatialError}
           onRemove={this.onSpatialRemove}
           hint={hint}
         >

--- a/static/src/js/components/SpatialDisplay/__tests__/SpatialDisplay.test.js
+++ b/static/src/js/components/SpatialDisplay/__tests__/SpatialDisplay.test.js
@@ -394,4 +394,26 @@ describe('SpatialDisplay component', () => {
       expect(props.onChangeQuery).toHaveBeenCalledWith({ collection: { spatial: { circle: ['-77,38,10000'] } } })
     })
   })
+
+  describe('#trimCoordinate', () => {
+    test('returns the input trimmed', () => {
+      const { enzymeWrapper } = setup()
+
+      const input = '45.60161000002, -94.60986000001'
+
+      const result = enzymeWrapper.instance().trimCoordinate(input)
+
+      expect(result).toEqual('45.60161,-94.60986')
+    })
+
+    test('returns the input if no match was found', () => {
+      const { enzymeWrapper } = setup()
+
+      const input = 'test'
+
+      const result = enzymeWrapper.instance().trimCoordinate(input)
+
+      expect(result).toEqual(input)
+    })
+  })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Pasting spatial coordinates didn't work if the pasted value didn't follow the decimal limit

### What is the Solution?

This change will trim the pasted value to fit the regex that enforces the decimal limit

### What areas of the application does this impact?

Manual spatial entry

# Testing

### Reproduction steps

Copy a spatial value with more than 5 decimal places, like `45.859602, -94.286033`
Paste that value into the manual entry spatial field, value should be trimmed to `45.85960,-94.28603`
Repeat for point/rectangle/circle fields

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
