### PR TITLE
EDSC-3000: Removes updateAuthTokenFromHeaders

### DIFF
--- a/static/src/js/actions/__tests__/authToken.test.js
+++ b/static/src/js/actions/__tests__/authToken.test.js
@@ -4,7 +4,7 @@ import nock from 'nock'
 import * as tinyCookie from 'tiny-cookie'
 
 import { UPDATE_AUTH } from '../../constants/actionTypes'
-import { logout, updateAuthToken, updateAuthTokenFromHeaders } from '../authToken'
+import { logout, updateAuthToken } from '../authToken'
 
 const mockStore = configureMockStore([thunk])
 
@@ -20,46 +20,6 @@ describe('updateAuthToken', () => {
       payload
     }
     expect(updateAuthToken(payload)).toEqual(expectedAction)
-  })
-})
-
-describe('updateAuthTokenFromHeaders', () => {
-  test('should update the authToken from a header token if available', () => {
-    const token = 'authToken-token'
-
-    const payload = {
-      'jwt-token': token
-    }
-
-    // mockStore with initialState
-    const store = mockStore({
-      authToken: '',
-      earthdataEnvironment: 'prod'
-    })
-
-    // call the dispatch
-    store.dispatch(updateAuthTokenFromHeaders(payload))
-
-    const storeActions = store.getActions()
-    expect(storeActions[0]).toEqual({
-      type: UPDATE_AUTH,
-      payload: token
-    })
-  })
-
-  test('should not remove the authToken if a header token is not available', () => {
-    // mockStore with initialState
-    const store = mockStore({
-      authToken: 'authToken-token',
-      earthdataEnvironment: 'prod'
-    })
-
-    // call the dispatch
-    store.dispatch(updateAuthTokenFromHeaders({}))
-
-    const storeActions = store.getActions()
-
-    expect(storeActions.length).toBe(0)
   })
 })
 

