### PR TITLE
EDSC-2986: Adds content type for remaining calls

### DIFF
--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -31,6 +31,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -56,6 +57,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when the tag is not already associated with the collection', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -69,6 +71,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -94,6 +97,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when the tag data already exists', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -114,6 +118,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -139,6 +144,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when new tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -159,6 +165,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -186,6 +193,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when append is set to false', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -206,6 +214,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -231,6 +240,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when requireGranules is set to true (and append is set to true)', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -251,6 +261,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -278,6 +289,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))
@@ -305,6 +317,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided but granules are required', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -325,6 +338,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC'
@@ -345,6 +359,7 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -367,6 +382,7 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -387,6 +403,7 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -416,6 +433,7 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but no collections are returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -440,6 +458,7 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))

--- a/serverless/src/processTag/__tests__/removeTag.test.js
+++ b/serverless/src/processTag/__tests__/removeTag.test.js
@@ -15,6 +15,7 @@ describe('removeTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .delete(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify({ short_name: 'MIL3MLS' }))
       .reply(200)
 
@@ -33,6 +34,7 @@ describe('removeTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .delete(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify({ short_name: 'MIL3MLS' }))
       .reply(500)
 

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -105,6 +105,7 @@ export const addTag = async ({
         url: addTagUrl,
         headers: {
           'Client-Id': getClientId().background,
+          'Content-Type': 'application/x-www-form-urlencoded',
           'Echo-Token': cmrToken
         },
         data: castArray(associationData)
@@ -135,6 +136,7 @@ export const addTag = async ({
       url: tagRemovalUrl,
       headers: {
         'Client-Id': getClientId().background,
+        'Content-Type': 'application/x-www-form-urlencoded',
         'Echo-Token': cmrToken
       },
       data: searchCriteria

--- a/serverless/src/processTag/handler.js
+++ b/serverless/src/processTag/handler.js
@@ -15,9 +15,6 @@ const processTag = async (event, context) => {
 
   const { Records: sqsRecords = [] } = event
 
-  console.log('Received payload:')
-  console.log(JSON.stringify(event.Records, null, 4))
-
   if (sqsRecords.length === 0) return
 
   console.log(`Processing ${sqsRecords.length} tag(s)`)

--- a/serverless/src/processTag/removeTag.js
+++ b/serverless/src/processTag/removeTag.js
@@ -20,6 +20,7 @@ export const removeTag = async (tagName, searchCriteria, cmrToken) => {
       url: tagRemovalUrl,
       headers: {
         'Client-Id': getClientId().background,
+        'Content-Type': 'application/x-www-form-urlencoded',
         'Echo-Token': cmrToken
       },
       data: searchCriteria


### PR DESCRIPTION
# Overview

Adds content type header for cmr calls.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
