### PR TITLE
EDSC-3046: Granule link overflow fix

### DIFF
--- a/static/src/js/components/CollapsePanel/CollapsePanel.js
+++ b/static/src/js/components/CollapsePanel/CollapsePanel.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Collapse } from 'react-bootstrap'
 import $ from 'jquery'
-import { FaChevronCircleUp, FaChevronCircleDown } from 'react-icons/fa'
+import { FaChevronUp, FaChevronDown } from 'react-icons/fa'
 
 import scrollParent from '../../util/scrollParent'
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
@@ -51,8 +51,8 @@ export class CollapsePanel extends Component {
     const panelClassNames = `collapse-panel__panel ${panelClassName}`
 
     const icon = open
-      ? <EDSCIcon icon={FaChevronCircleUp} />
-      : <EDSCIcon icon={FaChevronCircleDown} />
+      ? <EDSCIcon className="collapse-panel__button-secondary-icon" icon={FaChevronUp} />
+      : <EDSCIcon className="collapse-panel__button-secondary-icon" icon={FaChevronDown} />
 
     return (
       <div className={classNames}>

--- a/static/src/js/components/CollapsePanel/CollapsePanel.scss
+++ b/static/src/js/components/CollapsePanel/CollapsePanel.scss
@@ -4,4 +4,15 @@
     justify-content: space-between;
     align-items: center;
   }
+
+  &__button-secondary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__button-secondary-icon {
+    width: 0.825rem;
+    height: 0.825rem;
+  }
 }

--- a/static/src/js/components/CollapsePanel/__tests__/CollapsePanel.test.js
+++ b/static/src/js/components/CollapsePanel/__tests__/CollapsePanel.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import { FaChevronCircleDown, FaChevronCircleUp } from 'react-icons/fa'
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa'
 
 import { CollapsePanel } from '../CollapsePanel'
 
@@ -45,10 +45,10 @@ describe('CollapsePanel component', () => {
     const { enzymeWrapper } = setup()
     const button = enzymeWrapper.find('button')
     expect(enzymeWrapper.state('open')).toEqual(false)
-    expect(enzymeWrapper.find('EDSCIcon').prop('icon')).toEqual(FaChevronCircleDown)
+    expect(enzymeWrapper.find('EDSCIcon').prop('icon')).toEqual(FaChevronDown)
     button.simulate('click')
     expect(enzymeWrapper.state('open')).toEqual(true)
-    expect(enzymeWrapper.find('EDSCIcon').prop('icon')).toEqual(FaChevronCircleUp)
+    expect(enzymeWrapper.find('EDSCIcon').prop('icon')).toEqual(FaChevronUp)
   })
 
   test('renders it children correctly', () => {

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.scss
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.scss
@@ -106,13 +106,16 @@
   }
 
   &__action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-bottom: $spacer/4;
     color: $color__black--500;
-    padding: 0.3rem 0.625rem;
+    padding: 0.625rem 0.825rem;
     font-size: 0.925rem;
 
     .panels--sm & {
-      padding: 0.375rem 0.75rem;
+      padding: 0.625rem 0.825rem;
       font-size: 1rem;
     }
 
@@ -128,6 +131,11 @@
     .collection-results-item__link:hover & {
       background-color: $color__black--200;
       color: $color__black--600;
+    }
+
+    .edsc-icon {
+      height: 1.125rem;
+      width: 1.125rem;
     }
 
     &--add {

--- a/static/src/js/components/CustomToggle/MoreActionsToggle.scss
+++ b/static/src/js/components/CustomToggle/MoreActionsToggle.scss
@@ -1,4 +1,5 @@
 .more-actions-toggle {
   color: $color__black--400;
   font-size: 1.125rem;
+  width: 1.125rem;
 }

--- a/static/src/js/components/DataQualitySummary/DataQualitySummary.js
+++ b/static/src/js/components/DataQualitySummary/DataQualitySummary.js
@@ -18,7 +18,7 @@ export const DataQualitySummary = ({
         className="data-quality-summary__panel"
         header={(
           <>
-            <EDSCIcon icon={FaExclamationCircle} />
+            <EDSCIcon icon={FaExclamationCircle} className="data-quality-summary__icon" />
             {' Important data quality information'}
           </>
         )}

--- a/static/src/js/components/DataQualitySummary/DataQualitySummary.scss
+++ b/static/src/js/components/DataQualitySummary/DataQualitySummary.scss
@@ -21,6 +21,11 @@
       }
     }
 
+    .collapse-panel__button-primary {
+      display: flex;
+      align-items: center;
+    }
+
     .collapse-panel__button-secondary {
       color: rgba($color__black, 0.4)
     }
@@ -44,5 +49,11 @@
         max-height: 400px;
       }
     }
+  }
+
+  &__icon {
+    margin-right: 0.5rem;
+    color: rgba($color__black, 0.75);    width: 0.725rem;
+    height: 0.725rem;
   }
 }

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -49,7 +49,8 @@
 
   &__radio-icon {
     color: $color__white;
-    font-size: 0.625rem !important;
+    width: 0.625rem;
+    height: 0.625rem;
   }
 
   &__content {

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -62,7 +62,7 @@ export const GranuleResultsDataLinksButton = ({
         <Dropdown.Toggle as={CustomDataLinksToggle} />
         {
           ReactDOM.createPortal(
-            <Dropdown.Menu>
+            <Dropdown.Menu className="granule-results-data-links-button__menu">
               {
                 dataLinks.map((dataLink, i) => {
                   const key = `data_link_${i}`

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
@@ -8,9 +8,9 @@
       color: $color__black--200;
     }
   }
-}
 
-.dropdown-menu {
-  max-height: 15.825rem;
-  overflow-y: scroll;
+  &__menu {
+    max-height: 15.825rem;
+    overflow-y: scroll !important; // !important is needed here to override the !important included in the bootstrap css for .dropdown-menu
+  }
 }

--- a/static/src/js/components/MoreActionsDropdown/MoreActionsDropdown.scss
+++ b/static/src/js/components/MoreActionsDropdown/MoreActionsDropdown.scss
@@ -1,4 +1,7 @@
 .more-actions-dropdown {
+  display: flex;
+  align-items: center;
+
   &__toggle {
     &:hover,
     &:focus {
@@ -8,5 +11,11 @@
 
   &__menu {
     box-shadow: $box-shadow;
+  }
+
+  &__dropdown {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/static/src/js/components/ProjectCollections/ProjectCollectionItem.scss
+++ b/static/src/js/components/ProjectCollections/ProjectCollectionItem.scss
@@ -31,6 +31,7 @@
 
   &__header {
     display: flex;
+    align-items: flex-start;
   }
 
   &__title-button {
@@ -108,6 +109,9 @@
   }
 
   &__more-options-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 0;
     font-size: 0.85rem;
     color: $color__black--500;


### PR DESCRIPTION
# Overview

### What is the feature?

This PR addresses an issue where lists of granule links on granule search results were overflowing their container. There are also a few small css tweaks improving the display of icons on the project page.

### What is the Solution?

Tweak css to correctly override the default boostrap class causing the issue.

### What areas of the application does this impact?

Granule search results and the project page

# Testing

### Reproduction steps

- **Environment for testing:** Prod
- **Collection to test with:** C1711924822-LPCLOUD

1. Visit /search/granules?p=C1711924822-LPCLOUD&pg[0][gsk]=-start_date&q=hls&m=-8.718732723754655!-159.374267578125!7!1!0!0%2C2&tl=1595431927!4!!
2. Open the links on any granule
3. Confirm the list scrolls when links exist outside of the dropdown
4. Confirm the icons on the project page display as intended

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
