### PR TITLE
EDSC-3141: Display message on granule results page for CSDA collections

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-  collectCoverage: true,
-  collectCoverageFrom: [
-    'serverless/src/**/*.js',
-    'static/src/**/*.js',
-    'sharedUtils/**/*.js'
-  ],
+  // collectCoverage: true,
+  // collectCoverageFrom: [
+  //   'serverless/src/**/*.js',
+  //   'static/src/**/*.js',
+  //   'sharedUtils/**/*.js'
+  // ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/static/src/js/util/mocks/fileMock.js',
     '^.+\\.(css|less|scss)$': 'babel-jest'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-  // collectCoverage: true,
-  // collectCoverageFrom: [
-  //   'serverless/src/**/*.js',
-  //   'static/src/**/*.js',
-  //   'sharedUtils/**/*.js'
-  // ],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'serverless/src/**/*.js',
+    'static/src/**/*.js',
+    'sharedUtils/**/*.js'
+  ],
   moduleNameMapper: {
     '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/static/src/js/util/mocks/fileMock.js',
     '^.+\\.(css|less|scss)$': 'babel-jest'

--- a/static/src/css/modules/_badge.scss
+++ b/static/src/css/modules/_badge.scss
@@ -1,0 +1,6 @@
+.badge {
+  &--purple {
+    color: $color__white;
+    background-color: $color__purple;
+  }
+}

--- a/static/src/css/modules/modules.scss
+++ b/static/src/css/modules/modules.scss
@@ -1,3 +1,4 @@
+@import 'badge';
 @import 'dropdown';
 @import 'edsc-icons';
 @import 'error-page';

--- a/static/src/css/vendor/bootstrap/_overrides.scss
+++ b/static/src/css/vendor/bootstrap/_overrides.scss
@@ -1,6 +1,8 @@
 /*
 * Custom Variables
 */
+// Gutter width
+$grid-gutter-width: 2rem;
 
 // Font
 $font-size-base: 0.875rem;

--- a/static/src/js/actions/__tests__/focusedCollection.test.js
+++ b/static/src/js/actions/__tests__/focusedCollection.test.js
@@ -311,7 +311,11 @@ describe('getFocusedCollection', () => {
               conceptId: 'C10000000000-EDSC',
               shortName: 'id_1',
               versionId: 'VersionID',
-              dataCenter: 'CSDA'
+              dataCenters: [
+                {
+                  shortName: 'NASA/CSDA'
+                }
+              ]
             }
           }
         })

