### PR TITLE
EDSC-2986: Adds content type to CMR request

### DIFF
--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -13,6 +13,7 @@ beforeEach(() => {
 describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data existed', async () => {
     nock(/example/)
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -46,6 +46,7 @@ export const addTag = async ({
         url: `${getEarthdataConfig(deployedEnvironment()).cmrHost}/search/collections.json?${stringify(cmrParams)}`,
         headers: {
           'Client-Id': getClientId().background,
+          'Content-Type': 'application/x-www-form-urlencoded',
           'Echo-Token': cmrToken
         },
         data: searchCriteria


### PR DESCRIPTION
# Overview

### What is the feature?

`request-promise` automatically added headers when `form` was used, we needed to add the header when we switched to Axios and missed this one.

### What is the Solution?

Added the correct header to the CMR request.

### What areas of the application does this impact?

Tagging background jobs.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
