### PR TITLE
EDSC-3096: Set the default collection search to 'usage'

### DIFF
--- a/static/src/js/reducers/__tests__/query.test.js
+++ b/static/src/js/reducers/__tests__/query.test.js
@@ -17,7 +17,7 @@ const initialState = {
     keyword: '',
     hasGranulesOrCwic: true,
     pageNum: 1,
-    sortKey: [],
+    sortKey: ['-usage_score'],
     spatial: {},
     temporal: {}
   },
@@ -54,7 +54,7 @@ describe('UPDATE_COLLECTION_QUERY', () => {
         ...payload,
         byId: {},
         hasGranulesOrCwic: true,
-        sortKey: []
+        sortKey: ['-usage_score']
       },
       region: {
         exact: false
@@ -130,7 +130,14 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
-    const expectedState = query
+    const expectedState = {
+      ...initialState,
+      ...query,
+      collection: {
+        ...initialState.collection,
+        ...query.collection
+      }
+    }
 
     expect(queryReducer(undefined, action)).toEqual(expectedState)
   })

--- a/static/src/js/reducers/query.js
+++ b/static/src/js/reducers/query.js
@@ -18,7 +18,7 @@ const initialState = {
     pageNum: 1,
     spatial: {},
     temporal: {},
-    sortKey: []
+    sortKey: ['-usage_score']
   },
   region: {
     exact: false
@@ -199,7 +199,11 @@ const queryReducer = (state = initialState, action) => {
 
       return {
         ...state,
-        ...query
+        ...query,
+        collection: {
+          ...initialState.collection,
+          ...query.collection
+        }
       }
     }
     case CLEAR_FILTERS: {


### PR DESCRIPTION
# Overview

### What is the feature?

Changes the default collection sort to `usage`, or technically `-usage_score`

### What areas of the application does this impact?

Collection results

# Testing

Load EDSC, see the collection results are sorted by usage

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
