### PR TITLE
EDSC-3143: Adds CSDA messaging to the order status page

### DIFF
--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -156,6 +156,9 @@ class App extends Component {
                     <Route path={this.portalPaths('/projects')}>
                       <AboutCSDAModalContainer />
                     </Route>
+                    <Route path={this.portalPaths('/downloads')}>
+                      <AboutCSDAModalContainer />
+                    </Route>
                   </Switch>
                 </UrlQueryContainer>
               </AuthTokenContainer>

--- a/static/src/js/components/OrderStatus/OrderStatus.js
+++ b/static/src/js/components/OrderStatus/OrderStatus.js
@@ -46,7 +46,8 @@ export class OrderStatus extends Component {
       onChangePath,
       onFetchRetrieval,
       onFetchRetrievalCollection,
-      onFetchRetrievalCollectionGranuleLinks
+      onFetchRetrievalCollectionGranuleLinks,
+      onToggleAboutCSDAModal
     } = this.props
     const { jsondata = {}, links = [] } = retrieval
     const { source } = jsondata
@@ -71,11 +72,11 @@ export class OrderStatus extends Component {
 
     const collectionsById = Object.values(byId)
 
-    downloads = collectionsById.filter(collection => downloads.includes(collection.id))
-    opendapOrders = collectionsById.filter(collection => opendapOrders.includes(collection.id))
-    echoOrders = collectionsById.filter(collection => echoOrders.includes(collection.id))
-    esiOrders = collectionsById.filter(collection => esiOrders.includes(collection.id))
-    harmonyOrders = collectionsById.filter(collection => harmonyOrders.includes(collection.id))
+    downloads = collectionsById.filter(({ id }) => downloads.includes(id))
+    opendapOrders = collectionsById.filter(({ id }) => opendapOrders.includes(id))
+    echoOrders = collectionsById.filter(({ id }) => echoOrders.includes(id))
+    esiOrders = collectionsById.filter(({ id }) => esiOrders.includes(id))
+    harmonyOrders = collectionsById.filter(({ id }) => harmonyOrders.includes(id))
 
     const { edscHost } = getEnvironmentConfig()
 
@@ -134,6 +135,7 @@ export class OrderStatus extends Component {
                   onFetchRetrieval={onFetchRetrieval}
                   onFetchRetrievalCollection={onFetchRetrievalCollection}
                   onFetchRetrievalCollectionGranuleLinks={onFetchRetrievalCollectionGranuleLinks}
+                  onToggleAboutCSDAModal={onToggleAboutCSDAModal}
                   retrievalCollection={retrievalCollection}
                 />
               )
@@ -259,7 +261,8 @@ OrderStatus.propTypes = {
   onChangePath: PropTypes.func.isRequired,
   onFetchRetrieval: PropTypes.func.isRequired,
   onFetchRetrievalCollection: PropTypes.func.isRequired,
-  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired
+  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired
 }
 
 export default OrderStatus

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { Tab } from 'react-bootstrap'
+import { Col, Tab } from 'react-bootstrap'
 import { upperFirst } from 'lodash'
 import {
   FaChevronUp,
-  FaChevronDown
+  FaChevronDown,
+  FaQuestionCircle
 } from 'react-icons/fa'
 
 import { getApplicationConfig } from '../../../../../sharedUtils/config'
@@ -135,10 +136,11 @@ export class OrderStatusItem extends PureComponent {
     } = this.state
 
     const {
-      granuleDownload,
+      collection,
       earthdataEnvironment,
+      granuleDownload,
       onChangePath,
-      collection
+      onToggleAboutCSDAModal
     } = this.props
 
     const {
@@ -162,7 +164,8 @@ export class OrderStatusItem extends PureComponent {
       const {
         browseFlag,
         directDistributionInformation = {},
-        title
+        title,
+        isCSDA: collectionIsCSDA
       } = collectionMetadata
 
       const orderStatus = aggregatedOrderStatus(orders)
@@ -511,6 +514,26 @@ export class OrderStatusItem extends PureComponent {
                       )
                     }
                   </div>
+                  {
+                    collectionIsCSDA && (
+                      <Col className="order-status-item__note mb-3">
+                        {'This collection is made available through the '}
+                        <span className="order-status-item__note-emph order-status-item__note-emph--csda">NASA Commercial Smallsat Data Acquisition (CSDA) Program</span>
+                        {' for NASA funded researchers. Access to the data will require additional authentication. '}
+                        <Button
+                          className="order-status-item__header-message-link"
+                          dataTestId="order-status-item__csda-modal-button"
+                          onClick={() => onToggleAboutCSDAModal(true)}
+                          variant="link"
+                          bootstrapVariant="link"
+                          icon={FaQuestionCircle}
+                          label="More details"
+                        >
+                          More Details
+                        </Button>
+                      </Col>
+                    )
+                  }
                   <div className="order-status-item__additional-info">
                     {
                       messages.length > 0 && (
@@ -697,7 +720,8 @@ OrderStatusItem.propTypes = {
   match: PropTypes.shape({}).isRequired,
   onChangePath: PropTypes.func.isRequired,
   onFetchRetrievalCollection: PropTypes.func.isRequired,
-  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired
+  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired
 }
 
 export default OrderStatusItem

--- a/static/src/js/components/OrderStatus/OrderStatusItem.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.scss
@@ -192,6 +192,25 @@ $item-height: 3rem;
     font-size: 0.875rem;
   }
 
+  &__note {
+    display: block;
+    margin-bottom: $spacer/2;
+    color: $color__black--500;
+    font-size: 0.875rem;
+  }
+
+  &__note-emph {
+    font-weight: 500;
+
+    &--opensearch {
+      color: $color__yellow;
+    }
+
+    &--csda {
+      color: $color__purple;
+    }
+  }
+
   &__message {
     padding: 0.875rem $spacer;
     background-color: $color__pale-yellow;

--- a/static/src/js/components/OrderStatus/OrderStatusList.js
+++ b/static/src/js/components/OrderStatus/OrderStatusList.js
@@ -13,7 +13,8 @@ export const OrderStatusList = ({
   onChangePath,
   onFetchRetrieval,
   onFetchRetrievalCollection,
-  onFetchRetrievalCollectionGranuleLinks
+  onFetchRetrievalCollectionGranuleLinks,
+  onToggleAboutCSDAModal
 }) => (
   <div className="order-status-list">
     <ul className="order-status-list__list">
@@ -36,6 +37,7 @@ export const OrderStatusList = ({
               onFetchRetrieval={onFetchRetrieval}
               onFetchRetrievalCollection={onFetchRetrievalCollection}
               onFetchRetrievalCollectionGranuleLinks={onFetchRetrievalCollectionGranuleLinks}
+              onToggleAboutCSDAModal={onToggleAboutCSDAModal}
             />
           )
         })
@@ -56,7 +58,8 @@ OrderStatusList.propTypes = {
   onChangePath: PropTypes.func.isRequired,
   onFetchRetrieval: PropTypes.func.isRequired,
   onFetchRetrievalCollection: PropTypes.func.isRequired,
-  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired
+  onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired
 }
 
 export default OrderStatusList

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -43,6 +43,7 @@ function setup(overrideProps, mockRefresh) {
     onFetchRetrieval: jest.fn(),
     onFetchRetrievalCollection: jest.fn(),
     onFetchRetrievalCollectionGranuleLinks: jest.fn(),
+    onToggleAboutCSDAModal: jest.fn(),
     orders: [{
       type: 'download'
     }],
@@ -57,11 +58,6 @@ function setup(overrideProps, mockRefresh) {
     shouldRefreshMock
   }
 }
-
-
-
-
-
 
 describe('OrderStatusItem', () => {
   describe('Auto-refresh', () => {
@@ -327,6 +323,68 @@ describe('OrderStatusItem', () => {
       expect(scriptTab.props().title).toEqual('Download Script')
       expect(scriptTab.childAt(0).props().granuleCount).toEqual(100)
       expect(scriptTab.childAt(0).props().downloadLinks).toEqual([])
+    })
+  })
+
+  describe.only('CSDA', () => {
+    test('renders the CSDA information', () => {
+      const { enzymeWrapper } = setup({
+        type: 'download',
+        collection: {
+          id: 1,
+          collection_id: 'TEST_COLLECTION_111',
+          retrieval_id: '54',
+          collection_metadata: {
+            id: 'TEST_COLLECTION_111',
+            title: 'Test Dataset ID',
+            isCSDA: true
+          },
+          access_method: {
+            type: 'download'
+          },
+          granule_count: 100,
+          orders: [],
+          isLoaded: true
+        }
+      })
+
+      enzymeWrapper.find('.order-status-item__button').simulate('click')
+
+      const message = enzymeWrapper.find('.order-status-item__note')
+
+      expect(message.text()).toContain('This collection is made available through the NASA Commercial Smallsat Data Acquisition (CSDA) Program')
+    })
+
+    test('more details triggers modal on click', () => {
+      const { enzymeWrapper, props } = setup({
+        type: 'download',
+        collection: {
+          id: 1,
+          collection_id: 'TEST_COLLECTION_111',
+          retrieval_id: '54',
+          collection_metadata: {
+            id: 'TEST_COLLECTION_111',
+            title: 'Test Dataset ID',
+            isCSDA: true
+          },
+          access_method: {
+            type: 'download'
+          },
+          granule_count: 100,
+          orders: [],
+          isLoaded: true
+        }
+      })
+
+      enzymeWrapper.find('.order-status-item__button').simulate('click')
+
+      const message = enzymeWrapper.find('.order-status-item__note')
+      const moreDetailsButton = message.find('.order-status-item__header-message-link')
+
+      moreDetailsButton.simulate('click')
+
+      expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
+      expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
     })
   })
 

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -326,7 +326,7 @@ describe('OrderStatusItem', () => {
     })
   })
 
-  describe.only('CSDA', () => {
+  describe('CSDA', () => {
     test('renders the CSDA information', () => {
       const { enzymeWrapper } = setup({
         type: 'download',

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusList.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusList.test.js
@@ -31,7 +31,8 @@ function setup() {
     onChangePath: jest.fn(),
     onFetchRetrieval: jest.fn(),
     onFetchRetrievalCollection: jest.fn(),
-    onFetchRetrievalCollectionGranuleLinks: jest.fn()
+    onFetchRetrievalCollectionGranuleLinks: jest.fn(),
+    onToggleAboutCSDAModal: jest.fn()
   }
 
   const enzymeWrapper = shallow(<OrderStatusList {...props} />)
@@ -107,7 +108,8 @@ describe('OrderStatus component', () => {
         onChangePath: props.onChangePath,
         onFetchRetrieval: props.onFetchRetrieval,
         onFetchRetrievalCollection: props.onFetchRetrievalCollection,
-        onFetchRetrievalCollectionGranuleLinks: props.onFetchRetrievalCollectionGranuleLinks
+        onFetchRetrievalCollectionGranuleLinks: props.onFetchRetrievalCollectionGranuleLinks,
+        onToggleAboutCSDAModal: props.onToggleAboutCSDAModal
       })
     })
   })

--- a/static/src/js/components/OrderStatus/__tests__/mocks.js
+++ b/static/src/js/components/OrderStatus/__tests__/mocks.js
@@ -5,6 +5,7 @@ export const retrievalStatusProps = {
   onFetchRetrieval: jest.fn(),
   onFetchRetrievalCollection: jest.fn(),
   onFetchRetrievalCollectionGranuleLinks: jest.fn(),
+  onToggleAboutCSDAModal: jest.fn(),
   match: {
     search: {
       id: 7

--- a/static/src/js/components/SearchPanels/SearchPanels.scss
+++ b/static/src/js/components/SearchPanels/SearchPanels.scss
@@ -14,7 +14,7 @@
   &__note {
     display: block;
     margin-bottom: $spacer/2;
-    color: $color__black--400;
+    color: $color__black--500;
     font-size: 0.875rem;
   }
 

--- a/static/src/js/containers/OrderStatusContainer/OrderStatusContainer.js
+++ b/static/src/js/containers/OrderStatusContainer/OrderStatusContainer.js
@@ -29,7 +29,9 @@ export const mapDispatchToProps = dispatch => ({
       actions.fetchRetrievalCollectionGranuleLinks(retrievalCollection)
     ),
   onChangePath:
-    path => dispatch(actions.changePath(path))
+    path => dispatch(actions.changePath(path)),
+  onToggleAboutCSDAModal:
+    state => dispatch(actions.toggleAboutCSDAModal(state))
 })
 
 export const OrderStatusContainer = ({
@@ -42,6 +44,7 @@ export const OrderStatusContainer = ({
   onFetchRetrieval,
   onFetchRetrievalCollection,
   onFetchRetrievalCollectionGranuleLinks,
+  onToggleAboutCSDAModal,
   retrieval
 }) => (
   <OrderStatus
@@ -54,6 +57,7 @@ export const OrderStatusContainer = ({
     onFetchRetrieval={onFetchRetrieval}
     onFetchRetrievalCollection={onFetchRetrievalCollection}
     onFetchRetrievalCollectionGranuleLinks={onFetchRetrievalCollectionGranuleLinks}
+    onToggleAboutCSDAModal={onToggleAboutCSDAModal}
     retrieval={retrieval}
   />
 )
@@ -68,6 +72,7 @@ OrderStatusContainer.propTypes = {
   onFetchRetrieval: PropTypes.func.isRequired,
   onFetchRetrievalCollection: PropTypes.func.isRequired,
   onFetchRetrievalCollectionGranuleLinks: PropTypes.func.isRequired,
+  onToggleAboutCSDAModal: PropTypes.func.isRequired,
   retrieval: PropTypes.shape({}).isRequired
 }
 

--- a/static/src/js/containers/OrderStatusContainer/__tests__/OrderStatusContainer.test.js
+++ b/static/src/js/containers/OrderStatusContainer/__tests__/OrderStatusContainer.test.js
@@ -48,6 +48,16 @@ describe('mapDispatchToProps', () => {
     expect(spy).toBeCalledWith({ mock: 'data' })
   })
 
+  test('onToggleAboutCSDAModal calls actions.onToggleAboutCSDAModal', () => {
+    const dispatch = jest.fn()
+    const spy = jest.spyOn(actions, 'toggleAboutCSDAModal')
+
+    mapDispatchToProps(dispatch).onToggleAboutCSDAModal(true)
+
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith(true)
+  })
+
   test('onChangePath calls actions.changePath', () => {
     const dispatch = jest.fn()
     const spy = jest.spyOn(actions, 'changePath')
@@ -102,6 +112,7 @@ describe('OrderStatusContainer component', () => {
         onFetchRetrieval: jest.fn(),
         onFetchRetrievalCollection: jest.fn(),
         onFetchRetrievalCollectionGranuleLinks: jest.fn(),
+        onToggleAboutCSDAModal: jest.fn(),
         retrieval: {
           id: 7,
           collections: {


### PR DESCRIPTION
# Overview

### What is the feature?

Display contextual messaging on the order status page when downloading a CSDA collection

### What is the Solution?

Adds CSDA messaging to the order status page

### What areas of the application does this impact?

Order status page

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:** Any CSDA collection

1. Download a CSDA collection
2. Confirm contextual messaging appears on the order status page for the CSDA collection

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
