### PR TITLE
EDSC-3051: Fixes CollectionResultsListItem height on page load

### DIFF
--- a/static/src/js/components/CollectionResults/CollectionResultsListItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsListItem.js
@@ -43,9 +43,9 @@ export const CollectionResultsListItem = memo(({
   }, [])
 
   useEffect(() => {
-    // Calculate the height when the container width is changed
+    // Calculate the height when the container width or element ref is changed
     setSize(index, element.current.getBoundingClientRect().height)
-  }, [windowWidth])
+  }, [windowWidth, element.current])
 
   if (!isItemLoaded(index)) {
     return (


### PR DESCRIPTION
# Overview

### What is the feature?

When loading a collection result that included 3 different badge, like Map Imagery, Customizable and Short Name badges, the height was not being updated to account for the badges, cutting off the last badge

### What is the Solution?

Adding `element.current` to the dependency array for the useEffect that watches for `windowWidth` changes ensures the `setSize` function is called once the ref is loaded

### What areas of the application does this impact?

Collections Results List

# Testing

### Reproduction steps

With production data, search for `AE_Rain`. This should load two collections, the first of which displays the bug.
Ensure all badges are fully displayed without resizing the panel
