### PR TITLE
EDSC-3061: Fixes project submission with HUC s patial

### DIFF
--- a/static/src/js/util/__tests__/granules.test.js
+++ b/static/src/js/util/__tests__/granules.test.js
@@ -41,7 +41,7 @@ describe('#withAdvancedSearch', () => {
         const result = withAdvancedSearch(collectionParams, advancedSearch)
 
         expect(result).toEqual({
-          polygon: advSearchPolygon
+          polygon: [advSearchPolygon]
         })
       })
     })

--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -28,7 +28,8 @@ export const withAdvancedSearch = (granuleParams, advancedSearch) => {
 
   // If we have a spatial value for the selectedRegion, use that for the spatial
   if (!isEmpty(selectedRegion) && selectedRegion.spatial) {
-    mergedParams.polygon = selectedRegion.spatial
+    // Query spatial is saved as an array, but the selectedRegion spatial is not
+    mergedParams.polygon = [selectedRegion.spatial]
   }
 
   return mergedParams


### PR DESCRIPTION
# Overview

### What is the feature?

Projects with HUC spatial are unable to submit.

### What is the Solution?

HUC spatial is saved in the store as a string, but we save regular spatial as an array of strings. When we prepare granule params we need to wrap HUC spatial in an array to match the regular spatial params

### What areas of the application does this impact?

Projects with HUC spatial

# Testing

### Reproduction steps

Use advanced search to find a HUC polygon (HUC 020801 will work)
Find a collection that matches that spatial and try to submit a project with that collection.
The project should submit successfully

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
