### PR TITLE
EDSC-3081: Updates subscription queries to not be encoded strings

### DIFF
--- a/static/src/js/actions/__tests__/subscriptions.test.js
+++ b/static/src/js/actions/__tests__/subscriptions.test.js
@@ -104,7 +104,7 @@ describe('createSubscription', () => {
           options: { spatial: { or: true } },
           polygon: '-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           temporalString: '2020-01-01T00:00:00.000Z,2020-01-31T23:59:59.999Z'
-        })
+        }, { encode: false })
 
         // Mock the request if the the variables match
         return collectionConceptId === 'collectionId'
@@ -198,7 +198,7 @@ describe('createSubscription', () => {
             options: { spatial: { or: true } },
             polygon: '-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
             temporalString: '2020-01-01T00:00:00.000Z,2020-01-31T23:59:59.999Z'
-          })
+          }, { encode: false })
 
           // Mock the request if the the variables match
           return collectionConceptId === 'collectionId'
@@ -753,7 +753,7 @@ describe('updateSubscription', () => {
         payload: {
           collectionConceptId: 'collectionId',
           conceptId: 'SUB1000-EDSC',
-          query: 'browseOnly=true&options%5Bspatial%5D%5Bor%5D=true&temporalString=2020-01-01T00%3A00%3A00.000Z%2C2020-01-31T23%3A59%3A59.999Z'
+          query: 'browseOnly=true&options[spatial][or]=true&temporalString=2020-01-01T00:00:00.000Z,2020-01-31T23:59:59.999Z'
         }
       })
 

--- a/static/src/js/containers/SubscriptionsBodyContainer/__tests__/SubscriptionsBodyContainer.test.js
+++ b/static/src/js/containers/SubscriptionsBodyContainer/__tests__/SubscriptionsBodyContainer.test.js
@@ -63,7 +63,7 @@ describe('mapStateToProps', () => {
     }
 
     const expectedState = {
-      granuleQueryString: 'options%5Bspatial%5D%5Bor%5D=true',
+      granuleQueryString: 'options[spatial][or]=true',
       subscriptions: []
     }
 

--- a/static/src/js/selectors/__tests__/query.test.js
+++ b/static/src/js/selectors/__tests__/query.test.js
@@ -59,6 +59,6 @@ describe('getFocusedGranuleQueryString selector', () => {
       }
     }
 
-    expect(getFocusedGranuleQueryString(state)).toEqual('browseOnly=true&options%5Bspatial%5D%5Bor%5D=true&point=0%2C0')
+    expect(getFocusedGranuleQueryString(state)).toEqual('browseOnly=true&options[spatial][or]=true&point=0,0')
   })
 })

--- a/static/src/js/util/__tests__/subscriptions.test.js
+++ b/static/src/js/util/__tests__/subscriptions.test.js
@@ -34,7 +34,7 @@ describe('prepareSubscriptionQuery', () => {
       options: { spatial: { or: true } },
       polygon: '-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
       temporalString: '2020-01-01T00:00:00.000Z,2020-01-31T23:59:59.999Z'
-    })
+    }, { encode: false })
 
     expect(prepareSubscriptionQuery(inputParams)).toEqual(result)
   })

--- a/static/src/js/util/subscriptions.js
+++ b/static/src/js/util/subscriptions.js
@@ -15,6 +15,6 @@ export const prepareSubscriptionQuery = (params) => {
   delete prunedParams.pageNum
   delete prunedParams.sortKey
 
-  // Return the remaining parameters stringified
-  return stringify(prunedParams)
+  // Return the remaining parameters stringified, don't encode the values because CMR won't accept them
+  return stringify(prunedParams, { encode: false })
 }


### PR DESCRIPTION
# Overview

### What is the feature?

CMR can't decode URL encoded subscription queries

### What is the Solution?

Send subscription queries as URL parameters strings, but not encoded.

### What areas of the application does this impact?

Subscriptions

# Testing

Create a new subscription, ensure it is created successfully
Check the network tab for the request and ensure the `query` parameter is not encoded
![Screen Shot 2021-04-27 at 10 41 48 AM](https://user-images.githubusercontent.com/171388/116261007-39d87080-a745-11eb-9a93-a591ec6b11c5.png)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
