### PR TITLE
EDSC-3201: Adds CSDA authentication to download script

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -68,8 +68,9 @@
       "cmrHost": "https://cmr.earthdata.nasa.gov",
       "echoRestRoot": "https://cmr.earthdata.nasa.gov/legacy-services/rest",
       "edlHost": "https://urs.earthdata.nasa.gov",
+      "csdaHost": "https://auth.csdap.uat.earthdatacloud.nasa.gov",
       "graphQlHost": "https://graphql.earthdata.nasa.gov",
-      "regionHost": "https://fts.podaac.earthdata.nasa.gov/",
+      "regionHost": "https://fts.podaac.earthdata.nasa.gov",
       "opensearchRoot": "https://cmr.earthdata.nasa.gov/opensearch",
       "redirectUriPath": "/urs_callback"
     },
@@ -77,8 +78,9 @@
       "cmrHost": "https://cmr.sit.earthdata.nasa.gov",
       "echoRestRoot": "https://cmr.sit.earthdata.nasa.gov/legacy-services/rest",
       "edlHost": "https://sit.urs.earthdata.nasa.gov",
+      "csdaHost": "https://auth.csdap.uat.earthdatacloud.nasa.gov",
       "graphQlHost": "https://graphql.sit.earthdata.nasa.gov",
-      "regionHost": "https://d2dwjhzkooeayk.cloudfront.net/",
+      "regionHost": "https://d2dwjhzkooeayk.cloudfront.net",
       "opensearchRoot": "https://cmr.sit.earthdata.nasa.gov/opensearch",
       "redirectUriPath": "/urs_callback"
     },
@@ -86,8 +88,9 @@
       "cmrHost": "https://cmr.uat.earthdata.nasa.gov",
       "echoRestRoot": "https://cmr.uat.earthdata.nasa.gov/legacy-services/rest",
       "edlHost": "https://uat.urs.earthdata.nasa.gov",
+      "csdaHost": "https://auth.csdap.uat.earthdatacloud.nasa.gov",
       "graphQlHost": "https://graphql.uat.earthdata.nasa.gov",
-      "regionHost": "https://fts.podaac.uat.earthdata.nasa.gov/",
+      "regionHost": "https://fts.podaac.uat.earthdata.nasa.gov",
       "opensearchRoot": "https://cmr.uat.earthdata.nasa.gov/opensearch",
       "redirectUriPath": "/urs_callback"
     },
@@ -95,8 +98,9 @@
       "cmrHost": "https://cmr.earthdata.nasa.gov",
       "echoRestRoot": "https://cmr.earthdata.nasa.gov/legacy-services/rest",
       "edlHost": "https://urs.earthdata.nasa.gov",
+      "csdaHost": "https://auth.csdap.uat.earthdatacloud.nasa.gov",
       "graphQlHost": "https://graphql.earthdata.nasa.gov",
-      "regionHost": "https://fts.podaac.earthdata.nasa.gov/",
+      "regionHost": "https://fts.podaac.earthdata.nasa.gov",
       "opensearchRoot": "https://cmr.earthdata.nasa.gov/opensearch",
       "redirectUriPath": "/urs_callback"
     }

--- a/static/src/js/components/OrderStatus/OrderStatus.js
+++ b/static/src/js/components/OrderStatus/OrderStatus.js
@@ -48,6 +48,7 @@ export class OrderStatus extends Component {
       onFetchRetrievalCollection,
       onFetchRetrievalCollectionGranuleLinks
     } = this.props
+
     const { jsondata = {}, links = [] } = retrieval
     const { source } = jsondata
 

--- a/static/src/js/util/files/__tests__/generateDownloadScript.test.js
+++ b/static/src/js/util/files/__tests__/generateDownloadScript.test.js
@@ -1,0 +1,96 @@
+import { generateDownloadScript } from '../generateDownloadScript'
+
+import * as getEarthdataConfig from '../../../../../../sharedUtils/config'
+
+describe('generateDownloadScript', () => {
+  beforeEach(() => {
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementationOnce(() => ({
+      edlHost: 'http://edl.example.com',
+      csdaHost: 'http://csda.example.com'
+    }))
+  })
+
+  describe('when no collection metadata is present', () => {
+    test('authentication URL is edl', () => {
+      const script = generateDownloadScript([
+        'https://granule-link-one.hdf',
+        'https://granule-link-two.hdf'
+      ], {
+        collection_metadata: {},
+        urs_id: 'test-user'
+      })
+
+      expect(script).toContain('Username (test-user):')
+      expect(script).toContain('username:-test-user')
+
+      expect(script).toContain('edl.example.com')
+
+      expect(script).toContain('granule-link-one.hdf')
+      expect(script).toContain('granule-link-two.hdf')
+    })
+  })
+
+  describe('when collection metadata does not indicate CSDA at all', () => {
+    test('authentication URL is edl', () => {
+      const script = generateDownloadScript([
+        'https://granule-link-one.hdf',
+        'https://granule-link-two.hdf'
+      ], {
+        collection_metadata: {},
+        urs_id: 'test-user'
+      })
+
+      expect(script).toContain('Username (test-user):')
+      expect(script).toContain('username:-test-user')
+
+      expect(script).toContain('edl.example.com')
+
+      expect(script).toContain('granule-link-one.hdf')
+      expect(script).toContain('granule-link-two.hdf')
+    })
+  })
+
+  describe('when collection is not CSDA', () => {
+    test('authentication URL is edl', () => {
+      const script = generateDownloadScript([
+        'https://granule-link-one.hdf',
+        'https://granule-link-two.hdf'
+      ], {
+        collection_metadata: {
+          isCSDA: false
+        },
+        urs_id: 'test-user'
+      })
+
+      expect(script).toContain('Username (test-user):')
+      expect(script).toContain('username:-test-user')
+
+      expect(script).toContain('edl.example.com')
+
+      expect(script).toContain('granule-link-one.hdf')
+      expect(script).toContain('granule-link-two.hdf')
+    })
+  })
+
+  describe('when collection is CSDA', () => {
+    test('authentication URL is csda', () => {
+      const script = generateDownloadScript([
+        'https://granule-link-one.hdf',
+        'https://granule-link-two.hdf'
+      ], {
+        collection_metadata: {
+          isCSDA: true
+        },
+        urs_id: 'test-user'
+      })
+
+      expect(script).toContain('Username (test-user):')
+      expect(script).toContain('username:-test-user')
+
+      expect(script).toContain('csda.example.com')
+
+      expect(script).toContain('granule-link-one.hdf')
+      expect(script).toContain('granule-link-two.hdf')
+    })
+  })
+})


### PR DESCRIPTION
# Overview

### What is the feature?

Updates the download script to work with CSDA data.

### What is the Solution?

Added a check for isCSDA within the collection metadata, if its found and true we use the CSDA authentication endpoint over EDL.

### What areas of the application does this impact?

Retrieval / Download of CSDA data.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
