### PR TITLE
EDSC-2909: Fixes missing icons

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { Tab } from 'react-bootstrap'
 import { upperFirst } from 'lodash'
+import { FaChevronUp, FaChevronDown } from 'react-icons/fa'
 
 import { getApplicationConfig } from '../../../../../sharedUtils/config'
 import { getStateFromOrderStatus, aggregatedOrderStatus, formatOrderStatus } from '../../../../../sharedUtils/orderStatus'
@@ -616,7 +617,7 @@ export class OrderStatusItem extends PureComponent {
             <Button
               className="order-status-item__button"
               type="icon"
-              icon={opened ? 'FaChevronUp' : 'FaChevronDown'}
+              icon={opened ? FaChevronUp : FaChevronDown}
               label={opened ? 'Close details' : 'Show details'}
               title={opened ? 'Close details' : 'Show details'}
               onClick={this.onOpenClick}

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -11,6 +11,7 @@ import {
   FaInfoCircle,
   FaList,
   FaMap,
+  FaQuestionCircle,
   FaTable
 } from 'react-icons/fa'
 
@@ -391,7 +392,7 @@ class SearchPanels extends PureComponent {
                     onClick={() => onToggleAboutCwicModal(true)}
                     variant="link"
                     bootstrapVariant="link"
-                    icon="question-circle"
+                    icon={FaQuestionCircle}
                     label="More details"
                   >
                     More Details


### PR DESCRIPTION
# Overview

### What is the feature?

A couple of icons were missing, overlooked in the initial EDSC-2909 effort

### What is the Solution?

Icons need to be passed as Icons from the `react-icons/fa` library, not as strings

### What areas of the application does this impact?

Cwic granules page, download page

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
