### PR TITLE
EDSC-3094: Allow 0 values in preferences form

### DIFF
--- a/static/src/js/components/Preferences/PreferencesNumberField.js
+++ b/static/src/js/components/Preferences/PreferencesNumberField.js
@@ -25,6 +25,9 @@ class PreferencesNumberField extends Component {
       }, () => {
         let { formData } = this.state
 
+        // Borrowed this code from react-jsonschema-form. Its the code they use in their version of NumberField
+        // https://github.com/rjsf-team/react-jsonschema-form/blob/master/packages/core/src/components/fields/NumberField.js#L44
+
         // Normalize decimals that don't start with a zero character in advance so
         // that the rest of the normalization logic is simpler
         if (`${formData}`.charAt(0) === '.') {

--- a/static/src/js/components/Preferences/PreferencesNumberField.js
+++ b/static/src/js/components/Preferences/PreferencesNumberField.js
@@ -40,7 +40,9 @@ class PreferencesNumberField extends Component {
           ? asNumber(formData.replace(trailingCharMatcher, ''))
           : asNumber(formData)
 
-        return onChange(processed || formData)
+        const value = processed || processed === 0 ? processed : formData
+
+        return onChange(value)
       })
     }
   }

--- a/static/src/js/components/Preferences/__tests__/PreferencesNumberField.test.js
+++ b/static/src/js/components/Preferences/__tests__/PreferencesNumberField.test.js
@@ -35,13 +35,51 @@ describe('PreferencesNumberField component', () => {
     expect(input.props().name).toEqual('testField')
   })
 
-  test('onChange sets the state', () => {
-    const { enzymeWrapper } = setup()
+  describe('onChange', () => {
+    test('onChange calls props onChange', () => {
+      const { enzymeWrapper, props } = setup()
 
-    const input = enzymeWrapper.find(FormControl).last()
+      const input = enzymeWrapper.find(FormControl).last()
 
-    input.props().onChange({ target: { value: 0 } })
+      input.invoke('onChange')({ target: { value: '42' } })
 
-    expect(enzymeWrapper.state().formData).toEqual(0)
+      enzymeWrapper.update()
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).toHaveBeenCalledWith(42)
+    })
+
+    test('returns an integer 0 when the input is "0"', () => {
+      const { enzymeWrapper, props } = setup()
+
+      const input = enzymeWrapper.find(FormControl).last()
+
+      input.props().onChange({ target: { value: '0' } })
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).toHaveBeenCalledWith(0)
+    })
+
+    test('returns a number 0.1 when the input is ".1"', () => {
+      const { enzymeWrapper, props } = setup()
+
+      const input = enzymeWrapper.find(FormControl).last()
+
+      input.props().onChange({ target: { value: '.1' } })
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).toHaveBeenCalledWith(0.1)
+    })
+
+    test('returns a number -42 when the input is "-42"', () => {
+      const { enzymeWrapper, props } = setup()
+
+      const input = enzymeWrapper.find(FormControl).last()
+
+      input.props().onChange({ target: { value: '-42' } })
+
+      expect(props.onChange).toHaveBeenCalledTimes(1)
+      expect(props.onChange).toHaveBeenCalledWith(-42)
+    })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

On the preferences form, `0` was not accepted as a valid number in number fields

### What is the Solution?

`0` was being evaluated as falsey in the check for if the value was a number, I fixed that problem

### What areas of the application does this impact?

Preferences form

# Testing

Set the preferences form latitude or longitude to `0`, no error is shown and the value is able to be saved.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
