### PR TITLE
EDSC-2986: Ignore custom products when not in production

### DIFF
--- a/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
+++ b/serverless/src/generateGibsTags/__tests__/getSupportedGibsLayers.test.js
@@ -1,4 +1,5 @@
 import nock from 'nock'
+
 import { gibsResponse, capabilitiesResponse } from './mocks'
 import { getSupportedGibsLayers } from '../getSupportedGibsLayers'
 

--- a/serverless/src/generateGibsTags/__tests__/handler.test.js
+++ b/serverless/src/generateGibsTags/__tests__/handler.test.js
@@ -1,11 +1,27 @@
 import AWS from 'aws-sdk'
 import MockDate from 'mockdate'
 
+import * as deployedEnvironment from '../../../../sharedUtils/deployedEnvironment'
 import * as getSupportedGibsLayers from '../getSupportedGibsLayers'
 
 import generateGibsTags from '../handler'
 
 const OLD_ENV = process.env
+
+const sqsSendMessagePromise = jest.fn().mockReturnValue({
+  promise: jest.fn().mockResolvedValue()
+})
+
+AWS.SQS = jest.fn()
+  .mockImplementationOnce(() => ({
+    sendMessage: sqsSendMessagePromise
+  }))
+  .mockImplementationOnce(() => ({
+    sendMessage: sqsSendMessagePromise
+  }))
+  .mockImplementationOnce(() => ({
+    sendMessage: sqsSendMessagePromise
+  }))
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -29,102 +45,124 @@ afterEach(() => {
 })
 
 describe('generateGibsTags', () => {
-  test('correctly generates and queues tag data', async () => {
-    process.env.tagQueueUrl = 'http://example.com/tagQueue'
+  describe('when deployed environment is production', () => {
+    test('correctly generates and queues tag data including custom products', async () => {
+      process.env.tagQueueUrl = 'http://example.com/tagQueue'
 
-    jest.spyOn(getSupportedGibsLayers, 'getSupportedGibsLayers').mockImplementation(() => ({
-      MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily: {
-        startDate: '2002-07-04T00:00:00Z',
-        palette: {
-          id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily'
-        },
-        description: 'modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
-        format: 'image/png',
-        title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-        period: 'daily',
-        layergroup: [
-          'modis',
-          'modis_aqua'
-        ],
-        group: 'overlays',
-        dateRanges: [
-          {
-            startDate: '2002-07-04T00:00:00Z',
-            dateInterval: '1',
-            endDate: '2019-05-06T00:00:00Z'
-          }
-        ],
-        projections: {
-          geographic: {
-            source: 'GIBS:geographic',
-            matrixSet: '2km'
-          }
-        },
-        subtitle: 'Aqua / MODIS',
-        product: {
-          query: {
-            shortName: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+      jest.spyOn(deployedEnvironment, 'deployedEnvironment').mockImplementationOnce(() => 'prod')
+
+      const getSupportedGibsLayersMock = jest.spyOn(getSupportedGibsLayers, 'getSupportedGibsLayers').mockImplementationOnce(() => ({
+        MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily: {
+          startDate: '2002-07-04T00:00:00Z',
+          palette: {
+            id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily'
           },
-          handler: 'List',
-          name: 'PODAAC-MODAM-1D4N4'
+          description: 'modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+          format: 'image/png',
+          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+          period: 'daily',
+          layergroup: [
+            'modis',
+            'modis_aqua'
+          ],
+          group: 'overlays',
+          dateRanges: [
+            {
+              startDate: '2002-07-04T00:00:00Z',
+              dateInterval: '1',
+              endDate: '2019-05-06T00:00:00Z'
+            }
+          ],
+          projections: {
+            geographic: {
+              source: 'GIBS:geographic',
+              matrixSet: '2km'
+            }
+          },
+          subtitle: 'Aqua / MODIS',
+          product: {
+            query: {
+              shortName: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+            },
+            handler: 'List',
+            name: 'PODAAC-MODAM-1D4N4'
+          },
+          type: 'wmts',
+          id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+          tags: 'ssc podaac PO.DAAC'
         },
-        type: 'wmts',
-        id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
-        tags: 'ssc podaac PO.DAAC'
-      },
-      'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly': {
-        startDate: '2000-02-01',
-        product: {
-          query: {
-            conceptId: ['C84942916-LARC']
-          }
-        },
-        id: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
-        subtitle: 'Terra / MISR',
-        format: 'image/png',
-        title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
-        type: 'wmts',
-        projections: {
-          geographic: {
-            source: 'GIBS:geographic',
-            matrixSet: '2km'
+        'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly': {
+          startDate: '2000-02-01',
+          product: {
+            query: {
+              conceptId: ['C84942916-LARC']
+            }
+          },
+          id: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
+          subtitle: 'Terra / MISR',
+          format: 'image/png',
+          title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
+          type: 'wmts',
+          projections: {
+            geographic: {
+              source: 'GIBS:geographic',
+              matrixSet: '2km'
+            }
           }
         }
-      }
-    }))
-
-    const sqsSendMessagePromise = jest.fn().mockReturnValue({
-      promise: jest.fn().mockResolvedValue()
-    })
-
-    AWS.SQS = jest.fn()
-      .mockImplementationOnce(() => ({
-        sendMessage: sqsSendMessagePromise
-      }))
-      .mockImplementationOnce(() => ({
-        sendMessage: sqsSendMessagePromise
-      }))
-      .mockImplementationOnce(() => ({
-        sendMessage: sqsSendMessagePromise
       }))
 
-    await generateGibsTags({}, {})
+      await generateGibsTags({}, {})
 
-    expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
-      QueueUrl: 'http://example.com/tagQueue',
-      MessageBody: JSON.stringify({
-        tagName: 'edsc.extra.serverless.gibs',
-        action: 'ADD',
-        requireGranules: false,
-        tagData: {
-          'concept-id': 'C84942916-LARC',
-          data: [{
+      expect(getSupportedGibsLayersMock).toBeCalledWith(true)
+
+      expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'ADD',
+          requireGranules: false,
+          tagData: {
+            'concept-id': 'C84942916-LARC',
+            data: [{
+              match: {
+                time_start: '>=2000-02-01'
+              },
+              product: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
+              title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
+              source: 'Terra / MISR',
+              format: 'png',
+              updated_at: '1988-09-03T10:00:00.000Z',
+              antarctic: false,
+              antarctic_resolution: null,
+              arctic: false,
+              arctic_resolution: null,
+              geographic: true,
+              geographic_resolution: '2km'
+            }]
+          }
+        })
+      }])
+
+      expect(sqsSendMessagePromise.mock.calls[1]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'ADD',
+          requireGranules: false,
+          searchCriteria: {
+            condition: {
+              short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+            }
+          },
+          tagData: [{
             match: {
-              time_start: '>=2000-02-01'
+              time_start: '>=2002-07-04T00:00:00Z'
             },
-            product: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
-            title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
-            source: 'Terra / MISR',
+            product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+            group: 'overlays',
+            title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+            source: 'Aqua / MODIS',
             format: 'png',
             updated_at: '1988-09-03T10:00:00.000Z',
             antarctic: false,
@@ -134,66 +172,194 @@ describe('generateGibsTags', () => {
             geographic: true,
             geographic_resolution: '2km'
           }]
-        }
-      })
-    }])
+        })
+      }])
 
-    expect(sqsSendMessagePromise.mock.calls[1]).toEqual([{
-      QueueUrl: 'http://example.com/tagQueue',
-      MessageBody: JSON.stringify({
-        tagName: 'edsc.extra.serverless.gibs',
-        action: 'ADD',
-        requireGranules: false,
-        searchCriteria: {
-          condition: {
-            short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+      expect(sqsSendMessagePromise.mock.calls[2]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'REMOVE',
+          searchCriteria: {
+            condition: {
+              and: [{
+                tag: {
+                  tag_key: 'edsc.extra.serverless.gibs'
+                }
+              }, {
+                not: {
+                  or: [
+                    {
+                      concept_id: 'C84942916-LARC'
+                    }, {
+                      short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+                    }
+                  ]
+                }
+              }]
+            }
           }
-        },
-        tagData: [{
-          match: {
-            time_start: '>=2002-07-04T00:00:00Z'
-          },
-          product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
-          group: 'overlays',
-          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
-          source: 'Aqua / MODIS',
-          format: 'png',
-          updated_at: '1988-09-03T10:00:00.000Z',
-          antarctic: false,
-          antarctic_resolution: null,
-          arctic: false,
-          arctic_resolution: null,
-          geographic: true,
-          geographic_resolution: '2km'
-        }]
-      })
-    }])
+        })
+      }])
+    })
+  })
 
