### PR TITLE
EDSC-2939: Remove "Orig. Format" from granule results table

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -55,11 +55,11 @@
       "dbHost": "127.0.0.1",
       "dbName": "edsc_dev",
       "dbPort": 5432,
-      "apiHost": "http://localhost:3001/lab",
+      "apiHost": "http://localhost:3001/dev",
       "edscHost": "http://localhost:8080"
     },
     "production": {
-      "apiHost": "http://localhost:3001/lab",
+      "apiHost": "http://localhost:3001/dev",
       "edscHost": "http://localhost:8080"
     }
   },

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.js
@@ -98,15 +98,6 @@ export const GranuleResultsTable = ({
       }
     },
     {
-      Header: 'Orig. Format',
-      Cell,
-      accessor: 'originalFormat',
-      width: '100',
-      customProps: {
-        centerContent: true
-      }
-    },
-    {
       Header: 'Day/Night',
       Cell,
       accessor: 'dayNightFlag',

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsTable.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsTable.test.js
@@ -63,10 +63,6 @@ describe('GranuleResultsTable component', () => {
       accessor: 'timeEnd'
     }))
     expect(columns[4]).toEqual(expect.objectContaining({
-      Header: 'Orig. Format',
-      accessor: 'originalFormat'
-    }))
-    expect(columns[5]).toEqual(expect.objectContaining({
       Header: 'Day/Night',
       accessor: 'dayNightFlag'
     }))

--- a/static/src/js/util/formatGranulesList.js
+++ b/static/src/js/util/formatGranulesList.js
@@ -42,7 +42,6 @@ export const formatGranulesList = ({
       id,
       links,
       onlineAccessFlag,
-      originalFormat,
       producerGranuleId,
       thumbnail: granuleThumbnail,
       title
@@ -84,7 +83,6 @@ export const formatGranulesList = ({
       links,
       onlineAccessFlag,
       original,
-      originalFormat,
       temporal,
       thumbnail,
       timeEnd,


### PR DESCRIPTION
# Overview

### What is the feature?

Remove "Orig. Format" from granule results table

### What areas of the application does this impact?

Granule results table view

# Testing

### Reproduction steps

View granule results table view, `Orig. Format` column will be removed

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
