### PR TITLE
EDSC 3075-Fix 508 compliance 'element must contain ALT attribute'

### DIFF
--- a/static/src/partials/body.html
+++ b/static/src/partials/body.html
@@ -93,13 +93,16 @@
                     <span class="footer__info-bit footer__info-bit--emph">NASA Official: Stephen Berrick</span>
                     <span class="footer__info-bit"><a class="footer__info-link" aria-labelledby="NASA Freedom of Information Act"
                             href="http://www.nasa.gov/FOIA/index.html">FOIA</a></span>
-                    <span class="footer__info-bit"><a class="footer__info-link"
+                    <span class="footer__info-bit"><a class="footer__info-link" aria-labelledby="NASA Privacy Policy"
                             href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></span>
-                    <span class="footer__info-bit"><a class="footer__info-link" href="http://www.usa.gov">USA.gov</a></span>
+                    <span class="footer__info-bit"><a class="footer__info-link"
+                            aria-labelledby="USA Government Information and Services" href="http://www.usa.gov">USA.gov</a></span>
                 </span>
                 <span class="footer__info footer__info--right">
                     <span class="footer__info-bit footer__info-bit--clean footer__info-bit--emph">
-                        <a class="footer__info-link footer__info-link--underline" href="https://access.earthdata.nasa.gov/">
+                        <a class="footer__info-link footer__info-link--underline"
+                            aria-labelledby=" Earthdata Access 508 Accessible Alternative"
+                            href="https://access.earthdata.nasa.gov/">
                             Earthdata Access: A Section 508 accessible alternative
                         </a>
                     </span>

--- a/static/src/partials/body.html
+++ b/static/src/partials/body.html
@@ -1,7 +1,8 @@
 <noscript>
-    <% if (gtmPropertyId.length > 0) { %>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=<%= gtmPropertyId %>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    <% } %>
+    <% if (gtmPropertyId.length> 0) { %>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=<%= gtmPropertyId %>" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe>
+        <% } %>
 </noscript>
 <script type="text/javascript">
     var htmlElement = document.getElementsByTagName('html')[0];
