### PR TITLE
EDSC-3092: Only show reformatting options supported be EDSC

### DIFF
--- a/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { uniq } from 'lodash'
 
 import { Badge, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import SimpleBar from 'simplebar-react'
@@ -146,10 +147,15 @@ export const CollectionDetailsBody = ({
     const { items } = services
 
     if (items) {
+      const supportedServiceTypes = ['esi', 'opendap', 'echo orders', 'harmony']
       items.forEach((service) => {
         const {
-          supportedReformattings: supportedReformattingsList
+          supportedReformattings: supportedReformattingsList,
+          type
         } = service
+
+        // If the service type is not one that we support, don't display the reformatting options
+        if (!supportedServiceTypes.includes(type.toLowerCase())) return
 
         if (supportedReformattingsList) {
           supportedReformattingsList.forEach((supportedReformatting) => {
@@ -160,10 +166,11 @@ export const CollectionDetailsBody = ({
 
             const { [supportedInputFormat]: existingReformatting = [] } = reformattings
 
-            reformattings[supportedInputFormat] = [
+            // Ensure the reformatting options is a unique list
+            reformattings[supportedInputFormat] = uniq([
               ...existingReformatting,
               ...supportedOutputFormats
-            ]
+            ])
           })
         }
       })

--- a/static/src/js/components/CollectionDetails/__tests__/CollectionDetailsBody.test.js
+++ b/static/src/js/components/CollectionDetails/__tests__/CollectionDetailsBody.test.js
@@ -481,6 +481,95 @@ describe('CollectionDetails component', () => {
       expect(format1.find('dd').text()).toEqual('XML, ASCII, ICARTT')
       expect(format2.find('dd').text()).toEqual('PNG, JPEG, TIFF')
     })
+
+    test('does not render duplicate formats', () => {
+      const { enzymeWrapper } = setup({
+        overrideMetadata: {
+          services: {
+            items: [
+              {
+                type: 'ECHO ORDERS',
+                supportedOutputFormats: null,
+                supportedReformattings: null
+              },
+              {
+                type: 'ESI',
+                supportedReformattings: [
+                  {
+                    supportedInputFormat: 'HDF-EOS2',
+                    supportedOutputFormats: ['XML', 'ASCII', 'ICARTT']
+                  },
+                  {
+                    supportedInputFormat: 'HDF-EOS5',
+                    supportedOutputFormats: ['PNG', 'JPEG']
+                  },
+                  {
+                    supportedInputFormat: 'HDF-EOS5',
+                    supportedOutputFormats: ['TIFF', 'PNG', 'JPEG'] // PNG and JPEG are duplicated for HDF-EOS5
+                  }
+                ]
+              },
+              {
+                type: 'NOT PROVIDED',
+                supportedOutputFormats: null,
+                supportedReformattings: null
+              }
+            ]
+          }
+        }
+      })
+
+      const reformattingsDataElement = enzymeWrapper.find('.collection-details-body__info').find('dd').at(1)
+
+      const format1 = reformattingsDataElement.find('.collection-details-body__reformatting-item').at(0)
+      const format2 = reformattingsDataElement.find('.collection-details-body__reformatting-item').at(1)
+
+      expect(format1.find('dt').text()).toEqual('HDF-EOS2<EDSCIcon />')
+      expect(format2.find('dt').text()).toEqual('HDF-EOS5<EDSCIcon />')
+
+      expect(format1.find('dd').text()).toEqual('XML, ASCII, ICARTT')
+      expect(format2.find('dd').text()).toEqual('PNG, JPEG, TIFF')
+    })
+
+    test('does not render options not supported by EDSC', () => {
+      const { enzymeWrapper } = setup({
+        overrideMetadata: {
+          services: {
+            items: [
+              {
+                type: 'ECHO ORDERS',
+                supportedOutputFormats: null,
+                supportedReformattings: null
+              },
+              {
+                type: 'ESI',
+                supportedReformattings: null
+              },
+              {
+                type: 'NOT PROVIDED',
+                supportedOutputFormats: null,
+                supportedReformattings: [
+                  {
+                    supportedInputFormat: 'HDF-EOS2',
+                    supportedOutputFormats: ['XML', 'ASCII', 'ICARTT']
+                  },
+                  {
+                    supportedInputFormat: 'HDF-EOS5',
+                    supportedOutputFormats: ['PNG', 'JPEG']
+                  },
+                  {
+                    supportedInputFormat: 'HDF-EOS5',
+                    supportedOutputFormats: ['TIFF']
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      })
+
+      expect(enzymeWrapper.find('.collection-details-body__reformatting-item').exists()).toBeFalsy()
+    })
   })
 
   describe('Science Keywords', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

Only show reformatting options supported be EDSC, also don't show duplicates of reformatting options in the list

### What areas of the application does this impact?

Collection details

# Testing

Visit https://search.earthdata.nasa.gov/search/granules/collection-details?p=C1000001167-NSIDC_ECS&m=-0.140625!0.140625!2!1!0!0%2C2&ff=Customizable&tl=1598556866!4!!
Ensure no duplicates are present, and the correct options are there from the services EDSC supports (ESI, OPeNDAP, ECHO ORDERS, and Harmony)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
