### PR TITLE
EDSC-3036: Fix projection preference default

### DIFF
--- a/schemas/sitePreferencesSchema.json
+++ b/schemas/sitePreferencesSchema.json
@@ -94,7 +94,7 @@
         "projection": {
           "type": "string",
           "title": "Projection",
-          "default": "1",
+          "default": "epsg4326",
           "enum": [
             "epsg4326",
             "epsg3413",


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes an incorrect default value for the projection field in map preferences