### PR TITLE
EDSC-3146: Adding S3 links to the granule results page

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
   collectCoverage: true,
-  // collectCoverageFrom: [
-  //   'serverless/src/**/*.js',
-  //   'static/src/**/*.js',
-  //   'sharedUtils/**/*.js'
-  // ],
+  collectCoverageFrom: [
+    'serverless/src/**/*.js',
+    'static/src/**/*.js',
+    'sharedUtils/**/*.js'
+  ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/static/src/js/util/mocks/fileMock.js',
     '^.+\\.(css|less|scss)$': 'babel-jest'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: [
-    'serverless/src/**/*.js',
-    'static/src/**/*.js',
-    'sharedUtils/**/*.js'
-  ],
+  // collectCoverageFrom: [
+  //   'serverless/src/**/*.js',
+  //   'static/src/**/*.js',
+  //   'sharedUtils/**/*.js'
+  // ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/static/src/js/util/mocks/fileMock.js',
     '^.+\\.(css|less|scss)$': 'babel-jest'

--- a/static/src/css/vendor/bootstrap/overrides/_dropdown.scss
+++ b/static/src/css/vendor/bootstrap/overrides/_dropdown.scss
@@ -2,6 +2,8 @@
 // which would be done to overcome overflow issues.
 #root,
 .dropdown-menu {
+  box-shadow: 0 0 1rem rgba($color__black, 0.15);
+
   .dropdown-menu-dark,
   .dropdown-dark & {
     background-color: $color__black--800;

--- a/static/src/js/components/Button/Button.js
+++ b/static/src/js/components/Button/Button.js
@@ -25,6 +25,7 @@ export const Button = React.forwardRef(({
   disabled,
   href,
   icon,
+  iconPosition,
   iconSize,
   label,
   onClick,
@@ -45,6 +46,7 @@ export const Button = React.forwardRef(({
       [`button--${variant}`]: !!variant,
       'button--icon': !!icon,
       'button--icon-only': !!icon && children === null,
+      'button--icon-right': !!icon && iconPosition === 'right',
       'button--badge': !!badge,
       'button--svg-icon': icon && typeof icon !== 'string'
     },
@@ -99,7 +101,7 @@ export const Button = React.forwardRef(({
       style={style}
       data-test-id={dataTestId}
     >
-      {(!spinner && icon) && (
+      {(!spinner && icon && iconPosition === 'left') && (
         <EDSCIcon
           className={iconClasses}
           icon={icon}
@@ -116,6 +118,13 @@ export const Button = React.forwardRef(({
           : children
         }
       </span>
+      {(!spinner && icon && iconPosition === 'right') && (
+        <EDSCIcon
+          className={iconClasses}
+          icon={icon}
+          size={iconSize}
+        />
+      )}
       {badge && (
         <>
           <Badge
@@ -155,6 +164,7 @@ Button.defaultProps = {
   className: null,
   href: null,
   icon: null,
+  iconPosition: 'left',
   iconSize: null,
   onClick: null,
   overlayClass: null,
@@ -181,6 +191,7 @@ Button.propTypes = {
   children: PropTypes.node,
   href: PropTypes.string,
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  iconPosition: PropTypes.string,
   iconSize: PropTypes.string,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func,

--- a/static/src/js/components/Button/Button.scss
+++ b/static/src/js/components/Button/Button.scss
@@ -46,6 +46,11 @@
       vertical-align: text-bottom;
     }
 
+    .button--icon-right & {
+      margin-left: $spacer/2;
+      margin-right: 0;
+    }
+
     &--push {
       margin-right: $spacer/2;
     }

--- a/static/src/js/components/Button/__tests__/Button.test.js
+++ b/static/src/js/components/Button/__tests__/Button.test.js
@@ -5,6 +5,7 @@ import { FaGlobe } from 'react-icons/fa'
 
 import Button from '../Button'
 import Spinner from '../../Spinner/Spinner'
+import EDSCIcon from '../../EDSCIcon/EDSCIcon'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -27,6 +28,17 @@ function setup(type) {
   }
 
   if (type === 'spinner') {
+    props.spinner = true
+  }
+
+  if (type === 'icon-right') {
+    props.iconPosition = 'right'
+    props.icon = FaGlobe
+  }
+
+  if (type === 'icon-right-spinner') {
+    props.iconPosition = 'right'
+    props.icon = FaGlobe
     props.spinner = true
   }
 
@@ -99,6 +111,22 @@ describe('Button component', () => {
       expect(enzymeWrapper.find(Spinner).prop('size')).toEqual('tiny')
       expect(enzymeWrapper.find(Spinner).prop('inline')).toEqual(true)
       expect(enzymeWrapper.find(Spinner).prop('color')).toEqual('white')
+    })
+  })
+
+  describe('when positioning the icon to the right', () => {
+    test('should render the icon after the text', () => {
+      const { enzymeWrapper } = setup('icon-right')
+      expect(enzymeWrapper.find('button').childAt(0).type()).toBe('span')
+      expect(enzymeWrapper.find('button').childAt(0).text()).toBe('Button Text')
+      expect(enzymeWrapper.find('button').childAt(1).type()).toBe(EDSCIcon)
+    })
+
+    describe('when the spinner is active', () => {
+      test('should not render the icon', () => {
+        const { enzymeWrapper } = setup('icon-right-spinner')
+        expect(enzymeWrapper.find('button').find(EDSCIcon).length).toBe(0)
+      })
     })
   })
 })

--- a/static/src/js/components/EDSCTabs/EDSCTabs.js
+++ b/static/src/js/components/EDSCTabs/EDSCTabs.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
 import { Tabs } from 'react-bootstrap'
 
 import './EDSCTabs.scss'
@@ -11,16 +13,23 @@ import './EDSCTabs.scss'
  */
 export const EDSCTabs = ({
   className,
-  children
+  children,
+  padding
 }) => {
-  const classNames = `edsc-tabs${className ? ` ${className}` : ''}`
+  const tabsClassNames = classNames([
+    'edsc-tabs',
+    {
+      'edsc-tabs--no-padding': !padding,
+      [`${className}`]: className
+    }
+  ])
 
   return (
     (
       <>
         {
           children.filter(Boolean).length > 0 && (
-            <div className={classNames}>
+            <div className={tabsClassNames}>
               <Tabs className="edsc-tabs__tabs">
                 {children}
               </Tabs>
@@ -33,12 +42,14 @@ export const EDSCTabs = ({
 }
 
 EDSCTabs.defaultProps = {
-  className: ''
+  className: '',
+  padding: true
 }
 
 EDSCTabs.propTypes = {
   children: PropTypes.node.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  padding: PropTypes.bool
 }
 
 export default EDSCTabs

--- a/static/src/js/components/EDSCTabs/EDSCTabs.js
+++ b/static/src/js/components/EDSCTabs/EDSCTabs.js
@@ -10,6 +10,7 @@ import './EDSCTabs.scss'
  * Renders EDSCTabs.
  * @param {Node} children - Must be valid children for the react-bootstrap Tabs component.
  * @param {String} className - An optional classname.
+ * @param {Boolean} padding - Adds/disables padding in the tabs.
  */
 export const EDSCTabs = ({
   className,

--- a/static/src/js/components/EDSCTabs/EDSCTabs.scss
+++ b/static/src/js/components/EDSCTabs/EDSCTabs.scss
@@ -23,7 +23,18 @@
     }
   }
 
+  .nav-item:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
   .tab-content {
     padding: $spacer;
+  }
+
+  &--no-padding {
+    .tab-content {
+      padding: 0;
+    }
   }
 }

--- a/static/src/js/components/EDSCTabs/__tests__/EDSCTabs.test.js
+++ b/static/src/js/components/EDSCTabs/__tests__/EDSCTabs.test.js
@@ -83,4 +83,17 @@ describe('EDSCTabs component', () => {
       expect(tabs.length).toEqual(1)
     })
   })
+
+  describe('when padding is set to false', () => {
+    const { enzymeWrapper } = setup({
+      padding: false,
+      children: [
+        'Test children'
+      ]
+    })
+
+    test('should add the class', () => {
+      expect(enzymeWrapper.find('.edsc-tabs').props().className).toContain('edsc-tabs--no-padding')
+    })
+  })
 })

--- a/static/src/js/components/GranuleResults/GranuleResultsBody.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsBody.js
@@ -17,6 +17,7 @@ import './GranuleResultsBody.scss'
  * Renders GranuleResultsBody.
  * @param {Object} props - The props passed into the component.
  * @param {String} props.collectionId - The focused collection ID.
+ * @param {Object} props.directDistributionInformation - The collection direct distribution information.
  * @param {String} props.focusedGranuleId - The focused granule ID.
  * @param {Object} props.granuleSearchResults - Granules passed from redux store.
  * @param {Object} props.isOpenSearch - Flag set if the focused collection is a CWIC collection.
@@ -30,6 +31,7 @@ import './GranuleResultsBody.scss'
  */
 const GranuleResultsBody = ({
   collectionId,
+  directDistributionInformation,
   focusedGranuleId,
   granuleQuery,
   granuleSearchResults,
@@ -179,6 +181,7 @@ const GranuleResultsBody = ({
       >
         <GranuleResultsList
           collectionId={collectionId}
+          directDistributionInformation={directDistributionInformation}
           excludedGranuleIds={excludedGranuleIds}
           granules={granulesList}
           isCollectionInProject={isCollectionInProject}
@@ -206,6 +209,7 @@ const GranuleResultsBody = ({
       >
         <GranuleResultsTable
           collectionId={collectionId}
+          directDistributionInformation={directDistributionInformation}
           excludedGranuleIds={excludedGranuleIds}
           focusedGranuleId={focusedGranuleId}
           granules={granulesList}
@@ -255,6 +259,7 @@ const GranuleResultsBody = ({
 
 GranuleResultsBody.propTypes = {
   collectionId: PropTypes.string.isRequired,
+  directDistributionInformation: PropTypes.shape({}).isRequired,
   focusedGranuleId: PropTypes.string.isRequired,
   granuleQuery: PropTypes.shape({}).isRequired,
   granuleSearchResults: PropTypes.shape({}).isRequired,

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -47,9 +47,11 @@ CustomDataLinksToggle.propTypes = {
 /**
  * Renders GranuleResultsDataLinksButton.
  * @param {Object} props - The props passed into the component.
- * @param {String} props.collectionId - The collection ID.
  * @param {String} props.buttonVariant - The button variant.
+ * @param {String} props.collectionId - The collection ID.
+ * @param {Object} props.directDistributionInformation - The collection direct distribution information.
  * @param {Array} props.dataLinks - An array of data links.
+ * @param {Array} props.s3Links - An array of AWS S3 links.
  * @param {Function} props.onMetricsDataAccess - The metrics callback.
  */
 export const GranuleResultsDataLinksButton = ({
@@ -92,6 +94,8 @@ export const GranuleResultsDataLinksButton = ({
     }
   }
 
+  // If only one datalink is provided and s3 links are not provided, a button is shown rather
+  // than a dropdown list. Otherwise, use a dropdown for the links.
   if (dataLinks.length > 1 || s3Links.length > 0) {
     const dataLinksList = dataLinks.map((dataLink, i) => {
       const key = `data_link_${i}`
@@ -288,7 +292,7 @@ export const GranuleResultsDataLinksButton = ({
                         s3Links.length > 0 && (
                           <div className="granule-results-data-links-button__menu-panel">
                             <div className="tab-content">
-                              {s3LinksList}
+                              {s3LinksList()}
                             </div>
                           </div>
                         )

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -241,7 +241,6 @@ export const GranuleResultsDataLinksButton = ({
             <Dropdown.Menu
               ref={dropdownMenuRef}
               className="granule-results-data-links-button__menu"
-              // {...menuProps}
             >
               {
                 s3Links.length > 0 && dataLinks.length > 0

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -1,5 +1,4 @@
-/* eslint-disable no-unused-vars */
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import ReactDOM from 'react-dom'
 import { Dropdown, Tab } from 'react-bootstrap'
 import { PropTypes } from 'prop-types'
@@ -126,111 +125,107 @@ export const GranuleResultsDataLinksButton = ({
     })
 
     const s3LinksList = () => {
-      if (s3Links.length > 0) {
-        const {
-          region,
-          s3BucketAndObjectPrefixNames = [],
-          s3CredentialsApiDocumentationUrl,
-          s3CredentialsApiEndpoint
-        } = directDistributionInformation
+      const {
+        region,
+        s3BucketAndObjectPrefixNames = [],
+        s3CredentialsApiDocumentationUrl,
+        s3CredentialsApiEndpoint
+      } = directDistributionInformation
 
-        return (
-          <div>
-            {
-              region && (
-                <header className="granule-results-data-links-button__menu-panel-heading">
-                  <div className="granule-results-data-links-button__menu-panel-heading-row">
-                    {'Region: '}
-                    <Button
-                      variant="naked"
-                      className="granule-results-data-links-button__menu-panel-value"
-                      onClick={() => {
-                        copyStringToClipBoard(region, 'AWS S3 Region')
-                      }}
-                      label="Copy the AWS S3 Region"
-                      icon={FaRegCopy}
-                      iconPosition="right"
-                    >
-                      {region}
-                    </Button>
-                  </div>
-                  <div className="granule-results-data-links-button__menu-panel-heading-row">
-                    {'Bucket/Object Prefix: '}
-                    {s3BucketAndObjectPrefixNames.map((bucketAndObjPrefix, i) => (
-                      <React.Fragment key={`${region}_${bucketAndObjPrefix}`}>
-                        <Button
-                          variant="naked"
-                          className="granule-results-data-links-button__menu-panel-value"
-                          onClick={() => {
-                            copyStringToClipBoard(bucketAndObjPrefix, 'AWS S3 Bucket/Object Prefix')
-                          }}
-                          icon={FaRegCopy}
-                          iconPosition="right"
-                          label="Copy the AWS S3 Bucket/Object Prefix"
-                        >
-                          {bucketAndObjPrefix}
-                        </Button>
-                        {i !== s3BucketAndObjectPrefixNames.length - 1 && ', '}
-                      </React.Fragment>
-                    ))}
-                  </div>
-                  <div className="granule-results-data-links-button__menu-panel-heading-row">
-                    {'Credentials API: '}
-                    <span className="granule-results-data-links-button__menu-panel-value">
-                      <a
-                        className="link link--external"
-                        href={s3CredentialsApiEndpoint}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        S3 Credentials API
-                      </a>
-                      <a
-                        className="link link--separated link--external"
-                        href={s3CredentialsApiDocumentationUrl}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >
-                        Documentation
-                      </a>
-                    </span>
-                  </div>
-                </header>
-              )
-            }
-            {
-              s3Links.map((s3Link, i) => {
-                const key = `s3_link_${i}`
-                const s3LinkTitle = getFilenameFromPath(s3Link.href)
-
-                return (
-                  <Dropdown.Item
-                    as={Button}
-                    className="granule-results-data-links-button__dropdown-item"
-                    key={key}
-                    label="Copy path to file in AWS S3"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      copyS3PathToClipBoard(s3Link.href, s3LinkTitle)
-                      onMetricsDataAccess({
-                        type: 'single_granule_s3_access',
-                        collections: [{
-                          collectionId
-                        }]
-                      })
+      return (
+        <div>
+          {
+            region && (
+              <header className="granule-results-data-links-button__menu-panel-heading">
+                <div className="granule-results-data-links-button__menu-panel-heading-row">
+                  {'Region: '}
+                  <Button
+                    variant="naked"
+                    className="granule-results-data-links-button__menu-panel-value"
+                    onClick={() => {
+                      copyStringToClipBoard(region, 'AWS S3 Region')
                     }}
+                    label="Copy the AWS S3 Region"
+                    icon={FaRegCopy}
+                    iconPosition="right"
                   >
-                    {s3LinkTitle}
-                    <FaRegCopy className="granule-results-data-links-button__icon" />
-                  </Dropdown.Item>
-                )
-              })
-            }
-          </div>
-        )
-      }
+                    {region}
+                  </Button>
+                </div>
+                <div className="granule-results-data-links-button__menu-panel-heading-row">
+                  {'Bucket/Object Prefix: '}
+                  {s3BucketAndObjectPrefixNames.map((bucketAndObjPrefix, i) => (
+                    <React.Fragment key={`${region}_${bucketAndObjPrefix}`}>
+                      <Button
+                        variant="naked"
+                        className="granule-results-data-links-button__menu-panel-value"
+                        onClick={() => {
+                          copyStringToClipBoard(bucketAndObjPrefix, 'AWS S3 Bucket/Object Prefix')
+                        }}
+                        icon={FaRegCopy}
+                        iconPosition="right"
+                        label="Copy the AWS S3 Bucket/Object Prefix"
+                      >
+                        {bucketAndObjPrefix}
+                      </Button>
+                      {i !== s3BucketAndObjectPrefixNames.length - 1 && ', '}
+                    </React.Fragment>
+                  ))}
+                </div>
+                <div className="granule-results-data-links-button__menu-panel-heading-row">
+                  {'Credentials API: '}
+                  <span className="granule-results-data-links-button__menu-panel-value">
+                    <a
+                      className="link link--external"
+                      href={s3CredentialsApiEndpoint}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      S3 Credentials API
+                    </a>
+                    <a
+                      className="link link--separated link--external"
+                      href={s3CredentialsApiDocumentationUrl}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Documentation
+                    </a>
+                  </span>
+                </div>
+              </header>
+            )
+          }
+          {
+            s3Links.map((s3Link, i) => {
+              const key = `s3_link_${i}`
+              const s3LinkTitle = getFilenameFromPath(s3Link.href)
 
-      return null
+              return (
+                <Dropdown.Item
+                  as={Button}
+                  className="granule-results-data-links-button__dropdown-item"
+                  key={key}
+                  label="Copy path to file in AWS S3"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    copyS3PathToClipBoard(s3Link.href, s3LinkTitle)
+                    onMetricsDataAccess({
+                      type: 'single_granule_s3_access',
+                      collections: [{
+                        collectionId
+                      }]
+                    })
+                  }}
+                >
+                  {s3LinkTitle}
+                  <FaRegCopy className="granule-results-data-links-button__icon" />
+                </Dropdown.Item>
+              )
+            })
+          }
+        </div>
+      )
     }
 
     return (

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.js
@@ -62,23 +62,6 @@ export const GranuleResultsDataLinksButton = ({
   onMetricsDataAccess
 }) => {
   const dropdownMenuRef = useRef(null)
-  // const [widestTabWidth, setWidestTabWidth] = useState(null)
-
-  // useEffect(() => {
-  //   if (dropdownMenuRef.current) {
-  //     const tabs = dropdownMenuRef.current.getElementsByClassName('granule-results-data-links-button__menu-panel')
-  //     const tabWidthReducer = (acc, currVal) => {
-  //       const isActive = currVal.classList.contains('active')
-  //       currVal.classList.add('active')
-  //       const tabWidth = currVal.getBoundingClientRect().width
-  //       if (!isActive) currVal.classList.remove('active')
-  //       return (tabWidth > acc) ? tabWidth : acc
-  //     }
-
-  //     const widestTabWidth = Array.from(tabs).reduce(tabWidthReducer, tabs[0].getBoundingClientRect().width)
-  //     setWidestTabWidth(widestTabWidth)
-  //   }
-  // }, [dropdownMenuRef.current])
 
   const copyStringToClipBoard = async (string, name) => {
     try {
@@ -249,10 +232,6 @@ export const GranuleResultsDataLinksButton = ({
 
       return null
     }
-
-    // const menuProps = {}
-
-    // if (widestTabWidth) menuProps.style = { width: widestTabWidth }
 
     return (
       <Dropdown onClick={(e) => { e.stopPropagation() }} drop="right">

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.scss
@@ -2,15 +2,117 @@
   &__dropdown-item {
     color: $color__black--800;
     font-size: 0.875rem;
+    padding: 0.25rem 1rem;
+    user-select: text;
+    line-height: 1.5rem;
+    vertical-align: middle;
+    cursor: pointer;
 
     &:hover {
       background-color: $color__blue--dark;
-      color: $color__black--200;
+      color: $color__black--100;
     }
   }
 
   &__menu {
-    max-height: 15.825rem;
-    overflow-y: scroll !important; // !important is needed here to override the !important included in the bootstrap css for .dropdown-menu
+    padding: 0;
+
+    .edsc-tabs {
+      .nav-item {
+        flex-grow: 1;
+        text-align: center;
+      }
+    }
+
+    .tab-content {
+      max-height: 20rem;
+      overflow-y: scroll;
+    }
+  }
+
+  &__menu-panel-heading {
+    position: sticky;
+    top: 0;
+    left: 0;
+    padding: 0.325rem 1rem;
+    background: $color__black--100;
+    border-bottom: 1px solid $color__black--200;
+    color: $color__black--600;
+    font-size: 0.825rem;
+    line-height: 1.5rem;
+    white-space: nowrap;
+  }
+
+  &__menu-panel-heading-row {
+    display: flex;
+  }
+
+  &__icon {
+    margin-left: 0.5rem;
+    color: rgba($color__white, 0.8);
+    opacity: 0;
+    transition: all 0.2s ease;
+
+    &--download {
+      position: relative;
+      top: -0.125rem;
+    }
+
+    .granule-results-data-links-button__dropdown-item:hover & {
+      opacity: 1;
+    }
+  }
+
+  &__menu-panel-value {
+    position: relative;
+    top: -0.0125rem;
+    display: flex;
+    align-items: center;
+    margin-left: 0.25rem;
+    color: $color__black--700;
+    font-weight: 700;
+    align-items: center;
+    user-select: text;
+    white-space: nowrap;
+
+    .button__contents {
+      display: inline-block;
+    }
+
+    .button__icon {
+      position: relative;
+      margin-left: 0.25rem;
+      font-size: 0.825rem;
+      color: $color__black--500;
+      opacity: 0;
+      transition: opacity 0.1s ease-in-out;
+
+      .button--naked & {
+        vertical-align: initial;
+      }
+    }
+
+    &:hover,
+    &:focus {
+      .button__icon {
+        opacity: 1;
+      }
+    }
+  }
+
+  &__tab-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__tab-icon {
+    color: $color__black--300;
+    margin-right: 0.325rem;
+    transition: color 0.1s ease-in-out;
+
+    .nav-item.active & {
+      color: $color__black--500;
+    }
   }
 }

--- a/static/src/js/components/GranuleResults/GranuleResultsItem.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.js
@@ -27,6 +27,7 @@ const thumbnailWidth = getApplicationConfig().thumbnailSize.width
  * Renders GranuleResultsItem.
  * @param {Object} props - The props passed into the component.
  * @param {String} props.collectionId - Granule passed from redux store.
+ * @param {Object} props.directDistributionInformation - The collection direct distribution information.
  * @param {Object} props.granule - Granule passed from redux store.
  * @param {Boolean} props.isCollectionInProject - Flag designating if the collection is in the project.
  * @param {Function} props.isGranuleInProject - Function designating if the granule is in the project.

--- a/static/src/js/components/GranuleResults/GranuleResultsItem.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.js
@@ -40,6 +40,7 @@ const thumbnailWidth = getApplicationConfig().thumbnailSize.width
  */
 const GranuleResultsItem = forwardRef(({
   collectionId,
+  directDistributionInformation,
   granule,
   isCollectionInProject,
   isGranuleInProject,
@@ -80,6 +81,7 @@ const GranuleResultsItem = forwardRef(({
     isHoveredGranule,
     isFocusedGranule,
     onlineAccessFlag,
+    s3Links,
     timeEnd,
     timeStart,
     title
@@ -265,6 +267,8 @@ const GranuleResultsItem = forwardRef(({
                   <GranuleResultsDataLinksButton
                     collectionId={collectionId}
                     dataLinks={dataLinks}
+                    directDistributionInformation={directDistributionInformation}
+                    s3Links={s3Links}
                     onMetricsDataAccess={onMetricsDataAccess}
                   />
                 )
@@ -279,6 +283,7 @@ const GranuleResultsItem = forwardRef(({
 
 GranuleResultsItem.propTypes = {
   collectionId: PropTypes.string.isRequired,
+  directDistributionInformation: PropTypes.shape({}).isRequired,
   granule: PropTypes.shape({}).isRequired,
   isCollectionInProject: PropTypes.bool.isRequired,
   isGranuleInProject: PropTypes.func.isRequired,

--- a/static/src/js/components/GranuleResults/GranuleResultsList.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsList.js
@@ -12,6 +12,7 @@ import './GranuleResultsList.scss'
  * Renders GranuleResultsList.
  * @param {Object} props - The props passed into the component.
  * @param {String} props.collectionId - The collection ID.
+ * @param {Object} props.directDistributionInformation - The direct distribution information.
  * @param {Array} props.excludedGranuleIds - List of excluded granule IDs.
  * @param {Array} props.granules - List of formatted granule.
  * @param {Boolean} props.isOpenSearch - Flag designating CWIC collections.

--- a/static/src/js/components/GranuleResults/GranuleResultsList.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsList.js
@@ -32,6 +32,7 @@ import './GranuleResultsList.scss'
  */
 export const GranuleResultsList = ({
   collectionId,
+  directDistributionInformation,
   excludedGranuleIds,
   granules,
   isCollectionInProject,
@@ -56,6 +57,7 @@ export const GranuleResultsList = ({
         ({ height, width }) => (
           <GranuleResultsListBody
             collectionId={collectionId}
+            directDistributionInformation={directDistributionInformation}
             excludedGranuleIds={excludedGranuleIds}
             granules={granules}
             height={height}
@@ -89,6 +91,7 @@ GranuleResultsList.defaultProps = {
 
 GranuleResultsList.propTypes = {
   collectionId: PropTypes.string.isRequired,
+  directDistributionInformation: PropTypes.shape({}).isRequired,
   excludedGranuleIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   granules: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   isCollectionInProject: PropTypes.bool.isRequired,

--- a/static/src/js/components/GranuleResults/GranuleResultsListBody.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsListBody.js
@@ -55,6 +55,7 @@ innerElementType.propTypes = {
  * Renders GranuleResultsListBody.
  * @param {Object} props - The props passed into the component.
  * @param {String} props.collectionId - The collection ID.
+ * @param {Object} props.directDistributionInformation - The direct distribution information.
  * @param {Array} props.excludedGranuleIds - List of excluded granule IDs.
  * @param {Array} props.granules - List of formatted granule.
  * @param {Number} props.height - The height of the container provided by AutoSizer.

--- a/static/src/js/components/GranuleResults/GranuleResultsListBody.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsListBody.js
@@ -77,6 +77,7 @@ innerElementType.propTypes = {
  */
 export const GranuleResultsListBody = ({
   collectionId,
+  directDistributionInformation,
   excludedGranuleIds,
   granules,
   height,
@@ -190,6 +191,7 @@ export const GranuleResultsListBody = ({
             innerElementType={innerElementType}
             itemData={{
               collectionId,
+              directDistributionInformation,
               excludedGranuleIds,
               getRowHeight,
               granules,
@@ -243,6 +245,7 @@ GranuleResultsListBody.defaultProps = {
 
 GranuleResultsListBody.propTypes = {
   collectionId: PropTypes.string.isRequired,
+  directDistributionInformation: PropTypes.shape({}).isRequired,
   excludedGranuleIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   granules: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   height: PropTypes.number.isRequired,

--- a/static/src/js/components/GranuleResults/GranuleResultsListItem.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsListItem.js
@@ -29,6 +29,7 @@ export const GranuleResultsListItem = memo(({
 
   const {
     collectionId,
+    directDistributionInformation,
     granules,
     isCollectionInProject,
     isGranuleInProject,
@@ -98,6 +99,7 @@ export const GranuleResultsListItem = memo(({
     <li className="granule-results-list-item" style={customStyle}>
       <GranuleResultsItem
         collectionId={collectionId}
+        directDistributionInformation={directDistributionInformation}
         granule={granules[index]}
         isCollectionInProject={isCollectionInProject}
         isGranuleInProject={isGranuleInProject}

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.js
@@ -34,6 +34,7 @@ import './GranuleResultsTable.scss'
 
 export const GranuleResultsTable = ({
   collectionId,
+  directDistributionInformation,
   focusedGranuleId,
   granules,
   hasBrowseImagery,
@@ -61,6 +62,7 @@ export const GranuleResultsTable = ({
       customProps: {
         cellClassName: 'granule-results-table__cell--granule',
         collectionId,
+        directDistributionInformation,
         isGranuleInProject,
         GranuleResultsTableHeaderCell,
         location,
@@ -201,6 +203,7 @@ GranuleResultsTable.defaultProps = {
 
 GranuleResultsTable.propTypes = {
   collectionId: PropTypes.string.isRequired,
+  directDistributionInformation: PropTypes.shape({}).isRequired,
   focusedGranuleId: PropTypes.string.isRequired,
   granules: PropTypes.arrayOf(PropTypes.shape).isRequired,
   hasBrowseImagery: PropTypes.bool.isRequired,

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.js
@@ -14,6 +14,7 @@ import './GranuleResultsTable.scss'
  * Renders GranuleResultsTable.
  * @param {Object} props - The props passed into the component.
  * @param {String} props.collectionId - The collection ID.
+ * @param {Object} props.directDistributionInformation - The direct distribution information.
  * @param {String} props.focusedGranuleId - The focused granule ID.
  * @param {Array} props.granules - List of formatted granule.
  * @param {Boolean} props.hasBrowseImagery - Designates if the collection has browse imagery.

--- a/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.js
@@ -22,6 +22,7 @@ const GranuleResultsTableHeaderCell = (props) => {
   const { customProps } = column
   const { original: rowProps } = row
   const {
+    s3Links,
     dataLinks,
     id,
     isOpenSearch,
@@ -30,6 +31,7 @@ const GranuleResultsTableHeaderCell = (props) => {
 
   const {
     collectionId,
+    directDistributionInformation,
     isGranuleInProject,
     location,
     onAddGranuleToProjectCollection,
@@ -113,7 +115,9 @@ const GranuleResultsTableHeaderCell = (props) => {
           onlineAccessFlag && (
             <GranuleResultsDataLinksButton
               collectionId={collectionId}
+              directDistributionInformation={directDistributionInformation}
               dataLinks={dataLinks}
+              s3Links={s3Links}
               onMetricsDataAccess={onMetricsDataAccess}
               buttonVariant="naked"
             />

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsBody.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsBody.test.js
@@ -17,6 +17,7 @@ function setup(options = {
 }, overrideProps) {
   const props = {
     collectionId: 'collectionId',
+    directDistributionInformation: {},
     focusedGranuleId: '',
     granulesMetadata: {
       one: {

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
@@ -262,7 +262,8 @@ describe('GranuleResultsDataLinksButton component', () => {
           }
         ]
       })
-      const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+
+      const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
       expect(tabDropdownItems[0].type.displayName).toBe('DropdownItem')
       expect(tabDropdownItems[0].props.label).toBe('Copy path to file in AWS S3')
       expect(tabDropdownItems[0].props.children[0]).toBe('linkhref')
@@ -291,7 +292,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
         tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
         expect(stopPropagationMock).toHaveBeenCalledTimes(1)
       })
@@ -318,7 +319,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
         tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
         expect(props.onMetricsDataAccess).toHaveBeenCalledTimes(1)
         expect(props.onMetricsDataAccess).toHaveBeenCalledWith({
@@ -353,7 +354,7 @@ describe('GranuleResultsDataLinksButton component', () => {
               }
             ]
           })
-          const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+          const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
 
           tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
 
@@ -396,7 +397,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
         await tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
 
         expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
@@ -434,7 +435,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children.props.children[1]
         await tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
 
         expect(addToastMock.mock.calls.length).toBe(1)
@@ -465,7 +466,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+        const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
         const regionRow = distributionInformation.props.children[0]
         const value = regionRow.props.children[1]
         expect(value.props.children).toBe('aws-region')
@@ -499,7 +500,7 @@ describe('GranuleResultsDataLinksButton component', () => {
                 }
               ]
             })
-            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
             const regionRow = distributionInformation.props.children[0]
             const value = regionRow.props.children[1]
             await value.props.onClick()
@@ -540,7 +541,7 @@ describe('GranuleResultsDataLinksButton component', () => {
                 }
               ]
             })
-            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
             const regionRow = distributionInformation.props.children[0]
             const value = regionRow.props.children[1]
             await value.props.onClick()
@@ -576,7 +577,7 @@ describe('GranuleResultsDataLinksButton component', () => {
             }
           ]
         })
-        const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+        const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
         const bucketObjectPrefixRow = distributionInformation.props.children[1]
         const value = bucketObjectPrefixRow.props.children[1][0]
         const bucketObjectPrefixButton = value.props.children[0]
@@ -614,7 +615,7 @@ describe('GranuleResultsDataLinksButton component', () => {
                 }
               ]
             })
-            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
             const bucketObjectPrefixRow = distributionInformation.props.children[1]
             const value = bucketObjectPrefixRow.props.children[1][0]
             const bucketObjectPrefixButton = value.props.children[0]
@@ -659,7 +660,7 @@ describe('GranuleResultsDataLinksButton component', () => {
                 }
               ]
             })
-            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
             const bucketObjectPrefixRow = distributionInformation.props.children[1]
             const value = bucketObjectPrefixRow.props.children[1][0]
             const bucketObjectPrefixButton = value.props.children[0]
@@ -700,7 +701,7 @@ describe('GranuleResultsDataLinksButton component', () => {
               }
             ]
           })
-          const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+          const distributionInformation = enzymeWrapper.find('.tab-content').props().children.props.children[0]
           const bucketObjectPrefixRow = distributionInformation.props.children[1]
           const bucketObjectPrefixButtonOne = bucketObjectPrefixRow.props.children[1][0]
           const bucketObjectPrefixButtonTwo = bucketObjectPrefixRow.props.children[1][1]

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
@@ -36,7 +36,6 @@ function setup(overrideProps) {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  Object.defineProperty(global.navigator, 'writeText', () => Promise.resolve())
 })
 
 describe('GranuleResultsDataLinksButton component', () => {
@@ -54,6 +53,16 @@ describe('GranuleResultsDataLinksButton component', () => {
 
       expect(enzymeWrapper.find(Button).props().disabled).toBe(true)
       expect(enzymeWrapper.type()).toBe(Button)
+    })
+
+    test('prevents default when clicked', () => {
+      const preventDefaultMock = jest.fn()
+      const { enzymeWrapper } = setup({
+        dataLinks: []
+      })
+
+      enzymeWrapper.find(Button).simulate('click', { preventDefault: preventDefaultMock })
+      expect(preventDefaultMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -432,6 +441,272 @@ describe('GranuleResultsDataLinksButton component', () => {
         expect(addToastMock.mock.calls[0][0]).toEqual('Copied AWS S3 path for: linkhref')
         expect(addToastMock.mock.calls[0][1].appearance).toEqual('success')
         expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+      })
+    })
+
+    describe('when direct distribution information is provided', () => {
+      test('displays the region as a button', () => {
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+        const regionRow = distributionInformation.props.children[0]
+        const value = regionRow.props.children[1]
+        expect(value.props.children).toBe('aws-region')
+      })
+
+      describe('when clicking the region', () => {
+        describe('when navigation.clipboard.writeText is not defined', () => {
+          test('displays a toast', async () => {
+            // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+            ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+            const addToastMock = jest.spyOn(addToast, 'addToast')
+
+            Object.assign(navigator, {
+              clipboard: {}
+            })
+
+            const { enzymeWrapper } = setup({
+              dataLinks: [],
+              directDistributionInformation: {
+                region: 'aws-region'
+              },
+              s3Links: [
+                {
+                  rel: 'http://linkrel/s3#',
+                  title: 'linktitle',
+                  href: 's3://linkhref'
+                }, {
+                  rel: 'http://linkrel2/s3#',
+                  title: 'linktitle2',
+                  href: 's3://linkhref2'
+                }
+              ]
+            })
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const regionRow = distributionInformation.props.children[0]
+            const value = regionRow.props.children[1]
+            await value.props.onClick()
+
+            expect(addToastMock.mock.calls.length).toBe(1)
+            expect(addToastMock.mock.calls[0][0]).toEqual('Failed to copy the AWS S3 Region')
+            expect(addToastMock.mock.calls[0][1].appearance).toEqual('error')
+            expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+          })
+        })
+
+        describe('when navigation.clipboard.writeText is not defined', () => {
+          test('displays a toast', async () => {
+            // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+            ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+            const addToastMock = jest.spyOn(addToast, 'addToast')
+
+            Object.assign(navigator, {
+              clipboard: {
+                writeText: jest.fn()
+              }
+            })
+
+            const { enzymeWrapper } = setup({
+              dataLinks: [],
+              directDistributionInformation: {
+                region: 'aws-region'
+              },
+              s3Links: [
+                {
+                  rel: 'http://linkrel/s3#',
+                  title: 'linktitle',
+                  href: 's3://linkhref'
+                }, {
+                  rel: 'http://linkrel2/s3#',
+                  title: 'linktitle2',
+                  href: 's3://linkhref2'
+                }
+              ]
+            })
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const regionRow = distributionInformation.props.children[0]
+            const value = regionRow.props.children[1]
+            await value.props.onClick()
+
+            expect(addToastMock.mock.calls.length).toBe(1)
+            expect(addToastMock.mock.calls[0][0]).toEqual('Copied the AWS S3 Region')
+            expect(addToastMock.mock.calls[0][1].appearance).toEqual('success')
+            expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+          })
+        })
+      })
+
+      test('displays the s3 bucket and object prefix as a button', () => {
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region',
+            s3BucketAndObjectPrefixNames: ['TestBucketOrObjectPrefix'],
+            s3CredentialsApiEndpoint: 'https://DAACCredentialEndpoint.org',
+            s3CredentialsApiDocumentationUrl: 'https://DAACCredentialDocumentation.org'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+        const bucketObjectPrefixRow = distributionInformation.props.children[1]
+        const value = bucketObjectPrefixRow.props.children[1][0]
+        const bucketObjectPrefixButton = value.props.children[0]
+        expect(bucketObjectPrefixButton.props.children).toBe('TestBucketOrObjectPrefix')
+      })
+
+      describe('when clicking the bucket object prefix button', () => {
+        describe('when navigation.clipboard.writeText is not defined', () => {
+          test('displays a toast', async () => {
+            // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+            ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+            const addToastMock = jest.spyOn(addToast, 'addToast')
+
+            Object.assign(navigator, {
+              clipboard: {}
+            })
+
+            const { enzymeWrapper } = setup({
+              dataLinks: [],
+              directDistributionInformation: {
+                region: 'aws-region',
+                s3BucketAndObjectPrefixNames: ['TestBucketOrObjectPrefix'],
+                s3CredentialsApiEndpoint: 'https://DAACCredentialEndpoint.org',
+                s3CredentialsApiDocumentationUrl: 'https://DAACCredentialDocumentation.org'
+              },
+              s3Links: [
+                {
+                  rel: 'http://linkrel/s3#',
+                  title: 'linktitle',
+                  href: 's3://linkhref'
+                }, {
+                  rel: 'http://linkrel2/s3#',
+                  title: 'linktitle2',
+                  href: 's3://linkhref2'
+                }
+              ]
+            })
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const bucketObjectPrefixRow = distributionInformation.props.children[1]
+            const value = bucketObjectPrefixRow.props.children[1][0]
+            const bucketObjectPrefixButton = value.props.children[0]
+            await bucketObjectPrefixButton.props.onClick()
+
+            expect(addToastMock.mock.calls.length).toBe(1)
+            expect(addToastMock.mock.calls[0][0]).toEqual('Failed to copy the AWS S3 Bucket/Object Prefix')
+            expect(addToastMock.mock.calls[0][1].appearance).toEqual('error')
+            expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+          })
+        })
+
+        describe('when navigation.clipboard.writeText is not defined', () => {
+          test('displays a toast', async () => {
+            // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+            ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+            const addToastMock = jest.spyOn(addToast, 'addToast')
+
+            Object.assign(navigator, {
+              clipboard: {
+                writeText: jest.fn()
+              }
+            })
+
+            const { enzymeWrapper } = setup({
+              dataLinks: [],
+              directDistributionInformation: {
+                region: 'aws-region',
+                s3BucketAndObjectPrefixNames: ['TestBucketOrObjectPrefix'],
+                s3CredentialsApiEndpoint: 'https://DAACCredentialEndpoint.org',
+                s3CredentialsApiDocumentationUrl: 'https://DAACCredentialDocumentation.org'
+              },
+              s3Links: [
+                {
+                  rel: 'http://linkrel/s3#',
+                  title: 'linktitle',
+                  href: 's3://linkhref'
+                }, {
+                  rel: 'http://linkrel2/s3#',
+                  title: 'linktitle2',
+                  href: 's3://linkhref2'
+                }
+              ]
+            })
+            const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+            const bucketObjectPrefixRow = distributionInformation.props.children[1]
+            const value = bucketObjectPrefixRow.props.children[1][0]
+            const bucketObjectPrefixButton = value.props.children[0]
+            await bucketObjectPrefixButton.props.onClick()
+
+            expect(addToastMock.mock.calls.length).toBe(1)
+            expect(addToastMock.mock.calls[0][0]).toEqual('Copied the AWS S3 Bucket/Object Prefix')
+            expect(addToastMock.mock.calls[0][1].appearance).toEqual('success')
+            expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+          })
+        })
+      })
+
+      describe('when multiple bucket object prefixes are provided', () => {
+        test('displays the s3 bucket and object prefixes as buttons', () => {
+          ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+          const { enzymeWrapper } = setup({
+            dataLinks: [],
+            directDistributionInformation: {
+              region: 'aws-region',
+              s3BucketAndObjectPrefixNames: [
+                'TestBucketOrObjectPrefix',
+                'TestBucketOrObjectPrefixTwo'
+              ],
+              s3CredentialsApiEndpoint: 'https://DAACCredentialEndpoint.org',
+              s3CredentialsApiDocumentationUrl: 'https://DAACCredentialDocumentation.org'
+            },
+            s3Links: [
+              {
+                rel: 'http://linkrel/s3#',
+                title: 'linktitle',
+                href: 's3://linkhref'
+              }, {
+                rel: 'http://linkrel2/s3#',
+                title: 'linktitle2',
+                href: 's3://linkhref2'
+              }
+            ]
+          })
+          const distributionInformation = enzymeWrapper.find('.tab-content').props().children().props.children[0]
+          const bucketObjectPrefixRow = distributionInformation.props.children[1]
+          const bucketObjectPrefixButtonOne = bucketObjectPrefixRow.props.children[1][0]
+          const bucketObjectPrefixButtonTwo = bucketObjectPrefixRow.props.children[1][1]
+          expect(bucketObjectPrefixButtonOne.props.children[0].props.children).toBe('TestBucketOrObjectPrefix')
+          expect(bucketObjectPrefixButtonTwo.props.children[0].props.children).toBe('TestBucketOrObjectPrefixTwo')
+        })
       })
     })
   })

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.js
@@ -4,6 +4,7 @@ import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import { Dropdown } from 'react-bootstrap'
 
+import * as addToast from '../../../util/addToast'
 import { GranuleResultsDataLinksButton, CustomDataLinksToggle } from '../GranuleResultsDataLinksButton'
 import Button from '../../Button/Button'
 
@@ -12,6 +13,7 @@ Enzyme.configure({ adapter: new Adapter() })
 function setup(overrideProps) {
   const props = {
     collectionId: 'TEST_ID',
+    directDistributionInformation: {},
     dataLinks: [
       {
         rel: 'http://linkrel/data#',
@@ -19,6 +21,7 @@ function setup(overrideProps) {
         href: 'http://linkhref'
       }
     ],
+    s3Links: [],
     onMetricsDataAccess: jest.fn(),
     ...overrideProps
   }
@@ -33,6 +36,7 @@ function setup(overrideProps) {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  Object.defineProperty(global.navigator, 'writeText', () => Promise.resolve())
 })
 
 describe('GranuleResultsDataLinksButton component', () => {
@@ -94,6 +98,341 @@ describe('GranuleResultsDataLinksButton component', () => {
         ]
       })
       expect(enzymeWrapper.type()).toBe(Dropdown)
+    })
+
+    describe('when the dropdown is clicked', () => {
+      test('stops event propagation', () => {
+        const stopPropagationMock = jest.fn()
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [
+            {
+              rel: 'http://linkrel/data#',
+              title: 'linktitle',
+              href: 'http://linkhref'
+            }, {
+              rel: 'http://linkrel2/data#',
+              title: 'linktitle2',
+              href: 'http://linkhref2'
+            }
+          ]
+        })
+        enzymeWrapper.simulate('click', { stopPropagation: stopPropagationMock })
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when a link is clicked', () => {
+      test('stops propagation of events', () => {
+        const stopPropagationMock = jest.fn()
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [
+            {
+              rel: 'http://linkrel/data#',
+              title: 'linktitle',
+              href: 'http://linkhref'
+            }, {
+              rel: 'http://linkrel2/data#',
+              title: 'linktitle2',
+              href: 'http://linkhref2'
+            }
+          ]
+        })
+
+        const dataLinks = enzymeWrapper.find('.granule-results-data-links-button__dropdown-item')
+
+        dataLinks.at(0).simulate('click', { stopPropagation: stopPropagationMock })
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
+
+      test('calls the metrics event', () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+        const { enzymeWrapper, props } = setup({
+          dataLinks: [
+            {
+              rel: 'http://linkrel/data#',
+              title: 'linktitle',
+              href: 'http://linkhref'
+            }, {
+              rel: 'http://linkrel2/data#',
+              title: 'linktitle2',
+              href: 'http://linkhref2'
+            }
+          ]
+        })
+
+        const dataLinks = enzymeWrapper.find('.granule-results-data-links-button__dropdown-item')
+
+        dataLinks.at(0).simulate('click', { stopPropagation: () => {} })
+        expect(props.onMetricsDataAccess).toHaveBeenCalledTimes(1)
+        expect(props.onMetricsDataAccess).toHaveBeenCalledWith({
+          collections: [{
+            collectionId: 'TEST_ID'
+          }],
+          type: 'single_granule_download'
+        })
+      })
+
+      test('displays a success toast', () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+        const addToastMock = jest.spyOn(addToast, 'addToast')
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [
+            {
+              rel: 'http://linkrel/data#',
+              title: 'linktitle',
+              href: 'http://linkhref'
+            }, {
+              rel: 'http://linkrel2/data#',
+              title: 'linktitle2',
+              href: 'http://linkhref2'
+            }
+          ]
+        })
+
+        const dataLinks = enzymeWrapper.find('.granule-results-data-links-button__dropdown-item')
+
+        dataLinks.at(0).simulate('click', { stopPropagation: () => {} })
+
+        expect(addToastMock.mock.calls.length).toBe(1)
+        expect(addToastMock.mock.calls[0][0]).toEqual('Initiated download of file: linkhref')
+        expect(addToastMock.mock.calls[0][1].appearance).toEqual('success')
+        expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+      })
+    })
+  })
+
+  describe('when s3 links are provided', () => {
+    test('renders the correct element', () => {
+      // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+      ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+      const { enzymeWrapper } = setup({
+        s3Links: [
+          {
+            rel: 'http://linkrel/s3#',
+            title: 'linktitle',
+            href: 's3://linkhref'
+          }, {
+            rel: 'http://linkrel2/s3#',
+            title: 'linktitle2',
+            href: 's3://linkhref2'
+          }
+        ]
+      })
+      expect(enzymeWrapper.type()).toBe(Dropdown)
+    })
+
+    test('renders s3 links as buttons', () => {
+      // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+      ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+
+      const { enzymeWrapper } = setup({
+        dataLinks: [],
+        directDistributionInformation: {
+          region: 'aws-region'
+        },
+        s3Links: [
+          {
+            rel: 'http://linkrel/s3#',
+            title: 'linktitle',
+            href: 's3://linkhref'
+          }, {
+            rel: 'http://linkrel2/s3#',
+            title: 'linktitle2',
+            href: 's3://linkhref2'
+          }
+        ]
+      })
+      const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+      expect(tabDropdownItems[0].type.displayName).toBe('DropdownItem')
+      expect(tabDropdownItems[0].props.label).toBe('Copy path to file in AWS S3')
+      expect(tabDropdownItems[0].props.children[0]).toBe('linkhref')
+    })
+
+    describe('when clicking an s3 link', () => {
+      test('stops event propagation', () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+        const stopPropagationMock = jest.fn()
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
+        expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      })
+
+      test('calls the metrics event', async () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+        const stopPropagationMock = jest.fn()
+
+        const { enzymeWrapper, props } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
+        expect(props.onMetricsDataAccess).toHaveBeenCalledTimes(1)
+        expect(props.onMetricsDataAccess).toHaveBeenCalledWith({
+          collections: [{
+            collectionId: 'TEST_ID'
+          }],
+          type: 'single_granule_s3_access'
+        })
+      })
+
+      describe('when navigation.clipboard.writeText is not defined', () => {
+        test('displays a toast', async () => {
+          // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+          ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+          const stopPropagationMock = jest.fn()
+          const addToastMock = jest.spyOn(addToast, 'addToast')
+
+          const { enzymeWrapper } = setup({
+            dataLinks: [],
+            directDistributionInformation: {
+              region: 'aws-region'
+            },
+            s3Links: [
+              {
+                rel: 'http://linkrel/s3#',
+                title: 'linktitle',
+                href: 's3://linkhref'
+              }, {
+                rel: 'http://linkrel2/s3#',
+                title: 'linktitle2',
+                href: 's3://linkhref2'
+              }
+            ]
+          })
+          const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+
+          tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
+
+          expect(addToastMock.mock.calls.length).toBe(1)
+          expect(addToastMock.mock.calls[0][0]).toEqual('Failed to copy AWS S3 path for: linkhref')
+          expect(addToastMock.mock.calls[0][1].appearance).toEqual('error')
+          expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+        })
+      })
+    })
+
+    describe('when navigation.clipboard.writeText is defined', () => {
+      test('copies the s3 link', async () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+        const stopPropagationMock = jest.fn()
+
+        Object.assign(navigator, {
+          clipboard: {
+            writeText: () => {}
+          }
+        })
+
+        jest.spyOn(navigator.clipboard, 'writeText')
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        await tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('s3://linkhref')
+      })
+
+      test('displays a toast', async () => {
+        // Mocks createPortal method of ReactDOM (https://stackoverflow.com/a/60953708/8116576)
+        ReactDOM.createPortal = jest.fn(dropdown => dropdown)
+        const stopPropagationMock = jest.fn()
+        const addToastMock = jest.spyOn(addToast, 'addToast')
+
+        Object.assign(navigator, {
+          clipboard: {
+            writeText: () => {}
+          }
+        })
+
+        jest.spyOn(navigator.clipboard, 'writeText')
+
+        const { enzymeWrapper } = setup({
+          dataLinks: [],
+          directDistributionInformation: {
+            region: 'aws-region'
+          },
+          s3Links: [
+            {
+              rel: 'http://linkrel/s3#',
+              title: 'linktitle',
+              href: 's3://linkhref'
+            }, {
+              rel: 'http://linkrel2/s3#',
+              title: 'linktitle2',
+              href: 's3://linkhref2'
+            }
+          ]
+        })
+        const tabDropdownItems = enzymeWrapper.find('.tab-content').props().children().props.children[1]
+        await tabDropdownItems[0].props.onClick({ stopPropagation: stopPropagationMock })
+
+        expect(addToastMock.mock.calls.length).toBe(1)
+        expect(addToastMock.mock.calls[0][0]).toEqual('Copied AWS S3 path for: linkhref')
+        expect(addToastMock.mock.calls[0][1].appearance).toEqual('success')
+        expect(addToastMock.mock.calls[0][1].autoDismiss).toEqual(true)
+      })
     })
   })
 })

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsItem.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsItem.test.js
@@ -15,6 +15,7 @@ function setup(type, overrideProps) {
   const defaultProps = {
     browseUrl: undefined,
     collectionId: 'collectionId',
+    directDistributionInformation: {},
     focusedGranule: '',
     isCollectionInProject: false,
     isGranuleInProject: jest.fn(() => false),
@@ -56,6 +57,43 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
+        ],
+        s3Links: []
+      }
+    }
+  }
+
+  if (type === 'cmr-s3') {
+    props = {
+      ...defaultProps,
+      directDistributionInformation: {
+        region: 's3-region'
+      },
+      granule: {
+        id: 'granuleId',
+        browseFlag: true,
+        onlineAccessFlag: true,
+        formattedTemporal: [
+          '2019-04-28 00:00:00',
+          '2019-04-29 23:59:59'
+        ],
+        timeStart: '2019-04-28 00:00:00',
+        timeEnd: '2019-04-29 23:59:59',
+        granuleThumbnail: '/fake/path/image.jpg',
+        title: 'Granule title',
+        dataLinks: [
+          {
+            rel: 'http://linkrel/data#',
+            title: 'linktitle',
+            href: 'http://linkhref'
+          }
+        ],
+        s3Links: [
+          {
+            rel: 'http://linkrel/s3#',
+            title: 'linktitle',
+            href: 's3://linkhref'
+          }
         ]
       }
     }
@@ -82,7 +120,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 's3://bucket/filename'
           }
-        ]
+        ],
+        s3Links: []
       }
     }
   }
@@ -110,7 +149,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       }
     }
   }
@@ -136,7 +176,8 @@ function setup(type, overrideProps) {
           rel: 'http://linkrel',
           title: 'linktitle',
           href: 'http://linkhref'
-        }]
+        }],
+        s3Links: []
       }
     }
   }
@@ -159,7 +200,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       }
     }
   }
@@ -184,7 +226,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       }
     }
   }
@@ -210,7 +253,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       }
     }
   }
@@ -236,7 +280,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       },
       isLast: true
     }
@@ -263,7 +308,8 @@ function setup(type, overrideProps) {
             title: 'linktitle',
             href: 'http://linkhref'
           }
-        ]
+        ],
+        s3Links: []
       },
       ...overrideProps
     }
@@ -308,7 +354,6 @@ describe('GranuleResultsItem component', () => {
       } = setup('focused-granule')
 
       expect(enzymeWrapper.props().className).toContain('granule-results-item--active')
-
     })
   })
 
@@ -343,6 +388,30 @@ describe('GranuleResultsItem component', () => {
       expect(enzymeWrapper.find('.granule-results-item__temporal--start').find('p').text()).toEqual('2019-04-28 00:00:00')
       expect(enzymeWrapper.find('.granule-results-item__temporal--end').find('h5').text()).toEqual('End')
       expect(enzymeWrapper.find('.granule-results-item__temporal--end').find('p').text()).toEqual('2019-04-29 23:59:59')
+    })
+  })
+
+  describe('when passed s3 links', () => {
+    test('passes the direct distribution information to the data links button', () => {
+      const { enzymeWrapper } = setup('cmr-s3')
+      const dataLinksButtonProps = enzymeWrapper.find(GranuleResultsDataLinksButton).props()
+
+      expect(dataLinksButtonProps.directDistributionInformation).toEqual({
+        region: 's3-region'
+      })
+    })
+
+    test('passes the s3 links to the data links button', () => {
+      const { enzymeWrapper } = setup('cmr-s3')
+      const dataLinksButtonProps = enzymeWrapper.find(GranuleResultsDataLinksButton).props()
+
+      expect(dataLinksButtonProps.s3Links).toEqual([
+        {
+          rel: 'http://linkrel/s3#',
+          title: 'linktitle',
+          href: 's3://linkhref'
+        }
+      ])
     })
   })
 

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsList.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsList.test.js
@@ -32,6 +32,7 @@ function setup(type) {
   if (type === 'loaded') {
     props = {
       collectionId: 'collectionId',
+      directDistributionInformation: {},
       excludedGranuleIds: [],
       focusedGranule: '',
       granules: [

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsTable.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsTable.test.js
@@ -10,9 +10,10 @@ Enzyme.configure({ adapter: new Adapter() })
 
 function setup(overrideProps) {
   const props = {
+    collectionId: 'collectionId',
+    directDistributionInformation: {},
     focusedGranuleId: 'one',
     granules: granuleData,
-    collectionId: 'collectionId',
     isItemLoaded: jest.fn(),
     isGranuleInProject: jest.fn(),
     isProjectGranulesLoading: false,

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsTableHeaderCell.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsTableHeaderCell.test.js
@@ -13,6 +13,7 @@ function setup(overrideProps) {
     column: {
       customProps: {
         collectionId: 'collectionId',
+        directDistributionInformation: {},
         location: {},
         isGranuleInProject: jest.fn(),
         portal: {
@@ -35,6 +36,7 @@ function setup(overrideProps) {
         id: 'one',
         isOpenSearch: false,
         dataLinks: [],
+        s3Links: [],
         onlineAccessFlag: true,
         handleClick: jest.fn()
       }
@@ -88,6 +90,7 @@ describe('GranuleResultsTableHeaderCell component', () => {
           id: 'one',
           isOpenSearch: true,
           dataLinks: [],
+          s3Links: [],
           onlineAccessFlag: true,
           handleClick: jest.fn()
         }

--- a/static/src/js/components/SubscriptionsList/__tests__/SubscriptionsList.test.js
+++ b/static/src/js/components/SubscriptionsList/__tests__/SubscriptionsList.test.js
@@ -157,8 +157,6 @@ describe('SubscriptionsList component', () => {
 
     const editButton = enzymeWrapper.find('.subscriptions-list__button--edit')
 
-    console.log('editButton', editButton.debug())
-
     test('redirects to the focused collection subscriptions', () => {
       expect(editButton.props().to).toEqual({
         pathname: '/search/granules/subscriptions',

--- a/static/src/js/containers/GranuleResultsBodyContainer/GranuleResultsBodyContainer.js
+++ b/static/src/js/containers/GranuleResultsBodyContainer/GranuleResultsBodyContainer.js
@@ -68,7 +68,8 @@ export const GranuleResultsBodyContainer = (props) => {
   } = granuleQuery
 
   const {
-    isOpenSearch = false
+    isOpenSearch = false,
+    directDistributionInformation = {}
   } = collectionMetadata
 
   const loadNextPage = () => {
@@ -81,6 +82,7 @@ export const GranuleResultsBodyContainer = (props) => {
   return (
     <GranuleResultsBody
       collectionId={focusedCollectionId}
+      directDistributionInformation={directDistributionInformation}
       focusedGranuleId={focusedGranuleId}
       granuleQuery={granuleQuery}
       granuleSearchResults={granuleSearchResults}

--- a/static/src/js/util/__tests__/formatGranulesList.test.js
+++ b/static/src/js/util/__tests__/formatGranulesList.test.js
@@ -224,6 +224,87 @@ describe('granule metadata', () => {
     expect(granulesList[0].title).toEqual(granulesMetadata['http://cwic.wgiss.ceos.org/opensearch/granules.atom?uid=C1597928934-NOAA_NCEI:GHRSST-VIIRS_N20-OSPO-L2P.20181201112000-OSPO-L2P_GHRSST-SSTsubskin-VIIRS_N20-ACSPO_V2.60-v02.0-fv01.0.nc'].title)
   })
 
+  test('returns the s3 links if they exist', () => {
+    const granulesMetadata = {
+      'G1924512983-LANCEMODIS': {
+        producerGranuleId: 'MOD09GA.A2020226.h06v03.006.2020227005059.NRT.hdf',
+        timeStart: '2020-08-13T00:00:00.000Z',
+        updated: '2020-08-14T00:51:23.212Z',
+        datasetId: 'MODIS/Terra Near Real Time (NRT) Surface Reflectance Daily L2G Global 1km and 500m SIN Grid',
+        dataCenter: 'LANCEMODIS',
+        title: 'LANCEMODIS:1073941531',
+        coordinateSystem: 'GEODETIC',
+        dayNightFlag: 'UNSPECIFIED',
+        timeEnd: '2020-08-14T00:00:00.000Z',
+        id: 'G1924512983-LANCEMODIS',
+        originalFormat: 'ECHO10',
+        granuleSize: '5.89015102386475',
+        browseFlag: true,
+        polygons: [
+          [
+            '49.9154 -179.9921 49.916 -171.1374 52.3227 -170.9023 52.3246 179.7724 49.9154 -179.9921'
+          ]
+        ],
+        collectionConceptId: 'C1219248410-LANCEMODIS',
+        onlineAccessFlag: true,
+        links: [
+          {
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+            type: 'application/x-hdfeos',
+            hreflang: 'en-US',
+            href: 'https://nrt3.modaps.eosdis.nasa.gov/archive/allData/6/MOD09GA/2020/226/MOD09GA.A2020226.h06v03.006.NRT.hdf'
+          },
+          {
+            inherited: true,
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+            hreflang: 'en-US',
+            href: 'https://earthdata.nasa.gov/earth-observation-data/near-real-time/download-nrt-data/modis-nrt'
+          },
+          {
+            inherited: true,
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/s3#',
+            hreflang: 'en-US',
+            href: 's3://lance3.modaps.eosdis.nasa.gov/data_products/'
+          },
+          {
+            inherited: true,
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/s3#',
+            hreflang: 'en-US',
+            href: 's3://nrt3.modaps.eosdis.nasa.gov/archive/allData/6/MOD09GA'
+          },
+          {
+            inherited: true,
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/metadata#',
+            hreflang: 'en-US',
+            href: 'http://modis.gsfc.nasa.gov/sci_team/'
+          }
+        ],
+        isOpenSearch: false,
+        formattedTemporal: [
+          '2020-08-13 00:00:00',
+          '2020-08-14 00:00:00'
+        ],
+        thumbnail: 'https://cmr.earthdata.nasa.gov/browse-scaler/browse_images/granules/G1924512983-LANCEMODIS?h=85&w=85'
+      }
+    }
+    const { granulesList } = setup({ granulesMetadata })
+
+    expect(granulesList[0].s3Links).toEqual([
+      {
+        inherited: true,
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/s3#',
+        hreflang: 'en-US',
+        href: 's3://lance3.modaps.eosdis.nasa.gov/data_products/'
+      },
+      {
+        inherited: true,
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/s3#',
+        hreflang: 'en-US',
+        href: 's3://nrt3.modaps.eosdis.nasa.gov/archive/allData/6/MOD09GA'
+      }
+    ])
+  })
+
   test('defaults the formattedTemporal', () => {
     const { granulesList } = setup({
       granuleIds: ['G10000-EDSC'],

--- a/static/src/js/util/formatGranulesList.js
+++ b/static/src/js/util/formatGranulesList.js
@@ -1,5 +1,5 @@
 import { eventEmitter } from '../events/events'
-import { createDataLinks } from './granules'
+import { createDataLinks, createS3Links } from './granules'
 
 /**
  * @typedef {Object} GranuleListInfo
@@ -54,6 +54,7 @@ export const formatGranulesList = ({
     const thumbnail = browseFlag ? granuleThumbnail : false
 
     const dataLinks = createDataLinks(links)
+    const s3Links = createS3Links(links)
     const isFocusedGranule = isFocused || focusedGranuleId === id
     const isHoveredGranule = hoveredGranuleId === id
     const isInProject = isGranuleInProject(id)
@@ -95,7 +96,8 @@ export const formatGranulesList = ({
       isCollectionInProject,
       handleClick,
       handleMouseEnter,
-      handleMouseLeave
+      handleMouseLeave,
+      s3Links
     }
   })
 

--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -442,10 +442,23 @@ export const isDataLink = (link, type) => {
 }
 
 /**
+ * Determines if a given link is a data link.
+ * A link is a data link if it has data in the rel property and it is not inherited.
+ * @param {Object} link An individual link object from granule metadata
+ * @param {String} type 'http' or 'ftp'
+ * @returns {Boolean}
+ */
+export const isS3Link = (link) => {
+  const { rel } = link
+
+  return rel.indexOf('/s3#') !== -1
+}
+
+/**
  * Given a list of granule metadata links, filters out those links that are not data links
  * prefering http over ftp for duplicate filenames
  * @param {Array} links List of links from granule metadata
- * @returns {Array} List of data links filters from input links
+ * @returns {Array} List of data links filtered from input links
  */
 export const createDataLinks = (links = []) => {
   // All 'http' data links
@@ -469,6 +482,13 @@ export const createDataLinks = (links = []) => {
     ...ftpLinks
   ]
 }
+
+/**
+ * Given a list of granule metadata links, filters out those links that are not s3 links
+ * @param {Array} links List of links from granule metadata
+ * @returns {Array} List of s3 links filtered from input links
+ */
+export const createS3Links = (links = []) => links.filter(link => isS3Link(link))
 
 /**
 * Pull out download links from within the granule metadata


### PR DESCRIPTION
# Overview

### What is the feature?

Adds AWS S3 links and direct distribution information to the granule results page

### What is the Solution?

When the links are supplied along with data links, they are displayed in tabbed interface. S3 links are copied to the clipboard, rather than being navigated to directly.

### What areas of the application does this impact?

Granule results list page

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** Any collection with direct distribution links and s3 links

1. Navigate to the granule results page for a collection with the correct metadata/granules
2. Confirm direct distribution information is displayed
3. Confirm S3 links are displayed in the list

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
