### PR TITLE
EDSC-3062: Prevents overwriting tags with the same data

### DIFF
--- a/serverless/src/processTag/addTag.js
+++ b/serverless/src/processTag/addTag.js
@@ -55,6 +55,7 @@ export const addTag = async ({
       const { data = {} } = collectionJsonResponse
       const { feed = {} } = data
       const { entry = [] } = feed
+
       collections = entry
     } catch (e) {
       parseError(e, { reThrowError: true })

--- a/serverless/src/processTag/handler.js
+++ b/serverless/src/processTag/handler.js
@@ -1,7 +1,17 @@
 import 'array-foreach-async'
-import { getSystemToken } from '../util/urs/getSystemToken'
+
+import axios from 'axios'
+
+import { isEqual } from 'lodash'
+
 import { addTag } from './addTag'
+import { deployedEnvironment } from '../../../sharedUtils/deployedEnvironment'
+import { getClientId } from '../../../sharedUtils/getClientId'
+import { getEarthdataConfig } from '../../../sharedUtils/config'
+import { getSystemToken } from '../util/urs/getSystemToken'
+import { getValueForTag } from '../../../sharedUtils/tags'
 import { removeTag } from './removeTag'
+import { stringify } from '../../../static/src/js/util/url/url'
 
 /**
  * Accepts a Tag (or array of Tags) from SQS to process and store in our database
@@ -37,14 +47,68 @@ const processTag = async (event, context) => {
     } = providedTag
 
     if (action === 'ADD') {
-      await addTag({
-        tagName,
-        tagData,
-        searchCriteria,
-        requireGranules,
-        append,
-        cmrToken
-      })
+      const { collection = {} } = searchCriteria
+      const { condition = {} } = collection
+      const { concept_id: conceptId } = condition
+
+      let existingTagData = {}
+
+      if (conceptId) {
+        const { cmrHost } = getEarthdataConfig(deployedEnvironment())
+        const collectionSearchUrl = `${cmrHost}/search/concepts/${conceptId}.json`
+
+        const response = await axios({
+          method: 'post',
+          url: collectionSearchUrl,
+          data: stringify({
+            ...condition,
+            include_tags: tagName
+          }, { indices: false, arrayFormat: 'brackets' }),
+          headers: {
+            'Client-Id': getClientId().background,
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Echo-Token': cmrToken
+          }
+        })
+
+        const { data } = response
+        const { tags } = data
+
+        existingTagData = getValueForTag(tagName, tags, '')
+
+        const strippedExistingTagData = existingTagData
+        const strippedTagData = tagData
+
+        // There are a few jobs that add an 'updated_at' field to the tag data which will always
+        // make the tags appear different so we want to ensure we strip that out before comparing
+        if ('updated_at' in tagData) {
+          delete strippedExistingTagData.updated_at
+          delete strippedTagData.updated_at
+        }
+
+        // Prevent creating tag data that already exists
+        if (!isEqual(strippedTagData, strippedExistingTagData)) {
+          await addTag({
+            tagName,
+            tagData,
+            searchCriteria,
+            requireGranules,
+            append,
+            cmrToken
+          })
+        } else {
+          console.log(`Tag (${tagName}) for ${conceptId} matches existing value`)
+        }
+      } else {
+        await addTag({
+          tagName,
+          tagData,
+          searchCriteria,
+          requireGranules,
+          append,
+          cmrToken
+        })
+      }
     }
 
     if (action === 'REMOVE') {

--- a/serverless/src/processTag/handler.js
+++ b/serverless/src/processTag/handler.js
@@ -81,10 +81,8 @@ const processTag = async (event, context) => {
 
         // There are a few jobs that add an 'updated_at' field to the tag data which will always
         // make the tags appear different so we want to ensure we strip that out before comparing
-        if ('updated_at' in tagData) {
-          delete strippedExistingTagData.updated_at
-          delete strippedTagData.updated_at
-        }
+        delete strippedExistingTagData.updated_at
+        delete strippedTagData.updated_at
 
         // Prevent creating tag data that already exists
         if (!isEqual(strippedTagData, strippedExistingTagData)) {

--- a/static/src/js/components/AdvancedSearchModal/RegionSearchResults.js
+++ b/static/src/js/components/AdvancedSearchModal/RegionSearchResults.js
@@ -67,12 +67,12 @@ export class RegionSearch extends Component {
               className="region-search-results__back-button"
               variant="naked"
               icon={FaChevronLeft}
-              label="Back to Region Search"
+              label="Back to Feature"
               onClick={() => {
                 setModalOverlay(null)
               }}
             >
-              Back to Region Search
+              Back to Feature
             </Button>
           </Col>
         </Row>

--- a/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchForm.test.js
+++ b/static/src/js/components/AdvancedSearchModal/__tests__/AdvancedSearchForm.test.js
@@ -43,6 +43,7 @@ describe('AdvancedSearchForm component', () => {
 
     expect(enzymeWrapper.find(FormikForm).length).toEqual(1)
   })
+
   describe('when provided fields', () => {
     describe('when provided an input', () => {
       test('should render an input', () => {
@@ -82,6 +83,7 @@ describe('AdvancedSearchForm component', () => {
         })
       })
     })
+
     describe('when provided a regionSearch', () => {
       test('should render the RegionSearch component', () => {
         const { enzymeWrapper } = setup({
@@ -89,7 +91,7 @@ describe('AdvancedSearchForm component', () => {
             {
               name: 'regionSearch',
               type: 'regionSearch',
-              label: 'Search by region',
+              label: 'Search by Feature',
               fields: []
             }
           ]

--- a/static/src/js/data/advancedSearchFields.js
+++ b/static/src/js/data/advancedSearchFields.js
@@ -6,7 +6,7 @@ export const advancedSearchFields = [
   {
     name: 'regionSearch',
     type: 'regionSearch',
-    label: 'Search by region',
+    label: 'Search by Feature',
     fields: [
       {
         name: 'endpoint',


### PR DESCRIPTION
# Overview

### What is the feature?

Earthdata Search creates tag data in CMR and today it does so without knowledge of whether or not that data is the same data already in CMR. This PR adds an effort to check existing metadata and prevent retagging collections with data that matches existing data.

### What is the Solution?

Before sending the request to CMR to write tag data, Earthdata Search now queries CMR to retrieve the current metadata that can be compared to the data looking to be sent. If the data matches the request will not be sent and a log will be written indicating that it is being skipped.

### What areas of the application does this impact?

All tagging jobs that use `concept_id` as the search condition.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
