### PR TITLE
EDSC-3152: Retrieve the OpenSearch OSDD from the collection metadata

### DIFF
--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -270,12 +270,12 @@ describe('getSearchGranules', () => {
       metadata: {
         collections: {
           collectionId: {
-            hasGranules: false,
-            tags: {
-              'opensearch.granule.osdd': {
-                data: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
-              }
-            }
+            links: [{
+              length: '0.0KB',
+              rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+              hreflang: 'en-US',
+              href: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
+            }]
           }
         }
       },
@@ -375,12 +375,12 @@ describe('getSearchGranules', () => {
       metadata: {
         collections: {
           collectionId: {
-            hasGranules: false,
-            tags: {
-              'opensearch.granule.osdd': {
-                data: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
-              }
-            }
+            links: [{
+              length: '0.0KB',
+              rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+              hreflang: 'en-US',
+              href: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
+            }]
           }
         }
       },
@@ -745,12 +745,12 @@ describe('getProjectGranules', () => {
       metadata: {
         collections: {
           'C10000000000-EDSC': {
-            hasGranules: false,
-            tags: {
-              'opensearch.granule.osdd': {
-                data: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
-              }
-            }
+            links: [{
+              length: '0.0KB',
+              rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+              hreflang: 'en-US',
+              href: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
+            }]
           }
         }
       },

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -13,7 +13,6 @@ import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
 import { getFocusedCollectionId } from '../selectors/focusedCollection'
 import { getFocusedCollectionMetadata } from '../selectors/collectionMetadata'
 import { getUsername } from '../selectors/user'
-import { hasTag } from '../../../../sharedUtils/tags'
 import { parseGraphQLError } from '../../../../sharedUtils/parseGraphQLError'
 import { portalPathFromState } from '../../../../sharedUtils/portalPath'
 import { isCSDACollection } from '../util/isCSDACollection'
@@ -195,7 +194,6 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           dataCenters,
           granules,
           hasGranules,
-          links,
           nativeDataFormats,
           services,
           shortName,
@@ -214,10 +212,6 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           earthdataEnvironment
         )
 
-        // Check for an OpenSearch link, but fallback to the tag data
-        const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
-        const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
-
         payload.push({
           abstract,
           archiveAndDistributionInformation,
@@ -230,7 +224,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           hasGranules,
           id: conceptId,
           isCSDA: isCSDACollection(dataCenters),
-          isOpenSearch,
+          isOpenSearch: !!getOpenSearchOsddLink(collection),
           nativeDataFormats,
           services,
           shortName,

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -17,6 +17,7 @@ import { hasTag } from '../../../../sharedUtils/tags'
 import { parseGraphQLError } from '../../../../sharedUtils/parseGraphQLError'
 import { portalPathFromState } from '../../../../sharedUtils/portalPath'
 import { isCSDACollection } from '../util/isCSDACollection'
+import { getOpenSearchOsddLink } from '../util/getOpenSearchLink'
 
 import GraphQlRequest from '../util/request/graphQlRequest'
 
@@ -194,6 +195,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           dataCenters,
           granules,
           hasGranules,
+          links,
           nativeDataFormats,
           services,
           shortName,
@@ -212,6 +214,10 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           earthdataEnvironment
         )
 
+        // Check for an OpenSearch link, but fallback to the tag data
+        const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
+        const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
+
         payload.push({
           abstract,
           archiveAndDistributionInformation,
@@ -224,7 +230,7 @@ export const getFocusedCollection = () => async (dispatch, getState) => {
           hasGranules,
           id: conceptId,
           isCSDA: isCSDACollection(dataCenters),
-          isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
+          isOpenSearch,
           nativeDataFormats,
           services,
           shortName,

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -33,6 +33,7 @@ import { getUsername } from '../selectors/user'
 import { hasTag } from '../../../../sharedUtils/tags'
 import { isProjectCollectionValid } from '../util/isProjectCollectionValid'
 import { isCSDACollection } from '../util/isCSDACollection'
+import { getOpenSearchOsddLink } from '../util/getOpenSearchLink'
 
 import GraphQlRequest from '../util/request/graphQlRequest'
 
@@ -295,6 +296,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           dataCenters,
           granules,
           hasGranules,
+          links,
           services,
           shortName,
           subscriptions,
@@ -311,6 +313,10 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           earthdataEnvironment
         )
 
+        // Check for an OpenSearch link, but fallback to the tag data
+        const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
+        const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
+
         payload.push({
           abstract,
           archiveAndDistributionInformation,
@@ -323,7 +329,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           hasGranules,
           id: conceptId,
           isCSDA: isCSDACollection(dataCenters),
-          isOpenSearch: hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', ''),
+          isOpenSearch,
           services,
           shortName,
           subscriptions,

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -30,7 +30,6 @@ import { getApplicationConfig } from '../../../../sharedUtils/config'
 import { getCollectionsMetadata } from '../selectors/collectionMetadata'
 import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
 import { getUsername } from '../selectors/user'
-import { hasTag } from '../../../../sharedUtils/tags'
 import { isProjectCollectionValid } from '../util/isProjectCollectionValid'
 import { isCSDACollection } from '../util/isCSDACollection'
 import { getOpenSearchOsddLink } from '../util/getOpenSearchLink'
@@ -296,7 +295,6 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           dataCenters,
           granules,
           hasGranules,
-          links,
           services,
           shortName,
           subscriptions,
@@ -313,10 +311,6 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           earthdataEnvironment
         )
 
-        // Check for an OpenSearch link, but fallback to the tag data
-        const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
-        const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
-
         payload.push({
           abstract,
           archiveAndDistributionInformation,
@@ -329,7 +323,7 @@ export const getProjectCollections = () => async (dispatch, getState) => {
           hasGranules,
           id: conceptId,
           isCSDA: isCSDACollection(dataCenters),
-          isOpenSearch,
+          isOpenSearch: !!getOpenSearchOsddLink(metadata),
           services,
           shortName,
           subscriptions,

--- a/static/src/js/util/__tests__/getOpenSearchOsddLink.test.js
+++ b/static/src/js/util/__tests__/getOpenSearchOsddLink.test.js
@@ -1,11 +1,11 @@
 const { getOpenSearchOsddLink } = require('../getOpenSearchLink')
 
 describe('getOpenSearchOsddLink', () => {
-  test('returns false if no links exist', () => {
-    expect(getOpenSearchOsddLink()).toBeFalsy()
+  test('returns undefined if no links exist', () => {
+    expect(getOpenSearchOsddLink({})).toBe(undefined)
   })
 
-  test('returns false if no link exists', () => {
+  test('returns undefined if no link exists', () => {
     const links = [
       {
         length: '0.0KB',
@@ -27,10 +27,10 @@ describe('getOpenSearchOsddLink', () => {
       }
     ]
 
-    expect(getOpenSearchOsddLink(links)).toBeFalsy()
+    expect(getOpenSearchOsddLink(links)).toBe(undefined)
   })
 
-  test('returns the OSDD link', () => {
+  test('returns the OSDD link from the links', () => {
     const links = [
       {
         length: '0.0KB',
@@ -58,6 +58,16 @@ describe('getOpenSearchOsddLink', () => {
       }
     ]
 
-    expect(getOpenSearchOsddLink(links)).toEqual('https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products')
+    expect(getOpenSearchOsddLink({ links })).toEqual('https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products')
+  })
+
+  test('returns the OSDD link from the tags', () => {
+    const tags = {
+      'opensearch.granule.osdd': {
+        data: 'https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products'
+      }
+    }
+
+    expect(getOpenSearchOsddLink({ tags })).toEqual('https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products')
   })
 })

--- a/static/src/js/util/__tests__/getOpenSearchOsddLink.test.js
+++ b/static/src/js/util/__tests__/getOpenSearchOsddLink.test.js
@@ -1,0 +1,63 @@
+const { getOpenSearchOsddLink } = require('../getOpenSearchLink')
+
+describe('getOpenSearchOsddLink', () => {
+  test('returns false if no links exist', () => {
+    expect(getOpenSearchOsddLink()).toBeFalsy()
+  })
+
+  test('returns false if no link exists', () => {
+    const links = [
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://esatellus.service-now.com/csp?id=esa_simple_request'
+      },
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://eoportal.org/web/eoportal/fedeo?parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products'
+      },
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://fedeo.esa.int/opensearch/request/?httpAccept=application/vnd.iso.19139-2%2Bxml&parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products&recordSchema=iso19139-2'
+      }
+    ]
+
+    expect(getOpenSearchOsddLink(links)).toBeFalsy()
+  })
+
+  test('returns the OSDD link', () => {
+    const links = [
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://esatellus.service-now.com/csp?id=esa_simple_request'
+      },
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+        hreflang: 'en-US',
+        href: 'https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products'
+      },
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://eoportal.org/web/eoportal/fedeo?parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products'
+      },
+      {
+        length: '0.0KB',
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        hreflang: 'en-US',
+        href: 'https://fedeo.esa.int/opensearch/request/?httpAccept=application/vnd.iso.19139-2%2Bxml&parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products&recordSchema=iso19139-2'
+      }
+    ]
+
+    expect(getOpenSearchOsddLink(links)).toEqual('https://fedeo.esa.int/opensearch/description.xml?parentIdentifier=EOP:ESA:EARTH-ONLINE:CryoSat.products')
+  })
+})

--- a/static/src/js/util/getOpenSearchLink.js
+++ b/static/src/js/util/getOpenSearchLink.js
@@ -1,0 +1,20 @@
+/**
+ * Returns the OpenSearch OSDD link if one exists
+ * @param {Array} links Metadata links
+ * @returns {String} OpenSearch OSDD Link
+ */
+export const getOpenSearchOsddLink = (links = []) => {
+  let value = false
+
+  links.forEach((link) => {
+    const {
+      href, rel = ''
+    } = link
+
+    if (rel.indexOf('/search#') !== -1) {
+      value = href
+    }
+  })
+
+  return value
+}

--- a/static/src/js/util/getOpenSearchLink.js
+++ b/static/src/js/util/getOpenSearchLink.js
@@ -1,11 +1,20 @@
+import { getValueForTag } from '../../../../sharedUtils/tags'
+
 /**
  * Returns the OpenSearch OSDD link if one exists
- * @param {Array} links Metadata links
+ * @param {Object} metadata Collection metadata
  * @returns {String} OpenSearch OSDD Link
  */
-export const getOpenSearchOsddLink = (links = []) => {
-  let value = false
+export const getOpenSearchOsddLink = (metadata) => {
+  const {
+    hasGranules,
+    links = [],
+    tags
+  } = metadata
 
+  let value
+
+  // Check for an OpenSearch link
   links.forEach((link) => {
     const {
       href, rel = ''
@@ -15,6 +24,11 @@ export const getOpenSearchOsddLink = (links = []) => {
       value = href
     }
   })
+
+  // Fallback to the tag data if a link doesn't exist
+  if (!value && !hasGranules) {
+    value = getValueForTag('', tags, 'opensearch.granule.osdd')
+  }
 
   return value
 }

--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -2,7 +2,6 @@ import { convertSize } from './project'
 import { encodeGridCoords } from './url/gridEncoders'
 import { encodeTemporal } from './url/temporalEncoders'
 import { getEarthdataConfig, getApplicationConfig } from '../../../../sharedUtils/config'
-import { getValueForTag, hasTag } from '../../../../sharedUtils/tags'
 import { withAdvancedSearch } from './withAdvancedSearch'
 import { getOpenSearchOsddLink } from './getOpenSearchLink'
 
@@ -166,13 +165,6 @@ export const extractProjectCollectionGranuleParams = (state, collectionId) => {
  * @returns {Object} Parameters used in Granules request
  */
 export const prepareGranuleParams = (collectionMetadata, granuleParams) => {
-  // Metadata to help determine if and how to make our granule request
-  const {
-    hasGranules,
-    links,
-    tags
-  } = collectionMetadata
-
   // Default added and removed granuld ids because they will only be provided for project granule requests
   const {
     addedGranuleIds = [],
@@ -247,15 +239,7 @@ export const prepareGranuleParams = (collectionMetadata, granuleParams) => {
     temporalString = encodeTemporal(temporal)
   }
 
-  // Check for an OpenSearch link, but fallback to the tag data
-  const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
-  const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
-
-  let openSearchOsdd
-  if (isOpenSearch) {
-    // Use an OpenSearch link if it exists, but fallback to the tag data
-    openSearchOsdd = getOpenSearchOsddLink(links) || getValueForTag('', tags, 'opensearch.granule.osdd')
-  }
+  const isOpenSearch = !!getOpenSearchOsddLink(collectionMetadata)
 
   const options = {}
   if (readableGranuleName) {
@@ -279,7 +263,7 @@ export const prepareGranuleParams = (collectionMetadata, granuleParams) => {
     isOpenSearch,
     line,
     onlineOnly,
-    openSearchOsdd,
+    openSearchOsdd: getOpenSearchOsddLink(collectionMetadata),
     options,
     orbitNumber,
     pageNum,

--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -4,6 +4,7 @@ import { encodeTemporal } from './url/temporalEncoders'
 import { getEarthdataConfig, getApplicationConfig } from '../../../../sharedUtils/config'
 import { getValueForTag, hasTag } from '../../../../sharedUtils/tags'
 import { withAdvancedSearch } from './withAdvancedSearch'
+import { getOpenSearchOsddLink } from './getOpenSearchLink'
 
 /**
  * Populate granule payload used to update the store
@@ -168,6 +169,7 @@ export const prepareGranuleParams = (collectionMetadata, granuleParams) => {
   // Metadata to help determine if and how to make our granule request
   const {
     hasGranules,
+    links,
     tags
   } = collectionMetadata
 
@@ -245,11 +247,14 @@ export const prepareGranuleParams = (collectionMetadata, granuleParams) => {
     temporalString = encodeTemporal(temporal)
   }
 
-  const isOpenSearch = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
+  // Check for an OpenSearch link, but fallback to the tag data
+  const hasOpenSearchTag = hasGranules === false && hasTag({ tags }, 'opensearch.granule.osdd', '')
+  const isOpenSearch = !!getOpenSearchOsddLink(links) || hasOpenSearchTag
 
   let openSearchOsdd
   if (isOpenSearch) {
-    openSearchOsdd = getValueForTag('', tags, 'opensearch.granule.osdd')
+    // Use an OpenSearch link if it exists, but fallback to the tag data
+    openSearchOsdd = getOpenSearchOsddLink(links) || getValueForTag('', tags, 'opensearch.granule.osdd')
   }
 
   const options = {}

--- a/static/src/js/util/request/__tests__/collectionRequest.test.js
+++ b/static/src/js/util/request/__tests__/collectionRequest.test.js
@@ -160,12 +160,12 @@ describe('CollectionRequest#transformResponse', () => {
         updated: '2019-05-21T01:08:02.143Z',
         entry: [{
           id: 'collectionId',
-          has_granules: false,
-          tags: {
-            'opensearch.granule.osdd': {
-              data: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
-            }
-          }
+          links: [{
+            length: '0.0KB',
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+            hreflang: 'en-US',
+            href: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
+          }]
         }]
       }
     }
@@ -177,13 +177,13 @@ describe('CollectionRequest#transformResponse', () => {
         ...data.feed,
         entry: [{
           id: 'collectionId',
-          has_granules: false,
           has_map_imagery: false,
-          tags: {
-            'opensearch.granule.osdd': {
-              data: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
-            }
-          },
+          links: [{
+            length: '0.0KB',
+            rel: 'http://esipfed.org/ns/fedsearch/1.1/search#',
+            hreflang: 'en-US',
+            href: 'https://cwic.wgiss.ceos.org/opensearch/datasets/C1597928934-NOAA_NCEI/osdd.xml?clientId=eed-edsc-dev'
+          }],
           isOpenSearch: true,
           thumbnail: 'test-file-stub'
         }]

--- a/static/src/js/util/request/collectionRequest.js
+++ b/static/src/js/util/request/collectionRequest.js
@@ -7,6 +7,7 @@ import {
 
 import { hasTag } from '../../../../../sharedUtils/tags'
 import { isCSDACollection } from '../isCSDACollection'
+import { getOpenSearchOsddLink } from '../getOpenSearchLink'
 
 import unavailableImg from '../../../assets/images/image-unavailable.svg'
 
@@ -142,9 +143,12 @@ export default class CollectionRequest extends CmrRequest {
     entry.map((collection) => {
       const transformedCollection = collection
 
-      if (collection && collection.tags) {
-        transformedCollection.isOpenSearch = Object.keys(collection.tags).includes('opensearch.granule.osdd')
+      if (collection && (collection.tags || collection.links)) {
+        // Check for an OpenSearch link, but fallback to the tag data
+        const hasOpenSearchTags = hasTag(collection, 'opensearch.granule.osdd', '')
           && collection.has_granules === false
+        transformedCollection.isOpenSearch = !!getOpenSearchOsddLink(collection.links) || hasOpenSearchTags
+
         transformedCollection.has_map_imagery = hasTag(collection, 'gibs')
       }
 

--- a/static/src/js/util/request/collectionRequest.js
+++ b/static/src/js/util/request/collectionRequest.js
@@ -144,10 +144,7 @@ export default class CollectionRequest extends CmrRequest {
       const transformedCollection = collection
 
       if (collection && (collection.tags || collection.links)) {
-        // Check for an OpenSearch link, but fallback to the tag data
-        const hasOpenSearchTags = hasTag(collection, 'opensearch.granule.osdd', '')
-          && collection.has_granules === false
-        transformedCollection.isOpenSearch = !!getOpenSearchOsddLink(collection.links) || hasOpenSearchTags
+        transformedCollection.isOpenSearch = !!getOpenSearchOsddLink(collection)
 
         transformedCollection.has_map_imagery = hasTag(collection, 'gibs')
       }


### PR DESCRIPTION
# Overview

### What is the feature?

Retrieve the OpenSearch OSDD from the collection metadata, if the OSDD doesn't exist in the links, check the tags for the link

### What areas of the application does this impact?

OpenSearch collections and granules