@@ -24,102 +25,100 @@
     }
 </script>
 <% if (showTophat) { %>
-<div id="earthdata-tophat2" class="th-wrapper" style="height: 34px; background: #000;"></div>
-<% } %>
-<div id="root" class="root root--loading">
-    <div class="root__loading">
-        <div class="root__spinner spinner spinner--dots spinner--white spinner--small">
-            <div class="spinner__inner"></div>
-            <div class="spinner__inner"></div>
-            <div class="spinner__inner"></div>
-        </div>
-    </div>
-    <div id="app" class="root__app"></div>
-</div>
-<div class="fallback-page">
-    <div class="fallback-page__wrapper fallback-page__wrapper--no-js">
-        <div class="fallback-page__content">
-            <h3 class="fallback-page__heading">Earthdata Search uses JavaScript</h3>
-            <p class="fallback-page__note fallback-page__note--last">Please use a JavaScript-aware browser and make sure
-                JavaScript is enabled.</p>
-        </div>
-    </div>
-    <div class="fallback-page__wrapper fallback-page__wrapper--unsupported-browser">
-        <div class="fallback-page__content">
-            <h3 class="fallback-page__heading">Your browser is out of date</h3>
-            <p class="fallback-page__note">In order to use Earthdata Search, you must upgrade your web browser.<br>
-                Alternatively, you can <a href="https://access.earthdata.nasa.gov">Earthdata Access</a>.</p>
-            <p class="fallback-page__note fallback-page__note--last">To upgrade your browser, click on the icons below
-                to go to the download page.</p>
-            <ul class="browser-icons">
-                <li class="browser-icons__item">
-                    <a class="browser-icons__link" href="https://www.google.com/chrome/" target="_blank">
-                        <span class="browser-icons__icon browser-icons__icon--chrome"></span>
-                        <span class="browser-icons__name">Chrome</span>
-                    </a>
-                </li>
-                <li class="browser-icons__item">
-                    <a class="browser-icons__link" href="http://www.mozilla.org/firefox/" target="_blank">
-                        <span class="browser-icons__icon browser-icons__icon--firefox"></span>
-                        <span class="browser-icons__name">Firefox</span>
-                    </a>
-                </li>
-                <li class="browser-icons__item">
-                    <a class="browser-icons__link" href="http://www.apple.com/safari/" target="_blank">
-                        <span class="browser-icons__icon browser-icons__icon--safari"></span>
-                        <span class="browser-icons__name">Safari</span>
-                    </a>
-                </li>
-                <li class="browser-icons__item">
-                    <a class="browser-icons__link" href="http://www.opera.com/" target="_blank">
-                        <span class="browser-icons__icon browser-icons__icon--opera"></span>
-                        <span class="browser-icons__name">Opera</span>
-                    </a>
-                </li>
-                <li class="browser-icons__item">
-                    <a class="browser-icons__link" href="http://windows.microsoft.com/en-us/internet-explorer/download-ie" target="_blank">
-                        <span class="browser-icons__icon browser-icons__icon--ie"></span>
-                        <span class="browser-icons__name">Internet Explorer</span>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="footer fallback-page__footer">
-        <span class="footer__info footer__info--left">
-            <span class="footer__info-bit footer__info-bit--emph">NASA Official: Stephen Berrick</span>
-            <span class="footer__info-bit"><a class="footer__info-link" href="http://www.nasa.gov/FOIA/index.html">FOIA</a></span>
-            <span class="footer__info-bit"><a class="footer__info-link" href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></span>
-            <span class="footer__info-bit"><a class="footer__info-link" href="http://www.usa.gov">USA.gov</a></span>
-        </span>
-        <span class="footer__info footer__info--right">
-            <span class="footer__info-bit footer__info-bit--clean footer__info-bit--emph">
-                <a class="footer__info-link footer__info-link--underline" href="https://access.earthdata.nasa.gov/">
-                    Earthdata Access: A Section 508 accessible alternative
-                </a>
-            </span>
-        </span>
-    </div>
-</div>
-<% if (showTophat) { %>
-<script
-    id="earthdata-tophat-script"
-    src="https://cdn.earthdata.nasa.gov/tophat2/tophat2.js"
-    async="async"
-    defer="defer"
-    <% if (feedbackApp.length > 0) { %>
-    data-show-fbm="true"
-    <% } else { %>
-    data-show-fbm="false"
+    <div id="earthdata-tophat2" class="th-wrapper" style="height: 34px; background: #000;"></div>
     <% } %>
-    data-show-status="true"
-    data-status-api-url="https://status.earthdata.nasa.gov/api/v1/notifications"
-></script>
-<% } %>
-<% if (feedbackApp.length > 0) { %>
-<script
-    src="https://fbm.earthdata.nasa.gov/for/<%= feedbackApp %>/feedback.js"
-    type="text/javascript"
-></script>
-<script type="text/javascript">feedback.init({ showIcon: false });</script>
-<% } %>
+        <div id="root" class="root root--loading">
+            <div class="root__loading">
+                <div class="root__spinner spinner spinner--dots spinner--white spinner--small">
+                    <div class="spinner__inner"></div>
+                    <div class="spinner__inner"></div>
+                    <div class="spinner__inner"></div>
+                </div>
+            </div>
+            <div id="app" class="root__app"></div>
+        </div>
+        <div class="fallback-page">
+            <div class="fallback-page__wrapper fallback-page__wrapper--no-js">
+                <div class="fallback-page__content">
+                    <h3 class="fallback-page__heading">Earthdata Search uses JavaScript</h3>
+                    <p class="fallback-page__note fallback-page__note--last">Please use a JavaScript-aware browser and make sure
+                        JavaScript is enabled.</p>
+                </div>
+            </div>
+            <div class="fallback-page__wrapper fallback-page__wrapper--unsupported-browser">
+                <div class="fallback-page__content">
+                    <h3 class="fallback-page__heading">Your browser is out of date</h3>
+                    <p class="fallback-page__note">In order to use Earthdata Search, you must upgrade your web browser.<br>
+                        Alternatively, you can <a href="https://access.earthdata.nasa.gov">Earthdata Access</a>.</p>
+                    <p class="fallback-page__note fallback-page__note--last">To upgrade your browser, click on the icons below
+                        to go to the download page.</p>
+                    <ul class="browser-icons">
+                        <li class="browser-icons__item">
+                            <a class="browser-icons__link" href="https://www.google.com/chrome/" target="_blank">
+                                <span class="browser-icons__icon browser-icons__icon--chrome"></span>
+                                <span class="browser-icons__name">Chrome</span>
+                            </a>
+                        </li>
+                        <li class="browser-icons__item">
+                            <a class="browser-icons__link" href="http://www.mozilla.org/firefox/" target="_blank">
+                                <span class="browser-icons__icon browser-icons__icon--firefox"></span>
+                                <span class="browser-icons__name">Firefox</span>
+                            </a>
+                        </li>
+                        <li class="browser-icons__item">
+                            <a class="browser-icons__link" href="http://www.apple.com/safari/" target="_blank">
+                                <span class="browser-icons__icon browser-icons__icon--safari"></span>
+                                <span class="browser-icons__name">Safari</span>
+                            </a>
+                        </li>
+
+                        <li class="browser-icons__item">
+                            <a class="browser-icons__link" href="http://www.opera.com/" target="_blank">
+                                <span class="browser-icons__icon browser-icons__icon--opera"></span>
+                                <span class="browser-icons__name">Opera</span>
+                            </a>
+                        </li>
+                        <li class="browser-icons__item">
+                            <a class="browser-icons__link" href="http://windows.microsoft.com/en-us/internet-explorer/download-ie"
+                                target="_blank">
+                                <span class="browser-icons__icon browser-icons__icon--ie"></span>
+                                <span class="browser-icons__name">Internet Explorer</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer fallback-page__footer">
+                <span class="footer__info footer__info--left">
+                    <span class="footer__info-bit footer__info-bit--emph">NASA Official: Stephen Berrick</span>
+                    <span class="footer__info-bit"><a class="footer__info-link" aria-labelledby="NASA Freedom of Information Act"
+                            href="http://www.nasa.gov/FOIA/index.html">FOIA</a></span>
+                    <span class="footer__info-bit"><a class="footer__info-link"
+                            href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></span>
+                    <span class="footer__info-bit"><a class="footer__info-link" href="http://www.usa.gov">USA.gov</a></span>
+                </span>
+                <span class="footer__info footer__info--right">
+                    <span class="footer__info-bit footer__info-bit--clean footer__info-bit--emph">
+                        <a class="footer__info-link footer__info-link--underline" href="https://access.earthdata.nasa.gov/">
+                            Earthdata Access: A Section 508 accessible alternative
+                        </a>
+                    </span>
+                </span>
+            </div>
+        </div>
+        <% if (showTophat) { %>
+            <script id="earthdata-tophat-script" src="https://cdn.earthdata.nasa.gov/tophat2/tophat2.js" async="async"
+                defer="defer" <% if (feedbackApp.length> 0) { %>
+                        data - show - fbm="true"
+                            <% } else { %>
+                                data - show - fbm="false"
+                                    <% } %>
+                                        data - show - status="true"
+                    data - status - api - url="https://status.earthdata.nasa.gov/api/v1/notifications"
+                        ></script>
+            <% } %>
+                <% if (feedbackApp.length> 0) { %>
+                    <script src="https://fbm.earthdata.nasa.gov/for/<%= feedbackApp %>/feedback.js"
+                        type="text/javascript"></script>
+                    <script type="text/javascript">feedback.init({ showIcon: false });</script>
+                    <% } %>


### PR DESCRIPTION
# Overview

### What is the feature?

This is a fix for a 508 Compliance issue/task to add text to all A elements or an IMG with an ALT attribute. see https://github.com/nasa/earthdata-search/issues/1368.

### What is the Solution?

Since each A element already had text and they weren't images, the solution was to add an 'aria-labelledby' attribute to all of the A elements listed in the given picture from the issue. I followed the Sort sites accessibilities checkpoint page based of the provided error from the picture/text. Link: https://www.powermapper.com/products/sortsite/rules/acchtmllinktextblank/

### What areas of the application does this impact?

All of the A elements within <div class="footer fallback-page__footer"> near the bottom of body.html. 

# Testing
I tried to make changes to the 'span' elements that contain the anchor tags by taking out the text between the anchor tag to see if a screen reader would pick it up but even if I took out the text the page would still render with the same text it was originally supposed. For example, even if I took out NASA Privacy Policy, the site would still render it to say NASA Privacy Policy like in the picture below even though the HMTL file was updated. 

![image](https://user-images.githubusercontent.com/81826033/115941352-e66ed580-a459-11eb-86e3-a7d8ecefe3a7.png)

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
