### PR TITLE
EDSC-3142: Displaying CSDA information on the project edit options panel

### DIFF
--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -153,6 +153,9 @@ class App extends Component {
                       <AboutCSDAModalContainer />
                       <AboutCwicModalContainer />
                     </Route>
+                    <Route path={this.portalPaths('/projects')}>
+                      <AboutCSDAModalContainer />
+                    </Route>
                   </Switch>
                 </UrlQueryContainer>
               </AuthTokenContainer>

--- a/static/src/js/components/ProjectPanels/ProjectPanels.js
+++ b/static/src/js/components/ProjectPanels/ProjectPanels.js
@@ -5,8 +5,10 @@ import {
   FaCheckCircle,
   FaCog,
   FaExclamationCircle,
-  FaMap
+  FaMap,
+  FaQuestionCircle
 } from 'react-icons/fa'
+import { Col } from 'react-bootstrap'
 
 import Button from '../Button/Button'
 import Panels from '../Panels/Panels'
@@ -49,6 +51,7 @@ import './ProjectPanels.scss'
  * @param {Function} onAddGranuleToProjectCollection - Callback to add a granule to the project.
  * @param {Function} onRemoveGranuleFromProjectCollection - Callback to remove a granule from the project.
  * @param {Function} onTogglePanels - Toggles the panels opened or closed.
+ * @param {Function} onToggleAboutCSDAModal - Toggles the CSDA modal.
  * @param {Function} onSetActivePanel - Switches the currently active panel.
  */
 class ProjectPanels extends PureComponent {
@@ -275,6 +278,7 @@ class ProjectPanels extends PureComponent {
       onRemoveGranuleFromProjectCollection,
       onSelectAccessMethod,
       onSetActivePanel,
+      onToggleAboutCSDAModal,
       onTogglePanels,
       onUpdateAccessMethod,
       panels,
@@ -327,7 +331,8 @@ class ProjectPanels extends PureComponent {
       const { [collectionId]: collectionMetadata = {} } = projectCollectionsMetadata
 
       const {
-        title
+        title,
+        isCSDA: collectionIsCSDA
       } = collectionMetadata
 
       const { [collectionId]: collectionDataQualitySummaries = [] } = dataQualitySummaries
@@ -435,6 +440,30 @@ class ProjectPanels extends PureComponent {
         <PanelGroup
           key={`${collectionId}_edit-options`}
           primaryHeading="Edit Options"
+          headerMessage={(
+            <>
+              {
+                collectionIsCSDA && (
+                  <Col className="search-panels__note">
+                    {'This collection is made available through the '}
+                    <span className="search-panels__note-emph search-panels__note-emph--csda">NASA Commercial Smallsat Data Acquisition (CSDA) Program</span>
+                    {' for NASA funded researchers. Access to the data will require additional authentication. '}
+                    <Button
+                      className="search-panels__header-message-link"
+                      dataTestId="search-panels__csda-modal-button"
+                      onClick={() => onToggleAboutCSDAModal(true)}
+                      variant="link"
+                      bootstrapVariant="link"
+                      icon={FaQuestionCircle}
+                      label="More details"
+                    >
+                      More Details
+                    </Button>
+                  </Col>
+                )
+              }
+            </>
+          )}
           breadcrumbs={[
             {
               title,
@@ -505,6 +534,30 @@ class ProjectPanels extends PureComponent {
           ]}
           primaryHeading={title}
           headerMetaPrimaryText={projectGranulesHeaderMetaPrimaryText}
+          headerMessage={(
+            <>
+              {
+                collectionIsCSDA && (
+                  <Col className="search-panels__note">
+                    {'This collection is made available through the '}
+                    <span className="search-panels__note-emph search-panels__note-emph--csda">NASA Commercial Smallsat Data Acquisition (CSDA) Program</span>
+                    {' for NASA funded researchers. Access to the data will require additional authentication. '}
+                    <Button
+                      className="search-panels__header-message-link"
+                      dataTestId="search-panels__csda-modal-button"
+                      onClick={() => onToggleAboutCSDAModal(true)}
+                      variant="link"
+                      bootstrapVariant="link"
+                      icon={FaQuestionCircle}
+                      label="More details"
+                    >
+                      More Details
+                    </Button>
+                  </Col>
+                )
+              }
+            </>
+          )}
         >
           <PanelItem scrollable={false}>
             <CollectionDetails
@@ -562,6 +615,7 @@ ProjectPanels.propTypes = {
   onSelectAccessMethod: PropTypes.func.isRequired,
   onSetActivePanel: PropTypes.func.isRequired,
   onSetActivePanelGroup: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired,
   onTogglePanels: PropTypes.func.isRequired,
   onUpdateAccessMethod: PropTypes.func.isRequired,
   onUpdateFocusedCollection: PropTypes.func.isRequired,

--- a/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
@@ -3,6 +3,8 @@ import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import ProjectPanels from '../ProjectPanels'
+import PanelGroup from '../../Panels/PanelGroup'
+import PanelSection from '../../Panels/PanelSection'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -85,6 +87,7 @@ function setup(overrideProps) {
     overrideTemporal: {},
     onChangePath: jest.fn(),
     onSelectAccessMethod: jest.fn(),
+    onToggleAboutCSDAModal: jest.fn(),
     onTogglePanels: jest.fn(),
     onSetActivePanel: jest.fn(),
     onUpdateAccessMethod: jest.fn(),
@@ -448,6 +451,52 @@ describe('ProjectPanels component', () => {
           rawModel: undefined
         }
       }
+    })
+  })
+
+  describe('when on the access method panel', () => {
+    describe('when viewing a CSDA collection', () => {
+      test('shows a message and opens a modal for more information about the CSDA program', () => {
+        const { enzymeWrapper, props } = setup({
+          projectCollectionsMetadata: {
+            collectionId: {
+              isCSDA: true
+            }
+          }
+        })
+
+        const accessMethodPanelGroup = enzymeWrapper.find(PanelSection).at(1).find(PanelGroup).at(0)
+        const moreInfoButton = accessMethodPanelGroup.props()
+          .headerMessage.props.children.props.children[3]
+
+        moreInfoButton.props.onClick()
+
+        expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
+      })
+    })
+  })
+
+  describe('when on the collection panel', () => {
+    describe('when viewing a CSDA collection', () => {
+      test('shows a message and opens a modal for more information about the CSDA program', () => {
+        const { enzymeWrapper, props } = setup({
+          projectCollectionsMetadata: {
+            collectionId: {
+              isCSDA: true
+            }
+          }
+        })
+
+        const infoPanelGroup = enzymeWrapper.find(PanelSection).at(1).find(PanelGroup).at(0)
+        const moreInfoButton = infoPanelGroup.props()
+          .headerMessage.props.children.props.children[3]
+
+        moreInfoButton.props.onClick()
+
+        expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
+        expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
+      })
     })
   })
 })

--- a/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
+++ b/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
@@ -28,34 +28,61 @@ export const mapStateToProps = state => ({
 })
 
 export const mapDispatchToProps = dispatch => ({
+  onAddGranuleToProjectCollection:
+    data => dispatch(actions.addGranuleToProjectCollection(data)),
   onChangePath:
     path => dispatch(actions.changePath(path)),
+  onChangeProjectGranulePageNum:
+      data => dispatch(actions.changeProjectGranulePageNum(data)),
+  onFetchDataQualitySummaries:
+    conceptId => dispatch(actions.fetchDataQualitySummaries(conceptId)),
+  onFocusedGranuleChange:
+    granuleId => dispatch(actions.changeFocusedGranule(granuleId)),
+  onRemoveGranuleFromProjectCollection:
+    data => dispatch(actions.removeGranuleFromProjectCollection(data)),
   onSelectAccessMethod:
     method => dispatch(actions.selectAccessMethod(method)),
-  onTogglePanels:
-    value => dispatch(actions.togglePanels(value)),
   onSetActivePanel:
     panelId => dispatch(actions.setActivePanel(panelId)),
   onSetActivePanelGroup:
     panelId => dispatch(actions.setActivePanelGroup(panelId)),
+  onToggleAboutCSDAModal:
+    state => dispatch(actions.toggleAboutCSDAModal(state)),
+  onTogglePanels:
+    value => dispatch(actions.togglePanels(value)),
   onUpdateAccessMethod:
     data => dispatch(actions.updateAccessMethod(data)),
-  onFetchDataQualitySummaries:
-    conceptId => dispatch(actions.fetchDataQualitySummaries(conceptId)),
-  onAddGranuleToProjectCollection:
-    data => dispatch(actions.addGranuleToProjectCollection(data)),
-  onRemoveGranuleFromProjectCollection:
-    data => dispatch(actions.removeGranuleFromProjectCollection(data)),
   onUpdateFocusedCollection:
     collectionId => dispatch(actions.updateFocusedCollection(collectionId)),
-  onFocusedGranuleChange:
-    granuleId => dispatch(actions.changeFocusedGranule(granuleId)),
-  onChangeProjectGranulePageNum:
-    data => dispatch(actions.changeProjectGranulePageNum(data)),
   onViewCollectionGranules:
     collectionId => dispatch(actions.viewCollectionGranules(collectionId))
 })
 
+/**
+ * Renders ProjectPanelsContainer.
+ * @param {Object} dataQualitySummaries = The dataQualitySummaries from the store.
+ * @param {String} focusedCollectionId - The focused collection ID.
+ * @param {String} focusedGranuleId - The focused granule ID.
+ * @param {Object} collection - The current collection.
+ * @param {String} collectionId - The current collection ID.
+ * @param {Object} location - The location from the store.
+ * @param {Object} panels - The current panels state.
+ * @param {Object} portal - The portal from the store.
+ * @param {Object} project - The project from the store.
+ * @param {Object} spatial - The spatial from the store.
+ * @param {Object} shapefileId - The shapefileId from the store.
+ * @param {Object} projectCollection - The project collection.
+ * @param {Function} onSetActivePanelGroup - Callback to set the page number.
+ * @param {Function} onFocusedGranuleChange - Callback to change the focused granule.
+ * @param {Function} onSetActivePanelGroup - Callback to set the active panel group.
+ * @param {Function} onUpdateAccessMethod - Callback to update the access method.
+ * @param {Function} onUpdateFocusedCollection - Callback to update the focused collection.
+ * @param {Function} onAddGranuleToProjectCollection - Callback to add a granule to the project.
+ * @param {Function} onRemoveGranuleFromProjectCollection - Callback to remove a granule from the project.
+ * @param {Function} onTogglePanels - Toggles the panels opened or closed.
+ * @param {Function} onToggleAboutCSDAModal - Toggles the CSDA modal.
+ * @param {Function} onSetActivePanel - Switches the currently active panel.
+ */
 export const ProjectPanelsContainer = ({
   dataQualitySummaries,
   focusedCollectionId,
@@ -70,6 +97,7 @@ export const ProjectPanelsContainer = ({
   onSelectAccessMethod,
   onSetActivePanel,
   onSetActivePanelGroup,
+  onToggleAboutCSDAModal,
   onTogglePanels,
   onUpdateAccessMethod,
   onUpdateFocusedCollection,
@@ -97,6 +125,7 @@ export const ProjectPanelsContainer = ({
     onSelectAccessMethod={onSelectAccessMethod}
     onSetActivePanel={onSetActivePanel}
     onSetActivePanelGroup={onSetActivePanelGroup}
+    onToggleAboutCSDAModal={onToggleAboutCSDAModal}
     onTogglePanels={onTogglePanels}
     onUpdateAccessMethod={onUpdateAccessMethod}
     onUpdateFocusedCollection={onUpdateFocusedCollection}
@@ -132,6 +161,7 @@ ProjectPanelsContainer.propTypes = {
   onSelectAccessMethod: PropTypes.func.isRequired,
   onSetActivePanel: PropTypes.func.isRequired,
   onSetActivePanelGroup: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired,
   onTogglePanels: PropTypes.func.isRequired,
   onUpdateAccessMethod: PropTypes.func.isRequired,
   onUpdateFocusedCollection: PropTypes.func.isRequired,

--- a/static/src/js/containers/ProjectPanelsContainer/__tests__/ProjectPanelsContainer.test.js
+++ b/static/src/js/containers/ProjectPanelsContainer/__tests__/ProjectPanelsContainer.test.js
@@ -19,6 +19,7 @@ function setup() {
     onSelectAccessMethod: jest.fn(),
     onSetActivePanel: jest.fn(),
     onTogglePanels: jest.fn(),
+    onToggleAboutCSDAModal: jest.fn(),
     onUpdateAccessMethod: jest.fn(),
     onChangeProjectGranulePageNum: jest.fn(),
     onSetActivePanelGroup: jest.fn(),
@@ -185,6 +186,16 @@ describe('mapDispatchToProps', () => {
 
     expect(spy).toBeCalledTimes(1)
     expect(spy).toBeCalledWith('collectionId')
+  })
+
+  test('onToggleAboutCSDAModal calls actions.viewCollectionGranules', () => {
+    const dispatch = jest.fn()
+    const spy = jest.spyOn(actions, 'toggleAboutCSDAModal')
+
+    mapDispatchToProps(dispatch).onToggleAboutCSDAModal(true)
+
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith(true)
   })
 })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Inform users about CSDA authentication on the project page

### What is the Solution?

Display information about CSDA authentication the the edit options panel

### What areas of the application does this impact?

Project page edit options panel

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:**

1. Visit `/projects?p=C1240538039-CSDA!C1240538039-CSDA&pg[1][v]=t&pg[1][gsk]=-start_date&q=CSDA&ac=true&tl=1623265263!3!!&m=-0.0703125!0.0703125!2!1!0!0%2C2`
2. Verify CSDA information is displayed on the edit options and granules panels
3. Confirm more details link opens CSDA modal

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
