### PR TITLE
EDSC-3115: Update user_tokens table to accept longer EDL tokens

### DIFF
--- a/migrations/1619617419390_update-user-tokens-text.js
+++ b/migrations/1619617419390_update-user-tokens-text.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.alterColumn('user_tokens', 'access_token', {
+    type: 'text'
+  })
+  pgm.alterColumn('user_tokens', 'refresh_token', {
+    type: 'text'
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.alterColumn('user_tokens', 'access_token', {
+    type: 'varchar(100)'
+  })
+  pgm.alterColumn('user_tokens', 'refresh_token', {
+    type: 'varchar(100)'
+  })
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Our database needs to store larger tokens from EDL. This updates those fields to be `text` types