### PR TITLE
EDSC-3178: Removes wildcard characters when a user enters a quoted string into keyword search

### DIFF
--- a/static/src/js/util/__tests__/collections.test.js
+++ b/static/src/js/util/__tests__/collections.test.js
@@ -1,4 +1,4 @@
-import { prepareCollectionParams } from '../collections'
+import { buildCollectionSearchParams, prepareCollectionParams } from '../collections'
 
 describe('#prepareCollectionParams', () => {
   describe('when the customize facet is selected', () => {
@@ -20,6 +20,38 @@ describe('#prepareCollectionParams', () => {
           ]
         })
       )
+    })
+  })
+})
+
+describe('#buildCollectionParams', () => {
+  describe('when the keyword does not have a quoted string', () => {
+    test('the wildcard character is added between words', () => {
+      const params = buildCollectionSearchParams({
+        featureFacets: {},
+        keyword: 'modis terra',
+        sortKey: [],
+        viewAllFacets: {}
+      })
+
+      expect(params).toEqual(expect.objectContaining({
+        keyword: 'modis* terra*'
+      }))
+    })
+  })
+
+  describe('when the keyword has a quoted string', () => {
+    test('the wildcard character is not added between words', () => {
+      const params = buildCollectionSearchParams({
+        featureFacets: {},
+        keyword: '"modis" terra',
+        sortKey: [],
+        viewAllFacets: {}
+      })
+
+      expect(params).toEqual(expect.objectContaining({
+        keyword: '"modis" terra'
+      }))
     })
   })
 })

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -169,7 +169,13 @@ export const buildCollectionSearchParams = (params) => {
   }
 
   // If there is a keyword, add the wildcard character between words and following the final character
-  const keywordWithWildcard = !keyword ? undefined : `${keyword.replace(/\s+/g, '* ')}*`
+  // If the user types a quoted string, don't add the wildcard character
+  let keywordWithWildcard
+  if (keyword && keyword.match(/(".*")/)) {
+    keywordWithWildcard = keyword
+  } else if (keyword) {
+    keywordWithWildcard = `${keyword.replace(/\s+/g, '* ')}*`
+  }
 
   // Set up params that are not driven by the URL
   const defaultParams = {


### PR DESCRIPTION
# Overview

### What is the feature?

Quoted strings are now possible in CMR, but we don't want to add wildcard characters between words when a user provides a quoted string