-    expect(sqsSendMessagePromise.mock.calls[2]).toEqual([{
-      QueueUrl: 'http://example.com/tagQueue',
-      MessageBody: JSON.stringify({
-        tagName: 'edsc.extra.serverless.gibs',
-        action: 'REMOVE',
-        searchCriteria: {
-          condition: {
-            and: [{
-              tag: {
-                tag_key: 'edsc.extra.serverless.gibs'
-              }
-            }, {
-              not: {
-                or: [
-                  {
-                    concept_id: 'C84942916-LARC'
-                  }, {
-                    short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
-                  }
-                ]
-              }
+  describe('when deployed environment is production', () => {
+    test('correctly generates and queues tag data excluding custom products', async () => {
+      process.env.tagQueueUrl = 'http://example.com/tagQueue'
+
+      jest.spyOn(deployedEnvironment, 'deployedEnvironment').mockImplementationOnce(() => 'sit')
+
+      const getSupportedGibsLayersMock = jest.spyOn(getSupportedGibsLayers, 'getSupportedGibsLayers').mockImplementationOnce(() => ({
+        MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily: {
+          startDate: '2002-07-04T00:00:00Z',
+          palette: {
+            id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily'
+          },
+          description: 'modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+          format: 'image/png',
+          title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+          period: 'daily',
+          layergroup: [
+            'modis',
+            'modis_aqua'
+          ],
+          group: 'overlays',
+          dateRanges: [
+            {
+              startDate: '2002-07-04T00:00:00Z',
+              dateInterval: '1',
+              endDate: '2019-05-06T00:00:00Z'
+            }
+          ],
+          projections: {
+            geographic: {
+              source: 'GIBS:geographic',
+              matrixSet: '2km'
+            }
+          },
+          subtitle: 'Aqua / MODIS',
+          product: {
+            query: {
+              shortName: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+            },
+            handler: 'List',
+            name: 'PODAAC-MODAM-1D4N4'
+          },
+          type: 'wmts',
+          id: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+          tags: 'ssc podaac PO.DAAC'
+        },
+        'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly': {
+          startDate: '2000-02-01',
+          product: {
+            query: {
+              conceptId: ['C84942916-LARC']
+            }
+          },
+          id: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
+          subtitle: 'Terra / MISR',
+          format: 'image/png',
+          title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
+          type: 'wmts',
+          projections: {
+            geographic: {
+              source: 'GIBS:geographic',
+              matrixSet: '2km'
+            }
+          }
+        }
+      }))
+
+      await generateGibsTags({}, {})
+
+      expect(getSupportedGibsLayersMock).toBeCalledWith(false)
+
+      expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'ADD',
+          requireGranules: false,
+          tagData: {
+            'concept-id': 'C84942916-LARC',
+            data: [{
+              match: {
+                time_start: '>=2000-02-01'
+              },
+              product: 'MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-20km_Monthly',
+              title: 'Cloud Stereo Height (No Wind Correction, 1.5 - 2.0 km, Monthly)',
+              source: 'Terra / MISR',
+              format: 'png',
+              updated_at: '1988-09-03T10:00:00.000Z',
+              antarctic: false,
+              antarctic_resolution: null,
+              arctic: false,
+              arctic_resolution: null,
+              geographic: true,
+              geographic_resolution: '2km'
             }]
           }
-        }
-      })
-    }])
+        })
+      }])
+
+      expect(sqsSendMessagePromise.mock.calls[1]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'ADD',
+          requireGranules: false,
+          searchCriteria: {
+            condition: {
+              short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+            }
+          },
+          tagData: [{
+            match: {
+              time_start: '>=2002-07-04T00:00:00Z'
+            },
+            product: 'MODIS_Aqua_L3_SST_MidIR_4km_Night_Daily',
+            group: 'overlays',
+            title: 'Sea Surface Temperature (L3, Night, Daily, Mid Infrared, 4 km)',
+            source: 'Aqua / MODIS',
+            format: 'png',
+            updated_at: '1988-09-03T10:00:00.000Z',
+            antarctic: false,
+            antarctic_resolution: null,
+            arctic: false,
+            arctic_resolution: null,
+            geographic: true,
+            geographic_resolution: '2km'
+          }]
+        })
+      }])
+
+      expect(sqsSendMessagePromise.mock.calls[2]).toEqual([{
+        QueueUrl: 'http://example.com/tagQueue',
+        MessageBody: JSON.stringify({
+          tagName: 'edsc.extra.serverless.gibs',
+          action: 'REMOVE',
+          searchCriteria: {
+            condition: {
+              and: [{
+                tag: {
+                  tag_key: 'edsc.extra.serverless.gibs'
+                }
+              }, {
+                not: {
+                  or: [
+                    {
+                      concept_id: 'C84942916-LARC'
+                    }, {
+                      short_name: 'MODIS_AQUA_L3_SST_MID-IR_DAILY_4KM_NIGHTTIME_V2014.0'
+                    }
+                  ]
+                }
+              }]
+            }
+          }
+        })
+      }])
+    })
   })
 })

