### PR TITLE
EDSC-2251: Updates max redirects to 5 in download script

### DIFF
--- a/static/src/js/util/files/generateDownloadScript.js
+++ b/static/src/js/util/files/generateDownloadScript.js
@@ -55,7 +55,7 @@ exit_with_error() {
 
 prompt_credentials
   detect_app_approval() {
-    approved=\`curl -s -b "$cookiejar" -c "$cookiejar" -L --max-redirs 2 --netrc-file "$netrc" ${firstGranuleLink} -w %{http_code} | tail  -1\`
+    approved=\`curl -s -b "$cookiejar" -c "$cookiejar" -L --max-redirs 5 --netrc-file "$netrc" ${firstGranuleLink} -w %{http_code} | tail  -1\`
     if [ "$approved" -ne "302" ]; then
         # User didn't approve the app. Direct users to approve the app in URS
         exit_with_error "Please ensure that you have authorized the remote application by visiting the link below "


### PR DESCRIPTION
Allow for more redirects when downloading granule data via the download script.