### PR TITLE
EDSC-2626: Allow errors, for now.

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Bail on unset variables, errors and trace execution
-set -eux
+set -ux
 
 # Deployment configuration/variables
 ####################################


### PR DESCRIPTION
Deployment script is failing but nothing has changed, attempting to allow errors to be returned to see if it can get beyond this step that has always has the same output.