### PR TITLE
EDSC-3204: Makes the granule links page size configurable during deployment

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -15,6 +15,7 @@ config="`jq '.application.env = $newValue' --arg newValue $bamboo_STAGE_NAME <<<
 config="`jq '.application.defaultPortal = $newValue' --arg newValue $bamboo_DEFAULT_PORTAL <<< $config`"
 config="`jq '.application.feedbackApp = $newValue' --arg newValue $bamboo_FEEDBACK_APP <<< $config`"
 config="`jq '.application.analytics.gtmPropertyId = $newValue' --arg newValue $bamboo_GTM_ID <<< $config`"
+config="`jq '.application.granuleLinksPageSize = $newValue' --arg newValue $bamboo_GRANULE_LINKS_PAGE_SIZE <<< $config`"
 config="`jq '.environment.production.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.environment.production.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -421,7 +421,7 @@
   cmrGranuleSearch:
     handler: serverless/src/cmrGranuleSearch/handler.default
     timeout: ${env:LAMBDA_TIMEOUT}
-    memorySize: 192
+    memorySize: 256
     events:
       - http:
           method: post

--- a/static.config.json
+++ b/static.config.json
@@ -21,6 +21,7 @@
     "eosdisTagKey": "gov.nasa.eosdis",
     "defaultCmrPageSize": 20,
     "maxCmrPageSize": 2000,
+    "granuleLinksPageSize": 250,
     "defaultCmrSearchTags": [
       "edsc.*",
       "opensearch.granule.osdd"

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1037,7 +1037,7 @@ describe('fetchLinks', () => {
         echo_collection_id: 'C10000005-EDSC',
         bounding_box: '23.607421875,5.381262277997806,27.7965087890625,14.973184553280502'
       },
-      granule_count: 888
+      granule_count: 388
     }
 
     await store.dispatch(fetchLinks(params))
@@ -1154,7 +1154,7 @@ describe('fetchLinks', () => {
           echo_collection_id: 'C10000005-EDSC',
           bounding_box: '23.607421875,5.381262277997806,27.7965087890625,14.973184553280502'
         },
-        granule_count: 888
+        granule_count: 388
       }
 
       await store.dispatch(fetchLinks(params))

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -54,6 +54,9 @@ import { getProjectCollectionsIds } from '../selectors/project'
 import { getFocusedCollectionId } from '../selectors/focusedCollection'
 import { eventEmitter } from '../events/events'
 import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
+import { getApplicationConfig } from '../../../../sharedUtils/config'
+
+const { granuleLinksPageSize } = getApplicationConfig()
 
 export const addMoreGranuleResults = payload => ({
   type: ADD_MORE_GRANULE_RESULTS,
@@ -162,7 +165,7 @@ export const fetchLinks = retrievalCollectionData => (dispatch, getState) => {
   } = retrievalCollectionData
 
   // The number of granules to request per page from CMR
-  const pageSize = 500
+  const pageSize = granuleLinksPageSize
 
   // Determine how many pages we will need to load to display all granules
   const totalPages = Math.ceil(granuleCount / pageSize)


### PR DESCRIPTION
# Overview

### What is the feature?

Some collections have granules that have many links more than other collections. Currently those collections are pushing the upper limited of lambda response sizes. This change will allow us to easily configure the page_size parameter for fetching granule links in order to accommodate those larger collections