### PR TITLE
EDSC-3204: Fixes limit type in graphql query

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -21,7 +21,7 @@
     "eosdisTagKey": "gov.nasa.eosdis",
     "defaultCmrPageSize": 20,
     "maxCmrPageSize": 2000,
-    "granuleLinksPageSize": 500,
+    "granuleLinksPageSize": "500",
     "defaultCmrSearchTags": [
       "edsc.*",
       "opensearch.granule.osdd"

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -167,7 +167,7 @@ export const fetchLinks = retrievalCollectionData => (dispatch, getState) => {
   } = retrievalCollectionData
 
   // The number of granules to request per page from CMR
-  const pageSize = granuleLinksPageSize
+  const pageSize = parseInt(granuleLinksPageSize, 10)
 
   // Determine how many pages we will need to load to display all granules
   const totalPages = Math.ceil(granuleCount / pageSize)


### PR DESCRIPTION
# Overview

### What is the feature?

Environment variables from deployments are parsed as strings, `granuleLinksPageSize` needs to be parsed as a integer in order to be passed as the `limit` param to GraphQL