### PR TITLE
EDSC 3074: legend element

### DIFF
--- a/static/src/js/components/ContactInfo/ContactInfo.js
+++ b/static/src/js/components/ContactInfo/ContactInfo.js
@@ -61,7 +61,9 @@ class ContactInfo extends Component {
 
     return (
       <fieldset className="contact-info-form">
-        <h3>View Contact Information</h3>
+        <legend>
+          <h3>View Contact Information</h3>
+        </legend>
         <ul className="contact-info-form__list">
           <li className="contact-info-form__item">
             <span className="contact-info-form__label">First Name</span>


### PR DESCRIPTION
# Overview

### What is the feature?

Please summarize the feature or fix.
- This is a fix to add the Legend element to label the Fliedset element located on http://localhost:8080/contact_info. Full issue can be found at https://github.com/nasa/earthdata-search/issues/1367

### What is the Solution?
Summarize what you changed.
- Added the Legend element inside the Fieldset element to label the Fieldset element for it to be 508 compliant.

### What areas of the application does this impact?

List impacted areas.
- I changed the ContactInfo.js file located within /earthdata-search/static/src/js/components/ContactInfo/

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ n/a] I have added automated tests that prove my fix is effective or that my feature works
- [ y] New and existing unit tests pass locally with my changes
- [ y] I have performed a self-review of my own code
- [ n/a] I have commented my code, particularly in hard-to-understand areas
- [ n/a] I have made corresponding changes to the documentation
- [ y] My changes generate no new warnings
