### PR TITLE
EDSC-3184: Use the cloud_hosted parameter for the cloud feature facet

### DIFF
--- a/cypress/integration/paths/search/search_spec.js
+++ b/cypress/integration/paths/search/search_spec.js
@@ -446,7 +446,7 @@ describe('Path /search', () => {
           url: '**/search/collections.json'
         },
         (req) => {
-          expect(req.body).to.eq('has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.extra.%2A%2Copensearch.granule.osdd&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Bspatial%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&page_num=1&page_size=20&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&tag_key%5B%5D=gov.nasa.earthdatacloud.s3')
+          expect(req.body).to.eq('cloud_hosted=true&has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.extra.%2A%2Copensearch.granule.osdd&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Bspatial%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&page_num=1&page_size=20&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score')
 
           req.reply({
             body: awsCloudBody,

--- a/serverless/src/collectionSearch/handler.js
+++ b/serverless/src/collectionSearch/handler.js
@@ -27,6 +27,7 @@ const collectionSearch = async (event) => {
   const permittedCmrKeys = [
     'bounding_box',
     'circle',
+    'cloud_hosted',
     'collection_data_type',
     'concept_id',
     'data_center_h',

--- a/static.config.json
+++ b/static.config.json
@@ -19,7 +19,6 @@
     },
     "orderStatusRefreshTime": 60000,
     "eosdisTagKey": "gov.nasa.eosdis",
-    "availableFromAwsCloudTagKey": "gov.nasa.earthdatacloud.s3",
     "defaultCmrPageSize": 20,
     "maxCmrPageSize": 2000,
     "defaultCmrSearchTags": [

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -75,10 +75,8 @@ export const prepareCollectionParams = (state) => {
     serviceType.push('harmony')
   }
   if (featureFacets.mapImagery) tagKey.push(tagName('gibs'))
-  if (featureFacets.availableFromAwsCloud) {
-    const { availableFromAwsCloudTagKey } = getApplicationConfig()
-    tagKey.push(availableFromAwsCloudTagKey)
-  }
+  let cloudHosted
+  if (featureFacets.availableFromAwsCloud) cloudHosted = true
 
   const { query: portalQuery = {} } = portal
 
@@ -86,6 +84,7 @@ export const prepareCollectionParams = (state) => {
     authToken,
     boundingBox,
     circle,
+    cloudHosted,
     cmrFacets,
     featureFacets,
     hasGranulesOrCwic,
@@ -135,6 +134,7 @@ export const buildCollectionSearchParams = (params) => {
   const {
     boundingBox,
     circle,
+    cloudHosted,
     cmrFacets,
     conceptId,
     dataCenter,
@@ -196,6 +196,7 @@ export const buildCollectionSearchParams = (params) => {
     ...defaultParams,
     boundingBox,
     circle,
+    cloudHosted,
     collectionDataType: featureFacets.nearRealTime ? ['NEAR_REAL_TIME'] : undefined,
     concept_id: conceptId,
     dataCenterH: facetsToSend.data_center_h,

--- a/static/src/js/util/request/__tests__/collectionRequest.test.js
+++ b/static/src/js/util/request/__tests__/collectionRequest.test.js
@@ -36,6 +36,7 @@ describe('CollectionRequest#permittedCmrKeys', () => {
       'params',
       'bounding_box',
       'circle',
+      'cloud_hosted',
       'collection_data_type',
       'concept_id',
       'data_center_h',

--- a/static/src/js/util/request/collectionRequest.js
+++ b/static/src/js/util/request/collectionRequest.js
@@ -32,6 +32,7 @@ export default class CollectionRequest extends CmrRequest {
       'params',
       'bounding_box',
       'circle',
+      'cloud_hosted',
       'collection_data_type',
       'concept_id',
       'data_center_h',


### PR DESCRIPTION
# Overview

### What is the feature?

Use the new `cloud_hosted` CMR parameter to retrieve collections for the feature facet `Available from AWS Cloud` instead of using the tag

### What areas of the application does this impact?

Collection search

# Testing

Select the `Available from AWS Cloud` feature facet. Ensure collections are returned successfully. Inspect the network request to ensure `cloud_hosted` parameter is used and not `tag_key`
