### PR TITLE
EDSC-3208: Fixes key to send to CMR when concept id is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,8 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/nasa/earthdata-search/badge.svg)](https://snyk.io/test/github/nasa/earthdata-search)
 
 ## About
-Earthdata Search is a web application developed by [NASA](http://nasa.gov) [EOSDIS](https://earthdata.nasa.gov)
-to enable data discovery, search, comparison, visualization, and access across EOSDIS' Earth Science data holdings.
-It builds upon several public-facing services provided by EOSDIS, including
-the [Common Metadata Repository (CMR)](https://cmr.earthdata.nasa.gov/search/) for data discovery and access,
-EOSDIS [User Registration System (URS)](https://urs.earthdata.nasa.gov) authentication,
-the [Global Imagery Browse Services (GIBS)](https://earthdata.nasa.gov/gibs) for visualization,
-and a number of OPeNDAP services hosted by data providers.
+Earthdata Search is a web application developed by [NASA](http://nasa.gov) [EOSDIS](https://earthdata.nasa.gov) to enable data discovery, search, comparison, visualization, and access across EOSDIS' Earth Science data holdings.
+It builds upon several public-facing services provided by EOSDIS, including the [Common Metadata Repository (CMR)](https://cmr.earthdata.nasa.gov/search/) for data discovery and access, EOSDIS [User Registration System (URS)](https://urs.earthdata.nasa.gov) authentication, the [Global Imagery Browse Services (GIBS)](https://earthdata.nasa.gov/gibs) for visualization, and a number of OPeNDAP services hosted by data providers.
 
 ## License
 

--- a/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
+++ b/serverless/src/generateCollectionCapabilityTags/__tests__/handler.test.js
@@ -156,7 +156,7 @@ describe('generateCollectionCapabilityTags', () => {
 
       nock(/cmr/)
         .matchHeader('Echo-Token', 'mocked-system-token')
-        .post(/collections/, 'has_granules=true&page_num=1&page_size=300&include_granule_counts=true&include_tags=edsc.extra.serverless.%2A&collection_concept_id=C100000-EDSC')
+        .post(/collections/, 'has_granules=true&page_num=1&page_size=300&include_granule_counts=true&include_tags=edsc.extra.serverless.%2A&concept_id=C100000-EDSC')
         .reply(200, {
           feed: {
             entry: [{

--- a/serverless/src/generateCollectionCapabilityTags/handler.js
+++ b/serverless/src/generateCollectionCapabilityTags/handler.js
@@ -47,7 +47,7 @@ const generateCollectionCapabilityTags = async (input) => {
   delete input.conceptId
 
   // If a concept id was provided add it to the request params to scope it down
-  if (conceptId) cmrParams.collection_concept_id = conceptId
+  if (conceptId) cmrParams.concept_id = conceptId
 
   const { cmrHost } = getEarthdataConfig(deployedEnvironment())
   const collectionSearchUrl = `${cmrHost}/search/collections.json`
@@ -71,7 +71,20 @@ const generateCollectionCapabilityTags = async (input) => {
   const collections = readCmrResults('search/collections.json', response)
 
   // Filter out collections that dont have any granules
-  const collectionsWithGranules = collections.filter(collection => collection.granule_count > 0)
+  const collectionsWithGranules = collections.filter((collection) => {
+    const {
+      id,
+      granule_count: granuleCount
+    } = collection
+
+    const hasGranules = granuleCount > 0
+
+    if (!hasGranules) {
+      console.log(`${id} has no granules, skipping ${tagName('collection_capabilities')} tag.`)
+    }
+
+    return hasGranules
+  })
 
   console.log(`Number of collections with granules: ${collectionsWithGranules.length}`)
 


### PR DESCRIPTION
# Overview

### What is the feature?

Allows for running the collection capabilities tagging job on a single collection.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
