### PR TITLE
Update generated download script to use bash instead of sh

### DIFF
--- a/static/src/js/util/files/generateDownloadScript.js
+++ b/static/src/js/util/files/generateDownloadScript.js
@@ -19,7 +19,7 @@ export const generateDownloadScript = (granuleLinks, retrievalCollection, earthd
   let { edlHost } = getEarthdataConfig(earthdataEnvironment)
   edlHost = url.parse(edlHost).host
 
-  return `#!/bin/sh
+  return `#!/bin/bash
 
 GREP_OPTIONS=''
 


### PR DESCRIPTION
When I try running this download script under Ubuntu it doesn't run.  It is targeting sh and some of the commands used in the script are bash specific.  I retested the script under bash and it runs well.