### PR TITLE
EDSC-3183: Removing box shadow on preferences form

### DIFF
--- a/static/src/js/components/Preferences/PreferencesForm.js
+++ b/static/src/js/components/Preferences/PreferencesForm.js
@@ -63,6 +63,7 @@ const PreferencesForm = (props) => {
   return (
     <div className="preferences-form">
       <Form
+        idPrefix="preferences-form"
         fields={fields}
         formData={formData}
         liveValidate


### PR DESCRIPTION
# Overview

### What is the feature?

Removes the unwanted box shadow on the preferences form.

### What is the Solution?

Adding a `idPrefix` prevents the duplicate `#root` declaration and removes the unwanted styles.

### What areas of the application does this impact?

Preferences form

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** N/A

1. Load preferences form

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