--- a/static/src/js/actions/__tests__/collections.test.js
+++ b/static/src/js/actions/__tests__/collections.test.js
@@ -24,7 +24,6 @@ import {
   LOADING_COLLECTIONS,
   LOADING_FACETS,
   STARTED_COLLECTIONS_TIMER,
-  UPDATE_AUTH,
   UPDATE_COLLECTION_METADATA,
   UPDATE_COLLECTION_RESULTS,
   UPDATE_FACETS
@@ -250,16 +249,12 @@ describe('getCollections', () => {
       expect(storeActions[2]).toEqual({ type: STARTED_COLLECTIONS_TIMER })
       expect(storeActions[3]).toEqual({ type: FINISHED_COLLECTIONS_TIMER })
       expect(storeActions[4]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[5]).toEqual({
         type: UPDATE_COLLECTION_METADATA,
         payload: [{
           mockCollectionData: 'goes here'
         }]
       })
-      expect(storeActions[6]).toEqual({
+      expect(storeActions[5]).toEqual({
         type: ADD_MORE_COLLECTION_RESULTS,
         payload: {
           keyword: 'search keyword',
@@ -270,11 +265,11 @@ describe('getCollections', () => {
           hits: 1
         }
       })
-      expect(storeActions[7]).toEqual({
+      expect(storeActions[6]).toEqual({
         type: LOADED_COLLECTIONS,
         payload: { loaded: true }
       })
-      expect(storeActions[8]).toEqual({
+      expect(storeActions[7]).toEqual({
         type: LOADED_FACETS,
         payload: { loaded: true }
       })

--- a/static/src/js/actions/__tests__/focusedCollection.test.js
+++ b/static/src/js/actions/__tests__/focusedCollection.test.js
@@ -119,9 +119,6 @@ describe('getFocusedCollection', () => {
         const relevancyMock = jest.spyOn(actions, 'collectionRelevancyMetrics')
         relevancyMock.mockImplementationOnce(() => jest.fn())
 
-        const updateAuthTokenFromHeadersMock = jest.spyOn(actions, 'updateAuthTokenFromHeaders')
-        updateAuthTokenFromHeadersMock.mockImplementationOnce(() => jest.fn())
-
         const getSearchGranulesMock = jest.spyOn(actions, 'getSearchGranules')
         getSearchGranulesMock.mockImplementationOnce(() => jest.fn())
 
@@ -156,7 +153,6 @@ describe('getFocusedCollection', () => {
         })
 
         expect(relevancyMock).toHaveBeenCalledTimes(1)
-        expect(updateAuthTokenFromHeadersMock).toHaveBeenCalledTimes(1)
         expect(getSearchGranulesMock).toHaveBeenCalledTimes(1)
       })
 
@@ -186,9 +182,6 @@ describe('getFocusedCollection', () => {
 
           const relevancyMock = jest.spyOn(actions, 'collectionRelevancyMetrics')
           relevancyMock.mockImplementationOnce(() => jest.fn())
-
-          const updateAuthTokenFromHeadersMock = jest.spyOn(actions, 'updateAuthTokenFromHeaders')
-          updateAuthTokenFromHeadersMock.mockImplementationOnce(() => jest.fn())
 
           const getSearchGranulesMock = jest.spyOn(actions, 'getSearchGranules')
           getSearchGranulesMock.mockImplementationOnce(() => jest.fn())
@@ -230,7 +223,6 @@ describe('getFocusedCollection', () => {
           })
 
           expect(relevancyMock).toHaveBeenCalledTimes(1)
-          expect(updateAuthTokenFromHeadersMock).toHaveBeenCalledTimes(1)
           expect(getSearchGranulesMock).toHaveBeenCalledTimes(1)
         })
       })
@@ -367,9 +359,6 @@ describe('getCollectionSubscriptions', () => {
           }
         })
 
-      const updateAuthTokenFromHeadersMock = jest.spyOn(actions, 'updateAuthTokenFromHeaders')
-      updateAuthTokenFromHeadersMock.mockImplementationOnce(() => jest.fn())
-
       const store = mockStore({
         authToken: '',
         focusedCollection: 'C10000000000-EDSC',
@@ -407,8 +396,6 @@ describe('getCollectionSubscriptions', () => {
           }
         })
       })
-
-      expect(updateAuthTokenFromHeadersMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -431,9 +418,6 @@ describe('getCollectionSubscriptions', () => {
             }
           }
         })
-
-      const updateAuthTokenFromHeadersMock = jest.spyOn(actions, 'updateAuthTokenFromHeaders')
-      updateAuthTokenFromHeadersMock.mockImplementationOnce(() => jest.fn())
 
       const store = mockStore({
         authToken: '',
@@ -471,8 +455,6 @@ describe('getCollectionSubscriptions', () => {
           }
         })
       })
-
-      expect(updateAuthTokenFromHeadersMock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/static/src/js/actions/__tests__/focusedGranule.test.js
+++ b/static/src/js/actions/__tests__/focusedGranule.test.js
@@ -99,9 +99,6 @@ describe('getFocusedGranule', () => {
             }
           })
 
-        const updateAuthTokenFromHeadersMock = jest.spyOn(actions, 'updateAuthTokenFromHeaders')
-        updateAuthTokenFromHeadersMock.mockImplementationOnce(() => jest.fn())
-
         // mockStore with initialState
         const store = mockStore({
           authToken: '',
@@ -127,8 +124,6 @@ describe('getFocusedGranule', () => {
             ]
           })
         })
-
-        expect(updateAuthTokenFromHeadersMock).toHaveBeenCalledTimes(1)
       })
 
       describe('when the requested granule is cwic and a polygon search is active', () => {

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -28,7 +28,6 @@ import {
   STARTED_PROJECT_GRANULES_TIMER,
   TOGGLE_SPATIAL_POLYGON_WARNING,
   UNDO_EXCLUDE_GRANULE_ID,
-  UPDATE_AUTH,
   UPDATE_GRANULE_FILTERS,
   UPDATE_GRANULE_LINKS,
   UPDATE_GRANULE_RESULTS,
@@ -223,17 +222,13 @@ describe('getSearchGranules', () => {
         payload: 'collectionId'
       })
       expect(storeActions[5]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[6]).toEqual({
         type: LOADED_GRANULES,
         payload: {
           collectionId: 'collectionId',
           loaded: true
         }
       })
-      expect(storeActions[7]).toEqual({
+      expect(storeActions[6]).toEqual({
         type: ADD_GRANULE_METADATA,
         payload: [
           {
@@ -242,7 +237,7 @@ describe('getSearchGranules', () => {
           }
         ]
       })
-      expect(storeActions[8]).toEqual({
+      expect(storeActions[7]).toEqual({
         type: UPDATE_GRANULE_RESULTS,
         payload: {
           collectionId: 'collectionId',
@@ -581,17 +576,13 @@ describe('getProjectGranules', () => {
         payload: 'C10000000000-EDSC'
       })
       expect(storeActions[4]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[5]).toEqual({
         type: PROJECT_GRANULES_LOADED,
         payload: {
           collectionId: 'C10000000000-EDSC',
           loaded: true
         }
       })
-      expect(storeActions[6]).toEqual({
+      expect(storeActions[5]).toEqual({
         type: ADD_GRANULE_METADATA,
         payload: [
           {
@@ -600,7 +591,7 @@ describe('getProjectGranules', () => {
           }
         ]
       })
-      expect(storeActions[7]).toEqual({
+      expect(storeActions[6]).toEqual({
         type: UPDATE_PROJECT_GRANULE_RESULTS,
         payload: {
           collectionId: 'C10000000000-EDSC',

--- a/static/src/js/actions/__tests__/preferences.test.js
+++ b/static/src/js/actions/__tests__/preferences.test.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk'
 import nock from 'nock'
 import jwt from 'jsonwebtoken'
 
-import { SET_PREFERENCES_IS_SUBMITTING, SET_PREFERENCES, UPDATE_AUTH } from '../../constants/actionTypes'
+import { SET_PREFERENCES_IS_SUBMITTING, SET_PREFERENCES } from '../../constants/actionTypes'
 
 import {
   setIsSubmitting,
@@ -100,14 +100,10 @@ describe('updatePreferences', () => {
         payload: true
       })
       expect(storeActions[1]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[2]).toEqual({
         type: SET_PREFERENCES,
         payload: preferences
       })
-      expect(storeActions[3]).toEqual({
+      expect(storeActions[2]).toEqual({
         type: SET_PREFERENCES_IS_SUBMITTING,
         payload: false
       })

--- a/static/src/js/actions/__tests__/project.test.js
+++ b/static/src/js/actions/__tests__/project.test.js
@@ -14,7 +14,6 @@ import {
   SUBMITTING_PROJECT,
   TOGGLE_COLLECTION_VISIBILITY,
   UPDATE_ACCESS_METHOD,
-  UPDATE_AUTH,
   UPDATE_COLLECTION_METADATA
 } from '../../constants/actionTypes'
 
@@ -307,10 +306,6 @@ describe('getProjectCollections', () => {
 
     const storeActions = store.getActions()
     expect(storeActions[0]).toEqual({
-      type: UPDATE_AUTH,
-      payload: 'token'
-    })
-    expect(storeActions[1]).toEqual({
       type: UPDATE_COLLECTION_METADATA,
       payload: [
         expect.objectContaining({

--- a/static/src/js/actions/__tests__/timeline.test.js
+++ b/static/src/js/actions/__tests__/timeline.test.js
@@ -11,8 +11,7 @@ import {
 } from '../timeline'
 import {
   UPDATE_TIMELINE_INTERVALS,
-  UPDATE_TIMELINE_QUERY,
-  UPDATE_AUTH
+  UPDATE_TIMELINE_QUERY
 } from '../../constants/actionTypes'
 
 const mockStore = configureMockStore([thunk])
@@ -157,10 +156,6 @@ describe('getTimeline', () => {
       // Is updateTimelineIntervals called with the right payload
       const storeActions = store.getActions()
       expect(storeActions[0]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[1]).toEqual({
         type: UPDATE_TIMELINE_INTERVALS,
         payload: {
           results: [{

--- a/static/src/js/actions/__tests__/viewAllFacets.test.js
+++ b/static/src/js/actions/__tests__/viewAllFacets.test.js
@@ -14,7 +14,7 @@ import {
   triggerViewAllFacets,
   updateViewAllFacets
 } from '../viewAllFacets'
-// import * as actions from '../viewAllFacets'
+
 import {
   COPY_CMR_FACETS_TO_VIEW_ALL,
   ERRORED_VIEW_ALL_FACETS,
@@ -24,8 +24,7 @@ import {
   UPDATE_VIEW_ALL_FACETS,
   TOGGLE_VIEW_ALL_FACETS_MODAL,
   UPDATE_COLLECTION_QUERY,
-  UPDATE_SELECTED_CMR_FACET,
-  UPDATE_AUTH
+  UPDATE_SELECTED_CMR_FACET
 } from '../../constants/actionTypes'
 
 const mockStore = configureMockStore([thunk])
@@ -338,16 +337,12 @@ describe('getViewAllFacets', () => {
         payload: true
       })
       expect(storeActions[2]).toEqual({
-        type: UPDATE_AUTH,
-        payload: 'token'
-      })
-      expect(storeActions[3]).toEqual({
         type: LOADED_VIEW_ALL_FACETS,
         payload: {
           loaded: true
         }
       })
-      expect(storeActions[4]).toEqual({
+      expect(storeActions[3]).toEqual({
         type: UPDATE_VIEW_ALL_FACETS,
         payload: facetsPayload
       })

--- a/static/src/js/actions/authToken.js
+++ b/static/src/js/actions/authToken.js
@@ -1,4 +1,4 @@
-import { set, remove } from 'tiny-cookie'
+import { remove } from 'tiny-cookie'
 
 import { UPDATE_AUTH } from '../constants/actionTypes'
 
@@ -11,17 +11,6 @@ export const updateAuthToken = payload => ({
   type: UPDATE_AUTH,
   payload
 })
-
-export const updateAuthTokenFromHeaders = headers => (dispatch) => {
-  const { 'jwt-token': jwtToken = '' } = headers || {}
-
-  // Prevent optional authorizers from logging users out because they don't return an auth token
-  if (jwtToken) {
-    // Update the authToken cookie when we get a new token
-    set('authToken', jwtToken)
-    dispatch(updateAuthToken(jwtToken))
-  }
-}
 
 export const logout = () => (dispatch, getState) => {
   const state = getState()

--- a/static/src/js/actions/collections.js
+++ b/static/src/js/actions/collections.js
@@ -5,7 +5,6 @@ import {
   buildCollectionSearchParams,
   prepareCollectionParams
 } from '../util/collections'
-import { updateAuthTokenFromHeaders } from './authToken'
 import { handleError } from './errors'
 
 import {
@@ -195,8 +194,6 @@ export const getCollections = () => (dispatch, getState) => {
       }
 
       dispatch(finishCollectionsTimer())
-
-      dispatch(updateAuthTokenFromHeaders(headers))
 
       dispatch(updateCollectionMetadata(entry))
 

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -164,8 +164,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
       const payload = []
 
       const {
-        data: responseData,
-        headers
+        data: responseData
       } = response
 
       const { data } = responseData
@@ -220,7 +219,6 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
         })
 
         // A users authToken will come back with an authenticated request if a valid token was used
-        dispatch(actions.updateAuthTokenFromHeaders(headers))
 
         // Update metadata in the store
         dispatch(actions.updateCollectionMetadata(payload))
@@ -302,14 +300,10 @@ export const getCollectionSubscriptions = collectionId => async (dispatch, getSt
       parseGraphQLError(response)
 
       const {
-        data: responseData,
-        headers
+        data: responseData
       } = response.data
 
       const { subscriptions } = responseData
-
-      // A users authToken will come back with an authenticated request if a valid token was used
-      dispatch(actions.updateAuthTokenFromHeaders(headers))
 
       dispatch({
         type: UPDATE_COLLECTION_SUBSCRIPTIONS,

--- a/static/src/js/actions/focusedGranule.js
+++ b/static/src/js/actions/focusedGranule.js
@@ -87,8 +87,7 @@ export const getFocusedGranule = () => (dispatch, getState) => {
       const payload = []
 
       const {
-        data: responseData,
-        headers
+        data: responseData
       } = response
 
       const { data } = responseData
@@ -137,9 +136,6 @@ export const getFocusedGranule = () => (dispatch, getState) => {
           timeStart,
           title
         })
-
-        // A users authToken will come back with an authenticated request if a valid token was used
-        dispatch(actions.updateAuthTokenFromHeaders(headers))
 
         // Update metadata in the store
         dispatch(actions.updateGranuleMetadata(payload))

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -32,7 +32,6 @@ import {
   UPDATE_GRANULE_RESULTS,
   INITIALIZE_COLLECTION_GRANULES_QUERY
 } from '../constants/actionTypes'
-import { updateAuthTokenFromHeaders } from './authToken'
 import { mbr } from '../util/map/mbr'
 import { prepareGranuleAccessParams } from '../../../../sharedUtils/prepareGranuleAccessParams'
 import { toggleSpatialPolygonWarning } from './ui'
@@ -413,11 +412,9 @@ export const getSearchGranules = () => (dispatch, getState) => {
 
       dispatch(finishGranulesTimer(collectionId))
 
-      const { data, headers } = response
+      const { data } = response
       const { feed } = data
       const { entry } = feed
-
-      dispatch(updateAuthTokenFromHeaders(headers))
 
       dispatch(onGranulesLoaded({
         collectionId,
@@ -553,11 +550,9 @@ export const getProjectGranules = () => (dispatch, getState) => {
 
         dispatch(finishProjectGranulesTimer(collectionId))
 
-        const { data, headers } = response
+        const { data } = response
         const { feed } = data
         const { entry } = feed
-
-        dispatch(updateAuthTokenFromHeaders(headers))
 
         dispatch(projectGranulesLoaded({
           collectionId,

--- a/static/src/js/actions/index.js
+++ b/static/src/js/actions/index.js
@@ -40,8 +40,7 @@ import {
 } from './granules'
 import {
   logout,
-  updateAuthToken,
-  updateAuthTokenFromHeaders
+  updateAuthToken
 } from './authToken'
 import {
   changeTimelineQuery,
@@ -292,7 +291,6 @@ const actions = {
   updateAdminRetrievalsSortKey,
   updateAdvancedSearch,
   updateAuthToken,
-  updateAuthTokenFromHeaders,
   updateBrowserVersion,
   updateCmrFacet,
   updateCollectionMetadata,

--- a/static/src/js/actions/preferences.js
+++ b/static/src/js/actions/preferences.js
@@ -5,7 +5,6 @@ import { SET_PREFERENCES, SET_PREFERENCES_IS_SUBMITTING } from '../constants/act
 import { addToast } from '../util/addToast'
 import { displayNotificationType } from '../constants/enums'
 import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
-import { updateAuthTokenFromHeaders } from './authToken'
 
 import PreferencesRequest from '../util/request/preferencesRequest'
 
@@ -46,10 +45,9 @@ export const updatePreferences = data => (dispatch, getState) => {
 
   const response = requestObject.update({ preferences })
     .then((response) => {
-      const { data, headers } = response
+      const { data } = response
       const { preferences } = data
 
-      dispatch(updateAuthTokenFromHeaders(headers))
       dispatch(setPreferences(preferences))
       dispatch(setIsSubmitting(false))
       addToast('Preferences saved!', {

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -266,8 +266,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
       const payload = []
 
       const {
-        data: responseData,
-        headers
+        data: responseData
       } = response
 
       const { data } = responseData
@@ -322,9 +321,6 @@ export const getProjectCollections = () => async (dispatch, getState) => {
 
         dispatch(actions.fetchDataQualitySummaries(conceptId))
       })
-
-      // A users authToken will come back with an authenticated request if a valid token was used
-      dispatch(actions.updateAuthTokenFromHeaders(headers))
 
       // Update metadata in the store
       dispatch(actions.updateCollectionMetadata(payload))

--- a/static/src/js/actions/timeline.js
+++ b/static/src/js/actions/timeline.js
@@ -11,7 +11,6 @@ import {
 import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
 import { handleError } from './errors'
 import { prepareTimelineParams } from '../util/timeline'
-import { updateAuthTokenFromHeaders } from './authToken'
 
 export const updateTimelineIntervals = payload => ({
   type: UPDATE_TIMELINE_INTERVALS,
@@ -82,7 +81,6 @@ export const getTimeline = () => (dispatch, getState) => {
 
       payload.results = response.data
 
-      dispatch(updateAuthTokenFromHeaders(response.headers))
       dispatch(updateTimelineIntervals(payload))
     })
     .catch((error) => {

--- a/static/src/js/actions/viewAllFacets.js
+++ b/static/src/js/actions/viewAllFacets.js
@@ -3,7 +3,6 @@ import CollectionRequest from '../util/request/collectionRequest'
 import { buildCollectionSearchParams, prepareCollectionParams } from '../util/collections'
 import { prepareCMRFacetPayload } from '../util/facets'
 import { changeCmrFacet } from './facets'
-import { updateAuthTokenFromHeaders } from './authToken'
 
 import {
   ERRORED_VIEW_ALL_FACETS,
@@ -89,7 +88,6 @@ export const getViewAllFacets = (category = '') => (dispatch, getState) => {
       payload.facets = response.data.feed.facets.children || []
       payload.hits = parseInt(response.headers['cmr-hits'], 10)
 
-      dispatch(updateAuthTokenFromHeaders(response.headers))
       dispatch(onViewAllFacetsLoaded({
         loaded: true
       }))


### PR DESCRIPTION
# Overview

### What is the feature?

updateAuthTokenFromHeaders is unnecessary as the authToken does not change when the EDL token is refreshed

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