--- a/serverless/src/generateGibsTags/handler.js
+++ b/serverless/src/generateGibsTags/handler.js
@@ -1,11 +1,14 @@
 import 'array-foreach-async'
 import AWS from 'aws-sdk'
+
 import { groupBy, omit } from 'lodash'
-import { getSqsConfig } from '../util/aws/getSqsConfig'
-import { tagName } from '../../../sharedUtils/tags'
+
 import { constructLayerTagData } from './constructLayerTagData'
-import { getSupportedGibsLayers } from './getSupportedGibsLayers'
+import { deployedEnvironment } from '../../../sharedUtils/deployedEnvironment'
 import { getApplicationConfig } from '../../../sharedUtils/config'
+import { getSqsConfig } from '../util/aws/getSqsConfig'
+import { getSupportedGibsLayers } from './getSupportedGibsLayers'
+import { tagName } from '../../../sharedUtils/tags'
 
 // AWS SQS adapter
 let sqs
@@ -25,7 +28,12 @@ const generateGibsTags = async (event, context) => {
   // The headers we'll send back regardless of our response
   const { defaultResponseHeaders } = getApplicationConfig()
 
-  const supportedGibsLayers = await getSupportedGibsLayers()
+  // Prevent merging custom products in non-production deployments
+  let mergeCustomProducts = false
+  if (deployedEnvironment() === 'prod') {
+    mergeCustomProducts = true
+  }
+  const supportedGibsLayers = await getSupportedGibsLayers(mergeCustomProducts)
 
   const layerTagData = []
 

--- a/serverless/src/processTag/__tests__/addTag.test.js
+++ b/serverless/src/processTag/__tests__/addTag.test.js
@@ -31,7 +31,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -57,7 +56,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when the tag is not already associated with the collection', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -71,7 +69,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -97,7 +94,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when the tag data already exists', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -118,7 +114,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -144,7 +139,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when new tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -165,7 +159,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -193,7 +186,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when append is set to false', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -214,7 +206,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -240,7 +231,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when requireGranules is set to true (and append is set to true)', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -261,7 +251,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -289,7 +278,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))
@@ -317,7 +305,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided but granules are required', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true&has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -338,7 +325,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC'
@@ -359,7 +345,6 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -382,7 +367,6 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but an error is returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -403,7 +387,6 @@ describe('addTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify([
         {
           'concept-id': 'C123456789-EDSC',
@@ -433,7 +416,6 @@ describe('addTag', () => {
   test('does not call the cmr endpoint when tag data is provided but no collections are returned from the collection search endpoint', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post('/search/collections.json?include_tags=edsc.extra.gibs&include_has_granules=true', {
         short_name: 'MIL3MLS'
       })
@@ -458,7 +440,6 @@ describe('addTag', () => {
   test('correctly calls cmr endpoint when no tag data is provided', async () => {
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .post(/search\/tags\/edsc\.extra\.gibs\/associations\/by_query/, JSON.stringify({
         short_name: 'MIL3MLS'
       }))

--- a/serverless/src/processTag/__tests__/removeTag.test.js
+++ b/serverless/src/processTag/__tests__/removeTag.test.js
@@ -15,7 +15,6 @@ describe('removeTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .delete(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify({ short_name: 'MIL3MLS' }))
       .reply(200)
 
@@ -34,7 +33,6 @@ describe('removeTag', () => {
 
     nock(/example/)
       .matchHeader('Echo-Token', '1234-abcd-5678-efgh')
-      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
       .delete(/search\/tags\/edsc\.extra\.gibs\/associations/, JSON.stringify({ short_name: 'MIL3MLS' }))
       .reply(500)
 

--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -105,7 +105,6 @@ export const addTag = async ({
         url: addTagUrl,
         headers: {
           'Client-Id': getClientId().background,
-          'Content-Type': 'application/x-www-form-urlencoded',
           'Echo-Token': cmrToken
         },
         data: castArray(associationData)
@@ -136,7 +135,6 @@ export const addTag = async ({
       url: tagRemovalUrl,
       headers: {
         'Client-Id': getClientId().background,
-        'Content-Type': 'application/x-www-form-urlencoded',
         'Echo-Token': cmrToken
       },
       data: searchCriteria

--- a/serverless/src/processTag/removeTag.js
+++ b/serverless/src/processTag/removeTag.js
@@ -20,7 +20,6 @@ export const removeTag = async (tagName, searchCriteria, cmrToken) => {
       url: tagRemovalUrl,
       headers: {
         'Client-Id': getClientId().background,
-        'Content-Type': 'application/x-www-form-urlencoded',
         'Echo-Token': cmrToken
       },
       data: searchCriteria


### PR DESCRIPTION
# Overview

### What is the feature?

Prevent errors in the processTag lambda by ensuring that we dont merge custom products into the Gibs job when not in production.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
