### PR TITLE
EDSC-3062: Check for empty searchCriteria

### DIFF
--- a/serverless/src/processTag/__tests__/handler.test.js
+++ b/serverless/src/processTag/__tests__/handler.test.js
@@ -104,6 +104,40 @@ describe('processTag', () => {
     expect(addTagMock).toBeCalledTimes(0)
   })
 
+  test('correctly call addTag when no searchCriteria is provided', async () => {
+    jest.spyOn(getSystemToken, 'getSystemToken').mockImplementation(() => 'mocked-system-token')
+
+    const addTagMock = jest.spyOn(addTag, 'addTag').mockImplementation(() => jest.fn())
+
+    const tagData = { concept_id: 'C10000001-EDSC', data: 'AMSUA_NOAA15_Brightness_Temp_Channel_6' }
+
+    const event = {
+      Records: [
+        {
+          body: JSON.stringify({
+            tagName: 'edsc.extra.gibs',
+            action: 'ADD',
+            append: true,
+            requireGranules: false,
+            tagData
+          })
+        }
+      ]
+    }
+
+    await processTag(event, {})
+
+    expect(addTagMock).toBeCalledTimes(1)
+    expect(addTagMock).toBeCalledWith({
+      tagName: 'edsc.extra.gibs',
+      searchCriteria: {},
+      tagData: { concept_id: 'C10000001-EDSC', data: 'AMSUA_NOAA15_Brightness_Temp_Channel_6' },
+      requireGranules: false,
+      append: true,
+      cmrToken: 'mocked-system-token'
+    })
+  })
+
   test('doesnt call addTag when tagData matches current tagData when the difference is updated_at', async () => {
     jest.spyOn(getSystemToken, 'getSystemToken').mockImplementation(() => 'mocked-system-token')
 

--- a/serverless/src/processTag/handler.js
+++ b/serverless/src/processTag/handler.js
@@ -41,7 +41,7 @@ const processTag = async (event, context) => {
       action,
       append,
       requireGranules,
-      searchCriteria,
+      searchCriteria = {},
       tagData,
       tagName
     } = providedTag


### PR DESCRIPTION
Some jobs send an empty searchCriteria to processTag and that wasn't being defaulted in the new method, I've defaulted that to an empty object and added a test to catch it in the future.