### PR TITLE
EDSC-3112: Fixes bug when drawing granules with missing metadata

### DIFF
--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -208,7 +208,12 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       let value = matcher[prop]
 
       // Granule metadata is camel case, so camelCase the prop in order to find the granuleValue
-      const granuleValue = granule[camelCase(prop)].split('T')[0]
+      const metadataValue = granule[camelCase(prop)]
+
+      // If the granule metadata doesn't contain the prop, return
+      if (!metadataValue) return true
+
+      const granuleValue = metadataValue.split('T')[0]
       if (value && !granuleValue) { return false }
       let op = null
       operators.forEach((operator) => {


### PR DESCRIPTION
# Overview

### What is the feature?

When our GIBS tag includes a match field that is missing in the granule metadata, we weren't handling that and an error page was being shown

### What is the Solution?

Check for the existence of the metadata before continuing 

### What areas of the application does this impact?

Granules drawn on the map

# Testing

### Reproduction steps

Load the granules results page for this collection (in prod) `C1931660485-NSIDC_ECS`

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