--- a/static/src/js/actions/__tests__/project.test.js
+++ b/static/src/js/actions/__tests__/project.test.js
@@ -412,7 +412,11 @@ describe('getProjectCollections', () => {
             collections: {
               items: [{
                 conceptId: 'collectionId1',
-                dataCenter: 'CSDA'
+                dataCenters: [
+                  {
+                    shortName: 'NASA/CSDA'
+                  }
+                ]
               },
               {
                 conceptId: 'collectionId2'

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -221,6 +221,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           hasAllMetadata: true,
           hasGranules,
           id: conceptId,
+          isCSDA: dataCenter === 'CSDA',
           isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
           nativeDataFormats,
           services,

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -16,6 +16,7 @@ import { getUsername } from '../selectors/user'
 import { hasTag } from '../../../../sharedUtils/tags'
 import { parseGraphQLError } from '../../../../sharedUtils/parseGraphQLError'
 import { portalPathFromState } from '../../../../sharedUtils/portalPath'
+import { isCSDACollection } from '../util/isCSDACollection'
 
 import GraphQlRequest from '../util/request/graphQlRequest'
 
@@ -190,6 +191,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           conceptId,
           coordinateSystem,
           dataCenter,
+          dataCenters,
           granules,
           hasGranules,
           nativeDataFormats,
@@ -221,7 +223,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           hasAllMetadata: true,
           hasGranules,
           id: conceptId,
-          isCSDA: dataCenter === 'CSDA',
+          isCSDA: isCSDACollection(dataCenters),
           isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
           nativeDataFormats,
           services,

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -320,6 +320,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           hasAllMetadata: true,
           hasGranules,
           id: conceptId,
+          isCSDA: dataCenter === 'CSDA',
           isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
           services,
           shortName,

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -32,6 +32,7 @@ import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
 import { getUsername } from '../selectors/user'
 import { hasTag } from '../../../../sharedUtils/tags'
 import { isProjectCollectionValid } from '../util/isProjectCollectionValid'
+import { isCSDACollection } from '../util/isCSDACollection'
 
 import GraphQlRequest from '../util/request/graphQlRequest'
 
@@ -291,6 +292,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           conceptId,
           coordinateSystem,
           dataCenter,
+          dataCenters,
           granules,
           hasGranules,
           services,
@@ -320,7 +322,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           hasAllMetadata: true,
           hasGranules,
           id: conceptId,
-          isCSDA: dataCenter === 'CSDA',
+          isCSDA: isCSDACollection(dataCenters),
           isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
           services,
           shortName,

--- a/static/src/js/components/AutocompleteDisplay/AutocompleteDisplay.scss
+++ b/static/src/js/components/AutocompleteDisplay/AutocompleteDisplay.scss
@@ -26,7 +26,7 @@
     height: 1.25rem;
     max-width: 100%;
     padding: 0.125rem 0.5rem;
-    padding-right: 1.5rem;
+    padding-right: 1.625rem;
     font-size: 0.625rem;
     line-height: 1.25rem;
     font-weight: 700;
@@ -37,24 +37,18 @@
     position: absolute;
     top: 0;
     right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     z-index: 1;
     height: 1.25rem;
     width: 1.25rem;
     margin-left: auto;
-    padding: 0.125rem;
-    padding-right: 0.25rem;
+    padding: 0;
     font-size: 0.725rem;
     background-color: $color__blue;
     border-radius: 0;
-    align-items: center;
     color: rgba($color__black, 0.7);
-
-    .button__icon {
-      display: block;
-      position: relative;
-      top: -0.0375rem;
-      right: -0.0375rem;
-    }
 
     &:hover {
       background-color: darken($color__blue--dark, 1);

--- a/static/src/js/components/Button/Button.scss
+++ b/static/src/js/components/Button/Button.scss
@@ -15,7 +15,8 @@
 
   &--link {
     padding: 0;
-    vertical-align: baseline;
+    display: inline;
+    vertical-align: inherit;
     border: 0;
     line-height: 1em;
   }
@@ -56,6 +57,8 @@
     }
 
     .button--link & {
+      display: inline;
+      vertical-align: bottom;
       line-height: 1em;
       margin-right: $spacer/4;
     }

--- a/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
@@ -73,17 +73,17 @@ const buildNativeFormatList = (nativeFormats) => {
   )
 }
 
-const buildDoiLink = (doi) => {
+const buildDoiLink = (doiLink, doiText) => {
   const DoiBadge = (
     <SplitBadge
       primary="DOI"
-      secondary={doi.doiText}
+      secondary={doiText}
     />
   )
 
-  if (doi.doiLink) {
+  if (doiLink) {
     return (
-      <a className="collection-details-body__doi" href={doi.doiLink} target="_blank" rel="noopener noreferrer">
+      <a className="collection-details-body__doi" href={doiLink} target="_blank" rel="noopener noreferrer">
         {DoiBadge}
       </a>
     )
@@ -117,7 +117,7 @@ export const CollectionDetailsBody = ({
     associatedDois,
     dataCenters,
     directDistributionInformation,
-    doi,
+    doi = {},
     hasAllMetadata,
     gibsLayers,
     nativeDataFormats,
@@ -190,6 +190,11 @@ export const CollectionDetailsBody = ({
     s3CredentialsApiDocumentationUrl
   } = directDistributionInformation
 
+  const {
+    doiLink,
+    doiText
+  } = doi
+
   return (
     <div className="collection-details-body">
       <SimpleBar
@@ -205,7 +210,7 @@ export const CollectionDetailsBody = ({
                 <Badge className="collection-details-header__short-name mr-2" variant="light">{shortName}</Badge>
                 <Badge className="collection-details-header__version-id mr-2" variant="info">{`Version ${versionId}`}</Badge>
                 {
-                  doi && buildDoiLink(doi)
+                  doiText && buildDoiLink(doiLink, doiText)
                 }
               </div>
               {

--- a/static/src/js/components/Panels/PanelGroup.js
+++ b/static/src/js/components/Panels/PanelGroup.js
@@ -27,7 +27,8 @@ import './PanelGroup.scss'
  * @param {Function} props.onChangePanel - The action to change the panel
  * @param {String} props.panelGroupId - The element to be used as the header
  * @param {String} props.primaryHeading - The text to be used as the primary heading
- * @param {Array} props.sortsArray - The configuration for the sorts
+ * @param {String} props.secondaryHeading - The text to be used as the secondary heading
+* @param {Array} props.sortsArray - The configuration for the sorts
  * @param {Array} props.viewsArray - The configuration for the views
 */
 export const PanelGroup = ({
@@ -36,6 +37,7 @@ export const PanelGroup = ({
   activeView,
   breadcrumbs,
   children,
+  exportsArray,
   footer,
   handoffLinks,
   headerLoading,
@@ -49,7 +51,7 @@ export const PanelGroup = ({
   onChangePanel,
   panelGroupId,
   primaryHeading,
-  exportsArray,
+  secondaryHeading,
   sortsArray,
   viewsArray
 }) => {
@@ -82,6 +84,7 @@ export const PanelGroup = ({
         activeSort={activeSort}
         breadcrumbs={breadcrumbs}
         primaryHeading={primaryHeading}
+        secondaryHeading={secondaryHeading}
         headerLoading={headerLoading}
         headerMessage={headerMessage}
         handoffLinks={handoffLinks}
@@ -105,6 +108,7 @@ PanelGroup.defaultProps = {
   activeView: '',
   activePanelId: '0',
   breadcrumbs: [],
+  exportsArray: [],
   footer: null,
   handoffLinks: [],
   headerMessage: null,
@@ -119,9 +123,9 @@ PanelGroup.defaultProps = {
   panelGroupId: '',
   primaryHeading: null,
   headerLoading: false,
-  exportsArray: [],
-  viewsArray: [],
-  sortsArray: []
+  secondaryHeading: null,
+  sortsArray: [],
+  viewsArray: []
 }
 
 PanelGroup.propTypes = {
@@ -133,6 +137,7 @@ PanelGroup.propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
   ]).isRequired,
+  exportsArray: PropTypes.arrayOf(PropTypes.shape({})),
   footer: PropTypes.node,
   handoffLinks: PropTypes.arrayOf(PropTypes.shape({})),
   headerMessage: PropTypes.node,
@@ -158,9 +163,9 @@ PanelGroup.propTypes = {
   panelGroupId: PropTypes.string,
   primaryHeading: PropTypes.string,
   headerLoading: PropTypes.bool,
-  exportsArray: PropTypes.arrayOf(PropTypes.shape({})),
-  viewsArray: PropTypes.arrayOf(PropTypes.shape({})),
-  sortsArray: PropTypes.arrayOf(PropTypes.shape({}))
+  secondaryHeading: PropTypes.node,
+  sortsArray: PropTypes.arrayOf(PropTypes.shape({})),
+  viewsArray: PropTypes.arrayOf(PropTypes.shape({}))
 }
 
 export default PanelGroup

--- a/static/src/js/components/Panels/PanelGroup.js
+++ b/static/src/js/components/Panels/PanelGroup.js
@@ -28,7 +28,7 @@ import './PanelGroup.scss'
  * @param {String} props.panelGroupId - The element to be used as the header
  * @param {String} props.primaryHeading - The text to be used as the primary heading
  * @param {String} props.secondaryHeading - The text to be used as the secondary heading
-* @param {Array} props.sortsArray - The configuration for the sorts
+ * @param {Array} props.sortsArray - The configuration for the sorts
  * @param {Array} props.viewsArray - The configuration for the views
 */
 export const PanelGroup = ({

--- a/static/src/js/components/Panels/PanelGroupHeader.js
+++ b/static/src/js/components/Panels/PanelGroupHeader.js
@@ -36,6 +36,7 @@ import './PanelGroupHeader.scss'
  * @param {Array} props.moreActionsDropdownItems - An array of objects used to configure the more actions dropdown items
  * @param {String} props.panelGroupId - The element to be used as the header
  * @param {String} props.primaryHeading - The text to be used as the primary heading
+ * @param {String} props.secondaryHeading - The text to be used as the secondary heading
  * @param {Array} props.sortsArray - The text to be used as the secondary heading
  * @param {Array} props.viewsArray - The text to be used as the secondary heading
 */
@@ -52,6 +53,7 @@ export const PanelGroupHeader = ({
   headerLoading,
   moreActionsDropdownItems,
   exportsArray,
+  secondaryHeading,
   sortsArray,
   viewsArray
 }) => {
@@ -169,11 +171,12 @@ export const PanelGroupHeader = ({
               />
             )
             : (
-              <h2 className="panel-group-header__heading">
-                <span className="panel-group-header__heading-primary">
+              <span className="panel-group-header__heading">
+                <h2 className="panel-group-header__heading-primary">
                   {primaryHeading}
-                </span>
-              </h2>
+                </h2>
+                {secondaryHeading}
+              </span>
             )
         }
         {
@@ -327,6 +330,7 @@ PanelGroupHeader.defaultProps = {
   headerLoading: false,
   exportsArray: [],
   viewsArray: [],
+  secondaryHeading: null,
   sortsArray: []
 }
 
@@ -354,6 +358,7 @@ PanelGroupHeader.propTypes = {
   headerLoading: PropTypes.bool,
   exportsArray: PropTypes.arrayOf(PropTypes.shape({})),
   viewsArray: PropTypes.arrayOf(PropTypes.shape({})),
+  secondaryHeading: PropTypes.node,
   sortsArray: PropTypes.arrayOf(PropTypes.shape({}))
 }
 

--- a/static/src/js/components/Panels/PanelGroupHeader.scss
+++ b/static/src/js/components/Panels/PanelGroupHeader.scss
@@ -147,10 +147,17 @@
 
 
   &__heading-primary {
+    display: inline;
+    vertical-align: middle;
     margin-right: 0.75rem;
     font-size: 1rem;
     font-weight: 500;
     color: $color__black--700;
+  }
+
+  &__heading-badge {
+    display: inline;
+    vertical-align: middle;
   }
 
 

--- a/static/src/js/components/Panels/__tests__/PanelGroupHeader.test.js
+++ b/static/src/js/components/Panels/__tests__/PanelGroupHeader.test.js
@@ -105,6 +105,17 @@ describe('PanelGroupHeader component', () => {
     })
   })
 
+  describe('when a secondary header is provided', () => {
+    test('should render the secondary header', () => {
+      const { enzymeWrapper } = setup({
+        secondaryHeading: <span>Secondary Heading</span>
+      })
+
+      expect(enzymeWrapper.find('.panel-group-header__heading').children().length).toEqual(2)
+      expect(enzymeWrapper.find('.panel-group-header__heading').childAt(1).text()).toEqual('Secondary Heading')
+    })
+  })
+
   describe('when more action dropdown items are provided', () => {
     const firstMoreActionOnClickMock = jest.fn()
     const secondMoreActionOnClickMock = jest.fn()

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -187,7 +187,7 @@ class SearchPanels extends PureComponent {
     const {
       hasAllMetadata: hasAllCollectionMetadata = false,
       title: collectionTitle = '',
-      isCsda: collectionIsCSDA,
+      isCSDA: collectionIsCSDA,
       isOpenSearch: collectionIsOpenSearch
     } = collectionMetadata
 

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -5,14 +5,15 @@ import {
   Switch
 } from 'react-router-dom'
 import { isEqual, startCase } from 'lodash'
-import { Col } from 'react-bootstrap'
+import { Badge, Col } from 'react-bootstrap'
 import {
   FaBell,
   FaInfoCircle,
   FaList,
   FaMap,
   FaQuestionCircle,
-  FaTable
+  FaTable,
+  FaLock
 } from 'react-icons/fa'
 
 import { generateHandoffs } from '../../util/handoffs/generateHandoffs'
@@ -186,6 +187,7 @@ class SearchPanels extends PureComponent {
     const {
       hasAllMetadata: hasAllCollectionMetadata = false,
       title: collectionTitle = '',
+      isCsda: collectionIsCSDA,
       isOpenSearch: collectionIsOpenSearch
     } = collectionMetadata
 
@@ -403,9 +405,9 @@ class SearchPanels extends PureComponent {
           <>
             {
               collectionIsOpenSearch && (
-                <Col className="search-panels__cwic-note">
+                <Col className="search-panels__note">
                   {'This is '}
-                  <span className="granule-results-header__cwic-emph">Int&apos;l / Interagency Data</span>
+                  <span className="search-panels__note-emph search-panels__note-emph--opensearch">Int&apos;l / Interagency Data</span>
                   {' data. Searches will be performed by external services which may vary in performance and available features. '}
                   <Button
                     className="granule-results-header__link"
@@ -417,6 +419,27 @@ class SearchPanels extends PureComponent {
                   >
                     More Details
                   </Button>
+                </Col>
+              )
+            }
+            {
+              collectionIsCSDA && (
+                <Col className="search-panels__note">
+                  {'This collection is made available through the '}
+                  <span className="search-panels__note-emph search-panels__note-emph--csda">NASA Commercial Smallsat Data Acquisition (CSDA) Program</span>
+                  {' for NASA funded researchers. Access to the data will require additional authentication. '}
+                  {/*
+                    // TODO: Implement CSDA Modal (EDSC-3144)
+                    <Button
+                    className="granule-results-header__link"
+                    onClick={() => onToggleAboutCSDAModal(true)}
+                    variant="link"
+                    bootstrapVariant="link"
+                    icon={FaQuestionCircle}
+                    label="More details"
+                  >
+                    More Details
+                  </Button> */}
                 </Col>
               )
             }
@@ -436,6 +459,16 @@ class SearchPanels extends PureComponent {
           <GranuleResultsActionsContainer />
         )}
         primaryHeading={collectionTitle}
+        secondaryHeading={
+          collectionIsCSDA && (
+            <Badge className="panel-group-header__heading-badge badge--purple">
+              <span className="mr-1">
+                <FaLock />
+              </span>
+              CSDA
+            </Badge>
+          )
+        }
         headerLoading={!collectionSearchIsLoaded && hasAllCollectionMetadata === false}
         activeView={granulePanelView}
         activeSort={activeGranulesSortKey}

--- a/static/src/js/components/SearchPanels/SearchPanels.scss
+++ b/static/src/js/components/SearchPanels/SearchPanels.scss
@@ -11,10 +11,22 @@
     text-decoration: underline;
   }
 
-  &__cwic-note {
+  &__note {
     display: block;
     margin-bottom: $spacer/2;
     color: $color__black--400;
     font-size: 0.875rem;
+  }
+
+  &__note-emph {
+    font-weight: 500;
+
+    &--opensearch {
+      color: $color__yellow;
+    }
+
+    &--csda {
+      color: $color__purple;
+    }
   }
 }

--- a/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
+++ b/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
@@ -47,6 +47,7 @@ function setup(overrideProps, location = '/search') {
     collectionMetadata: {
       hasAllMetadata: true,
       title: 'Collection Title',
+      isCsda: false,
       isOpenSearch: false
     },
     collectionQuery: {
@@ -486,6 +487,81 @@ describe('SearchPanels component', () => {
         expect(granuleResultsPanelProps.headerMetaPrimaryText).toBe('Showing 2 of 4 matching granules')
         expect(granuleResultsPanelProps.headerLoading).toBe(false)
       })
+    })
+
+    describe('on a non-CSDA collection', () => {
+      test('does not display a badge in the secondary heading', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCsda: false,
+            isOpenSearch: false
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+
+        expect(granuleResultsPanelProps.secondaryHeading).toEqual(false)
+      })
+
+      test('does not display a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCsda: false,
+            isOpenSearch: false
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+
+        expect(granuleResultsPanelProps.headerMessage.props.children).toEqual([
+          false,
+          false
+        ])
+      })
+    })
+
+    describe('on a CSDA collection', () => {
+      test('displays a badge in the secondary heading', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCsda: true,
+            isOpenSearch: false
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+
+        expect(granuleResultsPanelProps.secondaryHeading.type.displayName).toEqual('Badge')
+        expect(granuleResultsPanelProps.secondaryHeading.props.className).toContain('badge--purple')
+        expect(granuleResultsPanelProps.secondaryHeading.props.children[1]).toEqual('CSDA')
+      })
+    })
+
+    test('displays a header message', () => {
+      const { enzymeWrapper } = setup({
+        collectionMetadata: {
+          hasAllMetadata: true,
+          title: 'Collection Title',
+          isCsda: true,
+          isOpenSearch: false
+        }
+      }, '/search/granules')
+      const panels = enzymeWrapper.find(Panels)
+      const granuleResultsPanel = panels.find(PanelGroup).at(1)
+      const granuleResultsPanelProps = granuleResultsPanel.props()
+      const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+
+      expect(messageProps.className).toEqual('search-panels__note')
+      expect(shallow(messageProps.children[1]).text()).toContain('NASA Commercial Smallsat Data Acquisition (CSDA) Program')
     })
   })
 

--- a/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
+++ b/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
@@ -47,7 +47,7 @@ function setup(overrideProps, location = '/search') {
     collectionMetadata: {
       hasAllMetadata: true,
       title: 'Collection Title',
-      isCsda: false,
+      isCSDA: false,
       isOpenSearch: false
     },
     collectionQuery: {
@@ -495,7 +495,7 @@ describe('SearchPanels component', () => {
           collectionMetadata: {
             hasAllMetadata: true,
             title: 'Collection Title',
-            isCsda: false,
+            isCSDA: false,
             isOpenSearch: false
           }
         }, '/search/granules')
@@ -511,7 +511,7 @@ describe('SearchPanels component', () => {
           collectionMetadata: {
             hasAllMetadata: true,
             title: 'Collection Title',
-            isCsda: false,
+            isCSDA: false,
             isOpenSearch: false
           }
         }, '/search/granules')
@@ -532,7 +532,7 @@ describe('SearchPanels component', () => {
           collectionMetadata: {
             hasAllMetadata: true,
             title: 'Collection Title',
-            isCsda: true,
+            isCSDA: true,
             isOpenSearch: false
           }
         }, '/search/granules')
@@ -551,7 +551,7 @@ describe('SearchPanels component', () => {
         collectionMetadata: {
           hasAllMetadata: true,
           title: 'Collection Title',
-          isCsda: true,
+          isCSDA: true,
           isOpenSearch: false
         }
       }, '/search/granules')

--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.js
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.js
@@ -60,7 +60,7 @@ export class SpatialSelectionDropdown extends PureComponent {
           id="spatial-selection-dropdown"
           className="spatial-selection-dropdown__button search-form__button search-form__button--dark"
         >
-          <EDSCIcon icon={FaCrop} size="0.825rem" />
+          <EDSCIcon className="spatial-selection-dropdown__icon" icon={FaCrop} size="0.825rem" />
         </Dropdown.Toggle>
         <Dropdown.Menu className="spatial-selection-dropdown__menu">
           <Dropdown.Item

--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.scss
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.scss
@@ -30,9 +30,8 @@
   }
 
   &__icon {
-    margin-right: .35rem;
-    width: 1rem;
-    text-align: center;
+    position: relative;
+    top: 0.0625rem;
   }
 
   &__small {

--- a/static/src/js/components/TemporalDisplay/TemporalDisplay.js
+++ b/static/src/js/components/TemporalDisplay/TemporalDisplay.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
-import { FaCalendar } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
 
 import TemporalDisplayEntry from './TemporalDisplayEntry'
 import FilterStackItem from '../FilterStack/FilterStackItem'
@@ -83,7 +83,7 @@ class TemporalDisplay extends PureComponent {
 
     return (
       <FilterStackItem
-        icon={FaCalendar}
+        icon={FaCalendarAlt}
         title="Temporal"
         onRemove={this.onTimelineRemove}
       >

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownToggle.js
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownToggle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { FaCalendar } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
 
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
@@ -12,7 +12,7 @@ const TemporalSelectionDropdownToggle = ({ onToggleClick }) => (
     className="temporal-selection-dropdown__button earch-form__button search-form__button--dark"
     onClick={onToggleClick}
   >
-    <EDSCIcon icon={FaCalendar} size="0.825rem" />
+    <EDSCIcon icon={FaCalendarAlt} size="0.825rem" />
   </Dropdown.Toggle>
 )
 

--- a/static/src/js/reducers/collectionMetadata.js
+++ b/static/src/js/reducers/collectionMetadata.js
@@ -21,7 +21,11 @@ const processResults = (results) => {
     const { id } = result
 
     byId[id] = {
-      ...camelCaseKeys(result),
+      ...camelCaseKeys(result, {
+        exclude: [
+          'isCSDA'
+        ]
+      }),
       conceptId: id
     }
   })

--- a/static/src/js/util/__tests__/isCSDACollection.test.js
+++ b/static/src/js/util/__tests__/isCSDACollection.test.js
@@ -1,0 +1,35 @@
+import { isCSDACollection } from '../isCSDACollection'
+
+describe('isCSDACollection', () => {
+  describe('when no dataCenters array is provided', () => {
+    test('returns false', () => {
+      expect(isCSDACollection(undefined)).toEqual(false)
+    })
+  })
+
+  describe('when provided an empty array', () => {
+    test('returns false', () => {
+      expect(isCSDACollection([])).toEqual(false)
+    })
+  })
+
+  describe('when provided an array with no matching data center', () => {
+    test('returns false', () => {
+      expect(isCSDACollection([
+        {
+          shortName: 'Some Short Name'
+        }
+      ])).toEqual(false)
+    })
+  })
+
+  describe('when provided an array with a matching data center', () => {
+    test('returns true', () => {
+      expect(isCSDACollection([
+        {
+          shortName: 'NASA/CSDA'
+        }
+      ])).toEqual(true)
+    })
+  })
+})

--- a/static/src/js/util/isCSDACollection.js
+++ b/static/src/js/util/isCSDACollection.js
@@ -1,0 +1,13 @@
+import { isArray } from 'lodash'
+
+/**
+ * Returns true if passed a matching data center/organization
+ * @param {Array} dataCenters - The data centers from the collection metadata
+ * @return {Boolean}
+ */
+export const isCSDACollection = dataCenters => !!(
+  isArray(dataCenters)
+  && dataCenters.some(({ shortName = '' }) => shortName === 'NASA/CSDA')
+)
+
+export default isCSDACollection


### PR DESCRIPTION
# Overview

### What is the feature?

Adds messaging to the granule results page for CSDA collections

### What is the Solution?

Added a badge and message to the top of the panel

### What areas of the application does this impact?

Granule results page

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:** C1240538039-CSDA

1. Log in to a EDL account with CSDA enabled
2. View the granules page
3. Confirm tag and message are displayed

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
