### PR TITLE
EDSC-2055: Disable download button on projects with an esi order that hasn't been customized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       run: npm run silent-test
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1
+      with:
+        files: './coverage/clover.xml'
   cypress:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       run: npm run silent-test
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1
-      with:
-        files: './coverage/clover.xml'
   cypress:
     runs-on: ubuntu-latest
     strategy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,9 +2956,9 @@
       }
     },
     "@edsc/echoforms": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.9.tgz",
-      "integrity": "sha512-epvgByHSnMJ1Dp95E2EE9PsclQtta07UgtD/SpVaLqWBK/Vd7yxj9RZWkcqSV0yPqc0ddYUEa3DCyn+W9LQRlg==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@edsc/echoforms/-/echoforms-1.1.10.tgz",
+      "integrity": "sha512-MZ05CsMB4dQA5HuTlwvIg7HQSPI1rd6dW2x6dgbLmmmvOn2hLcXLYi+Ea2/zX9umrtCQRT/DaY5NfCq3+AaRXg==",
       "requires": {
         "murmurhash": "^1.0.0",
         "react-icons": "^3.10.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.9.0",
     "@babel/runtime": "^7.4.4",
-    "@edsc/echoforms": "^1.1.9",
+    "@edsc/echoforms": "^1.1.10",
     "@edsc/timeline": "^1.0.1",
     "@googlemaps/google-maps-services-js": "^3.1.14",
     "@hot-loader/react-dom": "^16.12.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -126,7 +126,7 @@ custom:
   # Default is 3000 so to avoid conflicts with rails applications we'll define a new port
   serverless-offline:
     httpPort: 3001
-    useSeparateProcesses: true
+    allowCache: true
 
   # Serverless Webpack configurations
   webpack:

--- a/static/src/js/components/AccessMethod/EchoForm.js
+++ b/static/src/js/components/AccessMethod/EchoForm.js
@@ -112,9 +112,14 @@ export const EchoForm = ({
   }
 
   const onFormModelUpdated = (value) => {
-    const { model, rawModel: newRawModel } = value
+    const {
+      hasChanged,
+      model,
+      rawModel: newRawModel
+    } = value
 
     updateAccessMethod({
+      hasChanged,
       model,
       rawModel: newRawModel
     })

--- a/static/src/js/components/ProjectCollections/ProjectCollections.js
+++ b/static/src/js/components/ProjectCollections/ProjectCollections.js
@@ -94,7 +94,8 @@ export class ProjectCollections extends Component {
     const {
       valid: isValid,
       noGranules,
-      tooManyGranules
+      tooManyGranules,
+      needsCustomization
     } = isProjectValid(project, projectCollectionsMetadata)
 
     const { isSubmitting } = project
@@ -137,9 +138,16 @@ export class ProjectCollections extends Component {
             !isLoading && (
               <p className="project-collections__footer-message">
                 {
-                  !isValid && !tooManyGranules && !noGranules && (
+                  !isValid && !tooManyGranules && !noGranules && !needsCustomization && (
                     <>
                       {'Select a data access method for each collection in your project before downloading.'}
+                    </>
+                  )
+                }
+                {
+                  !isValid && needsCustomization && (
+                    <>
+                      {'One or more collections in your project have an access method selected that requires customization options. Please select a customization option or choose a different access method.'}
                     </>
                   )
                 }

--- a/static/src/js/components/ProjectCollections/__tests__/ProjectCollections.test.js
+++ b/static/src/js/components/ProjectCollections/__tests__/ProjectCollections.test.js
@@ -2,17 +2,28 @@ import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
+import Button from '../../Button/Button'
 import ProjectCollections from '../ProjectCollections'
 import ProjectCollectionsList from '../ProjectCollectionsList'
 import ProjectHeader from '../ProjectHeader'
 import projections from '../../../util/map/projections'
 
+import * as isProjectValid from '../../../util/isProjectValid'
+import { validAccessMethod } from '../../../util/accessMethods'
+
 Enzyme.configure({ adapter: new Adapter() })
 
-function setup() {
+function setup(overrideProps = {}) {
   const props = {
-    collectionSearch: {},
     collectionsQuery: {
+      byId: {
+        collectionId1: {
+          granules: {}
+        },
+        collectionId2: {
+          granules: {}
+        }
+      },
       pageNum: 1
     },
     mapProjection: projections.geographic,
@@ -43,7 +54,7 @@ function setup() {
         mock: 'data 2'
       }
     },
-    projectCollectionsIds: [],
+    projectCollectionsIds: ['collectionId1', 'collectionId2'],
     panels: {
       activePanel: '0.0.0',
       isOpen: false
@@ -61,7 +72,8 @@ function setup() {
     onSetActivePanelSection: jest.fn(),
     onUpdateFocusedCollection: jest.fn(),
     onViewCollectionDetails: jest.fn(),
-    onViewCollectionGranules: jest.fn()
+    onViewCollectionGranules: jest.fn(),
+    ...overrideProps
   }
 
   const enzymeWrapper = shallow(<ProjectCollections {...props} />)
@@ -77,7 +89,7 @@ describe('ProjectCollectionsList component', () => {
     const { enzymeWrapper, props } = setup()
 
     expect(enzymeWrapper.find(ProjectHeader).length).toBe(1)
-    expect(enzymeWrapper.find(ProjectHeader).props().collectionsQuery).toEqual({ pageNum: 1 })
+    expect(enzymeWrapper.find(ProjectHeader).props().collectionsQuery).toEqual(props.collectionsQuery)
     expect(enzymeWrapper.find(ProjectHeader).props().project).toEqual({
       collections: {
         allIds: ['collectionId1', 'collectionId2'],
@@ -135,5 +147,178 @@ describe('ProjectCollectionsList component', () => {
       .toEqual(props.onMetricsDataAccess)
 
     expect(enzymeWrapper.find('.project-collections__footer').length).toBe(1)
+  })
+
+  describe('help text', () => {
+    describe('when all project collections are valid', () => {
+      test('displays the correct help text', () => {
+        jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+          ...validAccessMethod
+        }))
+        const { enzymeWrapper } = setup()
+
+        const message = enzymeWrapper.find('.project-collections__footer-message')
+
+        expect(message.text()).toEqual(`Click ${String.fromCharCode(8220)}Edit Options${String.fromCharCode(8221)} above to customize the output for each project.`)
+      })
+    })
+
+    describe('when an access method has not been selected', () => {
+      test('displays the correct help text', () => {
+        jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+          ...validAccessMethod,
+          valid: false
+        }))
+        const { enzymeWrapper } = setup()
+
+        const message = enzymeWrapper.find('.project-collections__footer-message')
+
+        expect(message.text()).toEqual('Select a data access method for each collection in your project before downloading.')
+      })
+    })
+
+    describe('when an access method needs customization', () => {
+      test('displays the correct help text', () => {
+        jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+          ...validAccessMethod,
+          valid: false,
+          needsCustomization: true
+        }))
+        const { enzymeWrapper } = setup()
+
+        const message = enzymeWrapper.find('.project-collections__footer-message')
+
+        expect(message.text()).toEqual('One or more collections in your project have an access method selected that requires customization options. Please select a customization option or choose a different access method.')
+      })
+    })
+
+    describe('when a project collection has too many granules', () => {
+      test('displays the correct help text', () => {
+        jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+          ...validAccessMethod,
+          valid: false,
+          tooManyGranules: true
+        }))
+        const { enzymeWrapper } = setup()
+
+        const message = enzymeWrapper.find('.project-collections__footer-message')
+
+        expect(message.text()).toEqual('One or more collections in your project contains too many granules. Adjust temporal constraints or remove the collections before downloading.')
+      })
+    })
+
+    describe('when a project collection has no granules', () => {
+      test('displays the correct help text', () => {
+        jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+          ...validAccessMethod,
+          valid: false,
+          noGranules: true
+        }))
+        const { enzymeWrapper } = setup()
+
+        const message = enzymeWrapper.find('.project-collections__footer-message')
+
+        expect(message.text()).toEqual('One or more collections in your project does not contain granules. Adjust temporal constraints or remove the collections before downloading.')
+      })
+    })
+  })
+
+  describe('Download Data button', () => {
+    test('is enabled when the project is valid', () => {
+      jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+        ...validAccessMethod
+      }))
+      const { enzymeWrapper } = setup()
+
+      const button = enzymeWrapper.find(Button)
+
+      expect(button.props().disabled).toBeFalsy()
+    })
+
+    test('is disabled when the project is invalid', () => {
+      jest.spyOn(isProjectValid, 'isProjectValid').mockImplementation(() => ({
+        ...validAccessMethod,
+        valid: false
+      }))
+      const { enzymeWrapper } = setup()
+
+      const button = enzymeWrapper.find(Button)
+
+      expect(button.props().disabled).toBeTruthy()
+    })
+  })
+
+  describe('componentDidUpdate', () => {
+    test('calls onMetricsDataAccess and sets this.sentDataAccessMetrics', () => {
+      const { enzymeWrapper, props } = setup()
+
+      enzymeWrapper.setProps({
+        project: {
+          collections: {
+            allIds: ['collectionId1', 'collectionId2'],
+            byId: {
+              collectionId1: {
+                isValid: true,
+                granules: {
+                  hits: 1
+                }
+              },
+              collectionId2: {
+                isValid: true,
+                granules: {
+                  hits: 1
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(props.onMetricsDataAccess).toBeCalledTimes(2) // 2 collections
+      expect(props.onMetricsDataAccess).toBeCalledWith({ collections: [{ collectionId: 'collectionId1' }], type: 'data_access_init' })
+      expect(props.onMetricsDataAccess).toBeCalledWith({ collections: [{ collectionId: 'collectionId2' }], type: 'data_access_init' })
+
+      expect(enzymeWrapper.instance().sentDataAccessMetrics).toBeTruthy()
+    })
+
+    test('does not call onMetricsDataAccess if this.sentDataAccessMetrics is true', () => {
+      const { enzymeWrapper, props } = setup()
+
+      enzymeWrapper.instance().sentDataAccessMetrics = true
+
+      enzymeWrapper.setProps({
+        project: {
+          collections: {
+            allIds: ['collectionId1', 'collectionId2'],
+            byId: {
+              collectionId1: {
+                isValid: true,
+                granules: {
+                  hits: 1
+                }
+              },
+              collectionId2: {
+                isValid: true,
+                granules: {
+                  hits: 1
+                }
+              }
+            }
+          }
+        }
+      })
+
+      expect(props.onMetricsDataAccess).toBeCalledTimes(0)
+    })
+  })
+
+  describe('componentWillUnmount', () => {
+    test('sets this.sentDataAccessMetrics', () => {
+      const { enzymeWrapper } = setup()
+
+      enzymeWrapper.instance().componentWillUnmount()
+
+      expect(enzymeWrapper.instance().sentDataAccessMetrics).toBeFalsy()
+    })
   })
 })

--- a/static/src/js/containers/UrlQueryContainer/UrlQueryContainer.js
+++ b/static/src/js/containers/UrlQueryContainer/UrlQueryContainer.js
@@ -28,7 +28,7 @@ export const mapStateToProps = state => ({
   earthdataEnvironment: getEarthdataEnvironment(state),
   featureFacets: state.facetsParams.feature,
   focusedCollection: getFocusedCollectionId(state),
-  focusedGranuleId: getFocusedGranuleId(state),
+  focusedGranule: getFocusedGranuleId(state),
   granuleDataFormatFacets: state.facetsParams.cmr.granule_data_format_h,
   hasGranulesOrCwic: state.query.collection.hasGranulesOrCwic,
   horizontalDataResolutionRangeFacets: state.facetsParams.cmr.horizontal_data_resolution_range,

--- a/static/src/js/containers/UrlQueryContainer/__tests__/UrlQueryContainer.test.js
+++ b/static/src/js/containers/UrlQueryContainer/__tests__/UrlQueryContainer.test.js
@@ -143,7 +143,7 @@ describe('mapStateToProps', () => {
       earthdataEnvironment: 'prod',
       featureFacets: {},
       focusedCollection: 'collectionId',
-      focusedGranuleId: 'granuleIdId',
+      focusedGranule: 'granuleIdId',
       granuleDataFormatFacets: [],
       hasGranulesOrCwic: false,
       horizontalDataResolutionRangeFacets: [],

--- a/static/src/js/util/accessMethods.js
+++ b/static/src/js/util/accessMethods.js
@@ -6,7 +6,8 @@ import { getGranuleLimit } from './collectionMetadata/granuleLimit'
 export const validAccessMethod = {
   valid: true,
   noGranules: false,
-  tooManyGranules: false
+  tooManyGranules: false,
+  needsCustomization: false
 }
 
 /**
@@ -59,10 +60,19 @@ export const isAccessMethodValid = (projectCollection, collectionMetadata) => {
 
   const { [selectedAccessMethod]: selectedMethod = {} } = accessMethods
 
-  const { isValid = false } = selectedMethod
+  const {
+    isValid = false,
+    hasChanged = false
+  } = selectedMethod
+
+  let esiNeedsCustomization = false
+  if (selectedAccessMethod.startsWith('esi') && !hasChanged) {
+    esiNeedsCustomization = true
+  }
 
   return {
     ...validAccessMethod,
-    valid: isValid
+    valid: isValid && !esiNeedsCustomization,
+    needsCustomization: esiNeedsCustomization
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

ESI (customize) orders need to be customized before submission to avoid unnecessary processing with providers. This code disables the download data button for ESI orders until a customization option has been selected

### What areas of the application does this impact?

Customize orders

# Testing

### Reproduction steps

Load the project page with a customizable collection.
Select the Customize access method.
You will see the Download Data button disabled and a message you need to select a customization option or choose a different access method.
If you have previously download that collection, reset the form to see the message.
The Download Data button will be enabled after applying a customization.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
