### PR TITLE
EDSC-3077: Caches GIBS imagery in memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22004,6 +22004,11 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "lrucache": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lrucache/-/lrucache-1.0.3.tgz",
+      "integrity": "sha1-Ox3tDRuoLhiLm9q6nu5khvhkpDQ="
+    },
     "luxon": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "leaflet-draw": "^1.0.4",
     "lodash": "^4.17.20",
     "lowercase-keys": "^2.0.0",
+    "lrucache": "^1.0.3",
     "mini-css-extract-plugin": "^0.5.0",
     "moment": "^2.24.0",
     "node-forge": "^0.10.0",

--- a/static/src/js/components/Map/GranuleGridLayer.js
+++ b/static/src/js/components/Map/GranuleGridLayer.js
@@ -101,6 +101,7 @@ export class GranuleGridLayer extends MapLayer {
       onChangeFocusedGranule,
       onExcludeGranule,
       onMetricsMap,
+      imageryCache,
       isProjectPage
     } = props
 
@@ -125,6 +126,7 @@ export class GranuleGridLayer extends MapLayer {
         focusedCollectionId,
         focusedGranuleId,
         granules: granuleData,
+        imageryCache,
         isProjectPage,
         metadata,
         onChangeFocusedGranule,
@@ -163,6 +165,7 @@ export class GranuleGridLayer extends MapLayer {
       focusedGranuleId,
       projection,
       project,
+      imageryCache,
       isProjectPage,
       onChangeFocusedGranule,
       onExcludeGranule,
@@ -323,6 +326,7 @@ export class GranuleGridLayer extends MapLayer {
           focusedCollectionId,
           focusedGranuleId,
           granules: granuleData,
+          imageryCache,
           isProjectPage,
           lightColor,
           metadata,

--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -57,6 +57,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       focusedCollectionId,
       focusedGranuleId,
       granules,
+      imageryCache,
       isProjectPage,
       lightColor,
       metadata,
@@ -77,6 +78,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
     this.onExcludeGranule = onExcludeGranule
     this.onMetricsMap = onMetricsMap
     this.focusedCollectionId = focusedCollectionId
+    this.imageryCache = imageryCache
 
     const {
       addedGranuleIds = [],
@@ -502,6 +504,12 @@ export class GranuleGridLayerExtended extends L.GridLayer {
 
   loadImage(url, callback, retries = 0) {
     if (url != null) {
+      // Check for image in cache, return if found
+      const cachedImage = this.imageryCache.get(url)
+      if (cachedImage !== undefined) {
+        return callback(cachedImage)
+      }
+
       const image = new Image()
       image.onload = function onload() {
         callback(this)
@@ -521,6 +529,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       image.setAttribute('style', 'display: none;')
       document.body.appendChild(image)
       image.src = url
+
       return url
     }
     return callback(null)
@@ -623,6 +632,9 @@ export class GranuleGridLayerExtended extends L.GridLayer {
 
       // eslint-disable-next-line no-loop-func
       self.loadImage(url, (image) => {
+        // Cache the image
+        this.imageryCache.set(url, image)
+
         queue[i] = () => {
           const paths = []
           const deemphisizedPaths = []

--- a/static/src/js/containers/MapContainer/MapContainer.js
+++ b/static/src/js/containers/MapContainer/MapContainer.js
@@ -11,6 +11,7 @@ import {
   ScaleControl
 } from 'react-leaflet'
 import { difference } from 'lodash'
+import LRUCache from 'lrucache'
 
 import actions from '../../actions/index'
 
@@ -80,6 +81,8 @@ export class MapContainer extends Component {
     this.handleOverlayChange = this.handleOverlayChange.bind(this)
     this.handleProjectionSwitching = this.handleProjectionSwitching.bind(this)
     this.onMapReady = this.onMapReady.bind(this)
+
+    this.imageryCache = LRUCache(400)
   }
 
   componentDidMount() {
@@ -377,6 +380,7 @@ export class MapContainer extends Component {
           granulesMetadata={granulesMetadata}
           isProjectPage={isProjectPage}
           granules={nonExcludedGranules}
+          imageryCache={this.imageryCache}
           project={project}
           projection={projection}
           onChangeFocusedGranule={onChangeFocusedGranule}


### PR DESCRIPTION
# Overview

### What is the feature?

Cache GIBS imagery in browser memory

### What areas of the application does this impact?

Map imagery

# Testing

### Reproduction steps

Load a collection with map imagery, open devtools and clear the network requests.
Moving the map will redraw the images, but you won't see any network requests coming from `GranuleGridLayerExtended.js`
Changing the map zoom you will see requests from `GranuleGridLayerExtended.js`, but when you return to the initial zoom you won't see any requests

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
