### PR TITLE
EDSC-3174: Fixing space below granule items with browse imagery

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsItem.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.scss
@@ -118,6 +118,8 @@
     .more-actions-dropdown__toggle {
       padding: 0 0.325rem;
       height: 1.5rem;
+      display: flex;
+      align-items: center;
     }
 
     i {

--- a/static/src/js/components/GranuleResults/GranuleResultsItem.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.scss
@@ -113,6 +113,7 @@
   &__more-actions-dropdown {
     padding: $spacer/2;
     padding-left: 0;
+    align-items: flex-start;
 
     .more-actions-dropdown__toggle {
       padding: 0 0.325rem;
@@ -131,11 +132,12 @@
     justify-content: center;
     align-self: flex-end;
     padding: 0.25rem;
-    height: 5.2rem;
-    width: 5.2rem;
+    height: 5rem;
+    width: 5rem;
     background-color: #1a1a1a;
     overflow: hidden;
     font-size: 0.5rem;
+    border-bottom-left-radius: 0.25rem;
 
     .panels--sm & {
       display: flex;


### PR DESCRIPTION
# Overview

### What is the feature?

Fixing space below granule items with browse imagery

### What is the Solution?

Tweaked some css

### What areas of the application does this impact?

Granule results list

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:** C1233200839-LPCLOUDUAT

1. Confirm no space below the start and end times on a granule item

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
