### PR TITLE
EDSC-2626: Attempt to patch up deployment issues with AWS / Serverless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35111,6 +35111,15 @@
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
           }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -35582,13 +35591,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "webpack-merge": "^4.2.1",
     "webpack-node-externals": "^2.5.2",
     "webpackbar": "^4.0.0",
+    "ws": "^7.4.4",
     "xmldom": "^0.5.0",
     "xpath": "0.0.27",
     "yup": "^0.32.6"

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -261,7 +261,7 @@ describe('getSearchGranules', () => {
     const cwicRequestMock = jest.spyOn(OpenSearchGranuleRequest.prototype, 'search')
 
     nock(/localhost/)
-      .post(/cwic\/granules/)
+      .post(/opensearch\/granules/)
       .reply(200, '<feed><opensearch:totalResults>1</opensearch:totalResults><entry><title>CWIC Granule</title></entry></feed>')
 
     const store = mockStore({
@@ -366,7 +366,7 @@ describe('getSearchGranules', () => {
     const cwicRequestMock = jest.spyOn(OpenSearchGranuleRequest.prototype, 'search')
 
     nock(/localhost/)
-      .post(/cwic\/granules/)
+      .post(/opensearch\/granules/)
       .reply(200, '<feed><opensearch:totalResults>1</opensearch:totalResults><entry><title type="text">CWIC Granule</title><id>12345</id><updated>2020-06-09T23:59:59Z</updated></entry></feed>')
 
     const store = mockStore({
@@ -736,7 +736,7 @@ describe('getProjectGranules', () => {
     const cwicRequestMock = jest.spyOn(OpenSearchGranuleRequest.prototype, 'search')
 
     nock(/localhost/)
-      .post(/cwic\/granules/)
+      .post(/opensearch\/granules/)
       .reply(200, '<feed><opensearch:totalResults>1</opensearch:totalResults><entry><title>CWIC Granule</title></entry></feed>')
 
     const store = mockStore({

--- a/static/src/js/util/request/openSearchGranuleRequest.js
+++ b/static/src/js/util/request/openSearchGranuleRequest.js
@@ -19,7 +19,7 @@ export default class OpenSearchGranuleRequest extends Request {
       this.optionallyAuthenticated = true
     }
 
-    this.searchPath = 'cwic/granules'
+    this.searchPath = 'opensearch/granules'
   }
 
   /**


### PR DESCRIPTION
# Overview

### What is the feature?

Deployment of opensearch granule retrieval is giving us trouble.

### What is the Solution?

- Installs `ws` because someone can't figure out their dependencies.
- Downgrades the lockfile from 2, down to 1 allowing use of @macrouch fork of react-leaflet-draw
- Resets the API gateway path as the deployment.. seems to have figured itself out

### What areas of the application does this impact?

OpenSearch granule retrieval.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
