### PR TITLE
EDSC-3164: Adds application wide value for Lambda Timeout

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -143,12 +143,15 @@
 
   fetchCatalogRestOrder:
     handler: serverless/src/fetchCatalogRestOrder/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT}
 
   fetchLegacyServicesOrder:
     handler: serverless/src/fetchLegacyServicesOrder/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT}
 
   fetchHarmonyOrder:
     handler: serverless/src/fetchHarmonyOrder/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT}
 
   #
   # Scheduled Lambdas


### PR DESCRIPTION
Adds the timeout configuration to the fetch* Lambdas to prevent timeouts when retrieving status payloads for orders.