### PR TITLE
EDSC-3091: Fix getDbCredentials for dev environment

### DIFF
--- a/serverless/src/util/database/getDbCredentials.js
+++ b/serverless/src/util/database/getDbCredentials.js
@@ -1,7 +1,6 @@
 import AWS from 'aws-sdk'
 
-import { deployedEnvironment } from '../../../../sharedUtils/deployedEnvironment'
-import { getSecretEarthdataConfig } from '../../../../sharedUtils/config'
+import { getSecretEnvironmentConfig } from '../../../../sharedUtils/config'
 import { getSecretsManagerConfig } from '../aws/getSecretsManagerConfig'
 
 let dbCredentials
@@ -17,7 +16,7 @@ export const getDbCredentials = async () => {
     }
 
     if (process.env.NODE_ENV === 'development') {
-      const { dbUsername, dbPassword } = getSecretEarthdataConfig(deployedEnvironment())
+      const { dbUsername, dbPassword } = getSecretEnvironmentConfig(process.env.NODE_ENV)
 
       return {
         username: dbUsername,


### PR DESCRIPTION
# Overview

### What is the feature?

The EDSC team logs into their local database without username/password. If a dev needs to use username/password they weren't able to read those values from their `secret.config.json`. This change fixes that issue