### PR TITLE
EDSC-3219: Allow user to disable temporal subsetting for Harmony orders

### DIFF
--- a/serverless/src/getAccessMethods/__tests__/handler.test.js
+++ b/serverless/src/getAccessMethods/__tests__/handler.test.js
@@ -143,6 +143,7 @@ describe('getAccessMethods', () => {
             ],
             supportsBoundingBoxSubsetting: false,
             supportsShapefileSubsetting: false,
+            supportsTemporalSubsetting: false,
             supportsVariableSubsetting: false,
             type: 'Harmony',
             url: 'https://harmony.earthdata.nas.gov',

--- a/serverless/src/getAccessMethods/__tests__/supportsTemporalSubsetting.test.js
+++ b/serverless/src/getAccessMethods/__tests__/supportsTemporalSubsetting.test.js
@@ -1,0 +1,33 @@
+import { supportsTemporalSubsetting } from '../supportsTemporalSubsetting'
+
+describe('supportsTemporalSubsetting', () => {
+  describe('when temporal subsetting is supported', () => {
+    test('returns true', () => {
+      const response = supportsTemporalSubsetting({
+        conceptId: 'S100000-EDSC',
+        serviceOptions: {
+          subset: {
+            temporalSubset: {
+              allowMultipleValues: false
+            }
+          }
+        }
+      })
+
+      expect(response).toBeTruthy()
+    })
+  })
+
+  describe('when temporal subsetting is not supported', () => {
+    test('returns false', () => {
+      const response = supportsTemporalSubsetting({
+        conceptId: 'S100000-EDSC',
+        serviceOptions: {
+          supportedReformattings: {}
+        }
+      })
+
+      expect(response).toBeFalsy()
+    })
+  })
+})

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -15,11 +15,12 @@ import { getVerifiedJwtToken } from '../util/getVerifiedJwtToken'
 import { parseError } from '../../../sharedUtils/parseError'
 import { supportsBoundingBoxSubsetting } from './supportsBoundingBoxSubsetting'
 import { supportsShapefileSubsetting } from './supportsShapefileSubsetting'
+import { supportsTemporalSubsetting } from './supportsTemporalSubsetting'
 import { supportsVariableSubsetting } from './supportsVariableSubsetting'
 
 /**
  * Retrieve access methods for a provided collection
- * @param {Object} event Details about the HTTP request that it received
+ * @param {Object} event Details about the HTTP request that it receizved
  * @param {Object} context Methods and properties that provide information about the invocation, function, and execution environment
  */
 const getAccessMethods = async (event, context) => {
@@ -261,6 +262,7 @@ const getAccessMethods = async (event, context) => {
           supportedOutputProjections: outputProjections,
           supportsBoundingBoxSubsetting: supportsBoundingBoxSubsetting(serviceObject),
           supportsShapefileSubsetting: supportsShapefileSubsetting(serviceObject),
+          supportsTemporalSubsetting: supportsTemporalSubsetting(serviceObject),
           supportsVariableSubsetting: supportsVariableSubsetting(serviceObject),
           type,
           url: urlValue,

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -20,7 +20,7 @@ import { supportsVariableSubsetting } from './supportsVariableSubsetting'
 
 /**
  * Retrieve access methods for a provided collection
- * @param {Object} event Details about the HTTP request that it receizved
+ * @param {Object} event Details about the HTTP request that it received
  * @param {Object} context Methods and properties that provide information about the invocation, function, and execution environment
  */
 const getAccessMethods = async (event, context) => {

--- a/serverless/src/getAccessMethods/supportsTemporalSubsetting.js
+++ b/serverless/src/getAccessMethods/supportsTemporalSubsetting.js
@@ -1,0 +1,17 @@
+import { isEmpty } from 'lodash'
+
+/**
+ * Determine whether or not the provided UMM S record supports temporal subsetting
+ * @param {Object} service UMM S record to parse
+ */
+export const supportsTemporalSubsetting = (service) => {
+  const { serviceOptions = {} } = service
+
+  // If there are no service options the record can not support variable subsetting
+  if (serviceOptions == null) return false
+
+  const { subset = {} } = serviceOptions
+  const { temporalSubset = {} } = subset
+
+  return !isEmpty(temporalSubset)
+}

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -90,6 +90,7 @@ describe('submitHarmonyOrder', () => {
           jsondata: { source: '?sf=1', shapefileId: 1 },
           collection_id: 'C100000-EDSC',
           access_method: {
+            enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [
@@ -182,6 +183,7 @@ describe('submitHarmonyOrder', () => {
           jsondata: { source: '?sf=1&sfs[0]=1', shapefileId: 1, selectedFeatures: ['1'] },
           collection_id: 'C100000-EDSC',
           access_method: {
+            enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [
@@ -275,6 +277,7 @@ describe('submitHarmonyOrder', () => {
           jsondata: { source: '?sf=1', shapefileId: 1 },
           collection_id: 'C100000-EDSC',
           access_method: {
+            enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -43,6 +43,7 @@ export const constructOrderPayload = async ({
   const granuleIds = granuleResponseBody.map(granuleMetadata => granuleMetadata.id).join(',')
 
   const {
+    enableTemporalSubsetting,
     mbr,
     selectedOutputFormat,
     selectedOutputProjection,
@@ -52,8 +53,8 @@ export const constructOrderPayload = async ({
 
   // OGC uses duplicate parameter names for subsetting and the
   // standard javascript object will not support that so we need to use
-  // the FormData object to avoid any language specific restrictions on
   // duplicate keys
+  // the FormData object to avoid any language specific restrictions on
   const orderPayload = new FormData()
 
   orderPayload.append('forceAsync', 'true')
@@ -194,7 +195,7 @@ export const constructOrderPayload = async ({
     }
   }
 
-  if (temporal) {
+  if (temporal && enableTemporalSubsetting) {
     const [
       timeStart,
       timeEnd

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -39,15 +39,19 @@ export class AccessMethod extends Component {
 
     const {
       accessMethods,
-      selectedAccessMethod
+      selectedAccessMethod,
+      temporal
     } = props
+
+    const { isRecurring } = temporal
 
     const selectedMethod = accessMethods[selectedAccessMethod]
 
+    // Disable temporal subsetting if the user has a recurring date selected
     const {
       selectedOutputFormat = '',
       selectedOutputProjection = '',
-      enableTemporalSubsetting = true
+      enableTemporalSubsetting = !isRecurring
     } = selectedMethod || {}
 
     this.state = {
@@ -60,6 +64,19 @@ export class AccessMethod extends Component {
     this.handleOutputFormatSelection = this.handleOutputFormatSelection.bind(this)
     this.handleOutputProjectionSelection = this.handleOutputProjectionSelection.bind(this)
     this.handleToggleTemporalSubsetting = this.handleToggleTemporalSubsetting.bind(this)
+  }
+
+  componentWillReceiveProps() {
+    const { temporal } = this.props
+
+    const { isRecurring } = temporal
+
+    // Disable temporal subsetting if the user has a recurring date selected
+    if (isRecurring) {
+      this.setState({
+        enableTemporalSubsetting: false
+      })
+    }
   }
 
   handleAccessMethodSelection(method) {
@@ -433,6 +450,7 @@ export class AccessMethod extends Component {
                         customHeadingTag="h4"
                         heading="Temporal Subsetting"
                         intro="When enabled, temporal subsetting will trim the data to the selected temporal range."
+                        warning={isRecurring && 'To prevent unexpected results, temporal subsetting is not supported for recurring dates.'}
                         nested
                       >
                         {
@@ -447,11 +465,12 @@ export class AccessMethod extends Component {
                                   </span>
                                 )}
                                 checked={enableTemporalSubsetting}
+                                disabled={isRecurring}
                                 onChange={this.handleToggleTemporalSubsetting}
                               />
                               {
                                 enableTemporalSubsetting && (
-                                  <p className="access-method__section-status ml-3">
+                                  <p className="access-method__section-status mt-2 mb-0">
                                     Selected Range:
                                     <br />
                                     {selectedTemporalDisplay}

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -43,6 +43,7 @@ export class AccessMethod extends Component {
     } = props
 
     const selectedMethod = accessMethods[selectedAccessMethod]
+
     const {
       selectedOutputFormat = '',
       selectedOutputProjection = '',
@@ -436,8 +437,9 @@ export class AccessMethod extends Component {
                       >
                         {
                           (startDate || endDate) && (
-                            <Form.Group controlId="temporal-subsetting" className="mb-0">
+                            <Form.Group controlId="input__temporal-subsetting" className="mb-0">
                               <Form.Check
+                                id="input__temporal-subsetting"
                                 type="checkbox"
                                 label={(
                                   <span className={`mb-1 d-block ${!enableTemporalSubsetting && 'text-muted'}`}>

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -9,7 +9,7 @@ import ProjectPanelSection from '../../ProjectPanels/ProjectPanelSection'
 
 Enzyme.configure({ adapter: new Adapter() })
 
-function setup() {
+function setup(overrideProps) {
   const props = {
     accessMethods: {},
     index: 0,
@@ -22,7 +22,8 @@ function setup() {
     onSelectAccessMethod: jest.fn(),
     onSetActivePanel: jest.fn(),
     onUpdateAccessMethod: jest.fn(),
-    selectedAccessMethod: ''
+    selectedAccessMethod: '',
+    ...overrideProps
   }
 
   const enzymeWrapper = shallow(<AccessMethod {...props} />)
@@ -472,6 +473,422 @@ describe('AccessMethod component', () => {
               selectedOutputProjection: 'EPSG:4326'
             }
           }
+        })
+      })
+    })
+
+    describe('when temporal subsetting is not supported', () => {
+      describe('when a temporal range is not set', () => {
+        test('does not display the temporal subsetting input', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: false
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0'
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
+        })
+      })
+
+      describe('when a temporal range is set', () => {
+        test('does not display the temporal subsetting input', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: false
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
+        })
+      })
+    })
+
+    describe('when temporal subsetting is supported', () => {
+      describe('when a temporal range is not set', () => {
+        test('displays a message about temporal subsetting', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0'
+          })
+
+          expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('No temporal range selected.')
+        })
+      })
+
+      describe('when a temporal range is set', () => {
+        test('displays a checkbox input', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').length).toEqual(1)
+        })
+
+        test('displays the correct selected temporal range', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:2008-06-27 00:00:00 to 2021-08-01 23:59:59')
+        })
+
+        describe('when only an start date is set', () => {
+          test('displays the correct selected temporal range', () => {
+            const { enzymeWrapper } = setup()
+
+            const collectionId = 'collectionId'
+
+            enzymeWrapper.setProps({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true
+                }
+              },
+              metadata: {
+                conceptId: collectionId
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                isRecurring: false
+              }
+            })
+
+            expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:2008-06-27 00:00:00 ongoing')
+          })
+
+          describe('when only an end date is set', () => {
+            test('displays the correct selected temporal range', () => {
+              const { enzymeWrapper } = setup()
+
+              const collectionId = 'collectionId'
+
+              enzymeWrapper.setProps({
+                accessMethods: {
+                  harmony0: {
+                    isValid: true,
+                    type: 'Harmony',
+                    supportsTemporalSubsetting: true
+                  }
+                },
+                metadata: {
+                  conceptId: collectionId
+                },
+                selectedAccessMethod: 'harmony0',
+                temporal: {
+                  endDate: '2008-06-27T00:00:00.979Z',
+                  isRecurring: false
+                }
+              })
+
+              expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:Up to 2008-06-27 00:00:00')
+            })
+          })
+        })
+      })
+
+      describe('when enableTemporalSubsetting is not set', () => {
+        test('defaults the checkbox checked', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+        })
+      })
+
+      describe('when enableTemporalSubsetting is set to true', () => {
+        test('sets the checkbox checked', () => {
+          const { enzymeWrapper } = setup()
+
+          const collectionId = 'collectionId'
+
+          enzymeWrapper.setProps({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true,
+                enableTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+        })
+
+        describe('when the user clicks the checkbox', () => {
+          test('sets the checkbox checked', () => {
+            const { enzymeWrapper } = setup()
+
+            const collectionId = 'collectionId'
+
+            enzymeWrapper.setProps({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true,
+                  enableTemporalSubsetting: true
+                }
+              },
+              metadata: {
+                conceptId: collectionId
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                endDate: '2021-08-01T23:59:59.048Z',
+                isRecurring: false
+              }
+            })
+
+            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+
+            checkbox.simulate('change', { target: { checked: false } })
+
+            enzymeWrapper.update()
+
+            expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
+          })
+
+          test('calls onUpdateAccessMethod', () => {
+            const { enzymeWrapper, props } = setup({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true,
+                  enableTemporalSubsetting: true
+                }
+              },
+              metadata: {
+                conceptId: 'collectionId'
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                endDate: '2021-08-01T23:59:59.048Z',
+                isRecurring: false
+              }
+            })
+
+            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+
+            checkbox.simulate('change', { target: { checked: false } })
+
+            enzymeWrapper.update()
+
+            expect(props.onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+            expect(props.onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: false } } })
+          })
+        })
+      })
+
+      describe('when enableTemporalSubsetting is set to false', () => {
+        test('sets the checkbox unchecked', () => {
+          const { enzymeWrapper } = setup({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true,
+                enableTemporalSubsetting: false
+              }
+            },
+            metadata: {
+              conceptId: 'collectionId'
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              isRecurring: false
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
+        })
+
+        describe('when the user clicks the checkbox', () => {
+          test('sets the checkbox unchecked', () => {
+            const { enzymeWrapper } = setup()
+
+            const collectionId = 'collectionId'
+
+            enzymeWrapper.setProps({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true,
+                  enableTemporalSubsetting: true
+                }
+              },
+              metadata: {
+                conceptId: collectionId
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                endDate: '2021-08-01T23:59:59.048Z',
+                isRecurring: false
+              }
+            })
+
+            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+
+            checkbox.simulate('change', { target: { checked: true } })
+
+            enzymeWrapper.update()
+
+            expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+          })
+
+          test('calls onUpdateAccessMethod', () => {
+            const { enzymeWrapper, props } = setup()
+
+            const collectionId = 'collectionId'
+
+            enzymeWrapper.setProps({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true,
+                  enableTemporalSubsetting: true
+                }
+              },
+              metadata: {
+                conceptId: collectionId
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                endDate: '2021-08-01T23:59:59.048Z',
+                isRecurring: false
+              }
+            })
+
+            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+
+            checkbox.simulate('change', { target: { checked: true } })
+
+            enzymeWrapper.update()
+
+            expect(props.onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+            expect(props.onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: true } } })
+          })
         })
       })
     })

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -669,6 +669,83 @@ describe('AccessMethod component', () => {
         })
       })
 
+      describe('when the temporal selection is recurring', () => {
+        test('sets the checkbox unchecked', () => {
+          const { enzymeWrapper } = setup({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: 'collectionId'
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              recurringDayStart: 0,
+              recurringDayEnd: 10,
+              isRecurring: true
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
+        })
+
+        test('sets the checkbox disabled', () => {
+          const { enzymeWrapper } = setup({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: 'collectionId'
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              recurringDayStart: 0,
+              recurringDayEnd: 10,
+              isRecurring: true
+            }
+          })
+
+          expect(enzymeWrapper.find('#input__temporal-subsetting').props().disabled).toEqual(true)
+        })
+
+        test('sets a warning in the section', () => {
+          const { enzymeWrapper } = setup({
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                supportsTemporalSubsetting: true
+              }
+            },
+            metadata: {
+              conceptId: 'collectionId'
+            },
+            selectedAccessMethod: 'harmony0',
+            temporal: {
+              startDate: '2008-06-27T00:00:00.979Z',
+              endDate: '2021-08-01T23:59:59.048Z',
+              recurringDayStart: 0,
+              recurringDayEnd: 10,
+              isRecurring: true
+            }
+          })
+
+          expect(enzymeWrapper.find(ProjectPanelSection).at(1).childAt(0).props().warning).toEqual('To prevent unexpected results, temporal subsetting is not supported for recurring dates.')
+        })
+      })
+
       describe('when enableTemporalSubsetting is not set', () => {
         test('defaults the checkbox checked', () => {
           const { enzymeWrapper } = setup()

--- a/static/src/js/components/EDSCAlert/EDSCAlert.js
+++ b/static/src/js/components/EDSCAlert/EDSCAlert.js
@@ -10,6 +10,7 @@ import './EDSCAlert.scss'
 export const EDSCAlert = ({
   bootstrapVariant,
   children,
+  className,
   icon,
   variant
 }) => {
@@ -18,7 +19,8 @@ export const EDSCAlert = ({
     {
       'edsc-alert--icon': icon,
       [`edsc-alert--${variant}`]: variant
-    }
+    },
+    className
   ])
   return (
     <Alert
@@ -38,6 +40,7 @@ export const EDSCAlert = ({
 }
 
 EDSCAlert.defaultProps = {
+  className: '',
   children: null,
   icon: null,
   variant: false
@@ -45,6 +48,7 @@ EDSCAlert.defaultProps = {
 
 EDSCAlert.propTypes = {
   bootstrapVariant: PropTypes.string.isRequired,
+  className: PropTypes.string,
   children: PropTypes.node,
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   variant: PropTypes.oneOfType([

--- a/static/src/js/components/EDSCAlert/__tests__/EDSCAlert.test.js
+++ b/static/src/js/components/EDSCAlert/__tests__/EDSCAlert.test.js
@@ -30,6 +30,16 @@ describe('EDSCAlert component', () => {
     expect(enzymeWrapper.prop('className')).toContain('edsc-alert')
   })
 
+  describe('when an class name is provided', () => {
+    const { enzymeWrapper } = setup({
+      className: 'test-class-name'
+    })
+
+    test('should add the class name', () => {
+      expect(enzymeWrapper.props().className).toContain('test-class-name')
+    })
+  })
+
   describe('when a variant is declared', () => {
     const { enzymeWrapper } = setup({
       variant: 'test-variant'

--- a/static/src/js/components/ProjectPanels/ProjectPanelSection.js
+++ b/static/src/js/components/ProjectPanels/ProjectPanelSection.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import { FaExclamationCircle } from 'react-icons/fa'
+
+import EDSCAlert from '../EDSCAlert/EDSCAlert'
 
 import './ProjectPanelSection.scss'
 
@@ -21,7 +24,8 @@ export const ProjectPanelSection = ({
   headingLevel,
   intro,
   nested,
-  step
+  step,
+  warning
 }) => {
   const panelSectionClasses = classNames([
     'project-panel-section',
@@ -56,6 +60,17 @@ export const ProjectPanelSection = ({
         )
       }
       {children}
+      {
+        warning && (
+          <EDSCAlert
+            className="project-panel-section__warning"
+            bootstrapVariant="warning"
+            icon={FaExclamationCircle}
+          >
+            {warning}
+          </EDSCAlert>
+        )
+      }
     </div>
   )
 }
@@ -67,7 +82,8 @@ ProjectPanelSection.defaultProps = {
   headingLevel: 'h3',
   intro: null,
   nested: false,
-  step: null
+  step: null,
+  warning: ''
 }
 
 ProjectPanelSection.propTypes = {
@@ -77,7 +93,11 @@ ProjectPanelSection.propTypes = {
   headingLevel: PropTypes.string,
   intro: PropTypes.string,
   nested: PropTypes.bool,
-  step: PropTypes.number
+  step: PropTypes.number,
+  warning: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string
+  ])
 }
 
 export default ProjectPanelSection

--- a/static/src/js/components/ProjectPanels/ProjectPanelSection.scss
+++ b/static/src/js/components/ProjectPanels/ProjectPanelSection.scss
@@ -36,6 +36,14 @@
     }
   }
 
+  &__warning {
+    .project-panel-section--is-nested & {
+      margin-top: 1rem;
+      margin-bottom: 0;
+      font-size: 0.825rem;
+    }
+  }
+
   &__step {
     position: absolute;
     left: -1.75rem;

--- a/static/src/js/components/ProjectPanels/__tests__/ProjectPanelSection.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/ProjectPanelSection.test.js
@@ -3,6 +3,7 @@ import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import ProjectPanelSection from '../ProjectPanelSection'
+import EDSCAlert from '../../EDSCAlert/EDSCAlert'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -143,6 +144,23 @@ describe('ProjectPanelSelection', () => {
       })
 
       expect(enzymeWrapper.find('.project-panel-section__intro').text()).toEqual(intro)
+    })
+  })
+
+  describe('when warning text is provided', () => {
+    test('displays an alert', () => {
+      const children = (
+        <div className="children-div">
+          children
+        </div>
+      )
+      const { enzymeWrapper } = setup({
+        warning: 'This is a test warning',
+        children
+      })
+
+      expect(enzymeWrapper.find(EDSCAlert).props().children).toEqual('This is a test warning')
+      expect(enzymeWrapper.find(EDSCAlert).props().bootstrapVariant).toEqual('warning')
     })
   })
 })

--- a/static/src/js/util/url/__tests__/projectCollections.test.js
+++ b/static/src/js/util/url/__tests__/projectCollections.test.js
@@ -151,6 +151,149 @@ describe('url#decodeUrlParams', () => {
 
     expect(decodeUrlParams('?p=!collectionId1!collectionId2&pg[1][m]=opendap&pg[1][uv]=V123456-EDSC!V987654-EDSC')).toEqual(expectedResult)
   })
+
+  describe('enable temporal subsetting flag', () => {
+    test('decodes enable temporal subsetting correctly when false', () => {
+      const expectedResult = {
+        ...emptyDecodedResult,
+        focusedCollection: '',
+        project: {
+          collections: {
+            allIds: ['collectionId1', 'collectionId2'],
+            byId: {
+              collectionId1: {
+                granules: {},
+                isVisible: true,
+                accessMethods: {
+                  harmony: {
+                    enableTemporalSubsetting: false,
+                    selectedOutputFormat: undefined,
+                    selectedOutputProjection: undefined,
+                    selectedVariables: undefined
+                  }
+                },
+                selectedAccessMethod: 'harmony'
+              },
+              collectionId2: {
+                granules: {},
+                isVisible: true,
+                selectedAccessMethod: undefined
+              }
+            }
+          }
+        },
+        query: {
+          collection: {
+            ...emptyDecodedResult.query.collection,
+            byId: {
+              collectionId1: {
+                granules: {}
+              },
+              collectionId2: {
+                granules: {}
+              }
+            }
+          }
+        }
+      }
+
+      expect(decodeUrlParams('?p=!collectionId1!collectionId2&pg[1][m]=harmony&pg[1][ets]=f')).toEqual(expectedResult)
+    })
+
+    test('decodes enable temporal subsetting correctly when true', () => {
+      const expectedResult = {
+        ...emptyDecodedResult,
+        focusedCollection: '',
+        project: {
+          collections: {
+            allIds: ['collectionId1', 'collectionId2'],
+            byId: {
+              collectionId1: {
+                granules: {},
+                isVisible: true,
+                accessMethods: {
+                  harmony: {
+                    enableTemporalSubsetting: true,
+                    selectedOutputFormat: undefined,
+                    selectedOutputProjection: undefined,
+                    selectedVariables: undefined
+                  }
+                },
+                selectedAccessMethod: 'harmony'
+              },
+              collectionId2: {
+                granules: {},
+                isVisible: true,
+                selectedAccessMethod: undefined
+              }
+            }
+          }
+        },
+        query: {
+          collection: {
+            ...emptyDecodedResult.query.collection,
+            byId: {
+              collectionId1: {
+                granules: {}
+              },
+              collectionId2: {
+                granules: {}
+              }
+            }
+          }
+        }
+      }
+
+      expect(decodeUrlParams('?p=!collectionId1!collectionId2&pg[1][m]=harmony&pg[1][ets]=t')).toEqual(expectedResult)
+    })
+
+    test('decodes enable temporal subsetting correctly when not encoded', () => {
+      const expectedResult = {
+        ...emptyDecodedResult,
+        focusedCollection: '',
+        project: {
+          collections: {
+            allIds: ['collectionId1', 'collectionId2'],
+            byId: {
+              collectionId1: {
+                granules: {},
+                isVisible: true,
+                accessMethods: {
+                  harmony: {
+                    enableTemporalSubsetting: true,
+                    selectedOutputFormat: undefined,
+                    selectedOutputProjection: undefined,
+                    selectedVariables: undefined
+                  }
+                },
+                selectedAccessMethod: 'harmony'
+              },
+              collectionId2: {
+                granules: {},
+                isVisible: true,
+                selectedAccessMethod: undefined
+              }
+            }
+          }
+        },
+        query: {
+          collection: {
+            ...emptyDecodedResult.query.collection,
+            byId: {
+              collectionId1: {
+                granules: {}
+              },
+              collectionId2: {
+                granules: {}
+              }
+            }
+          }
+        }
+      }
+
+      expect(decodeUrlParams('?p=!collectionId1!collectionId2&pg[1][m]=harmony')).toEqual(expectedResult)
+    })
+  })
 })
 
 describe('url#encodeUrlQuery', () => {
@@ -265,5 +408,35 @@ describe('url#encodeUrlQuery', () => {
     }
 
     expect(encodeUrlQuery(props)).toEqual('/path/here?p=!collectionId1!collectionId2&pg[1][v]=f&pg[1][m]=opendap&pg[1][uv]=V123456-EDSC!V987654-EDSC&pg[2][v]=f')
+  })
+
+  test('correctly encodes enable temporal subsetting', () => {
+    const props = {
+      collectionsMetadata: {
+        collectionId1: {},
+        collectionId2: {}
+      },
+      hasGranulesOrCwic: true,
+      pathname: '/path/here',
+      focusedCollection: '',
+      project: {
+        collections: {
+          allIds: ['collectionId1', 'collectionId2'],
+          byId: {
+            collectionId1: {
+              accessMethods: {
+                harmony: {
+                  enableTemporalSubsetting: false
+                }
+              },
+              selectedAccessMethod: 'harmony'
+            },
+            collectionId2: {}
+          }
+        }
+      }
+    }
+
+    expect(encodeUrlQuery(props)).toEqual('/path/here?p=!collectionId1!collectionId2&pg[1][v]=f&pg[1][m]=harmony&pg[1][ets]=f&pg[2][v]=f')
   })
 })

--- a/static/src/js/util/url/collectionsEncoders.js
+++ b/static/src/js/util/url/collectionsEncoders.js
@@ -81,6 +81,24 @@ const encodeSelectedVariables = (projectCollection) => {
   return selectedVariables.join('!')
 }
 
+const encodeTemoralSubsetting = (projectCollection) => {
+  if (!projectCollection) return null
+
+  const {
+    accessMethods,
+    selectedAccessMethod
+  } = projectCollection
+
+  if (!accessMethods || !selectedAccessMethod) return null
+
+  const selectedMethod = accessMethods[selectedAccessMethod]
+  const {
+    enableTemporalSubsetting
+  } = selectedMethod
+
+  return !!enableTemporalSubsetting
+}
+
 const encodeOutputFormat = (projectCollection) => {
   if (!projectCollection) return null
 
@@ -165,6 +183,12 @@ const decodedOutputProjection = (pgParam) => {
   const { op: outputProjection } = pgParam
 
   return outputProjection
+}
+
+const decodedTemporalSubsetting = (pgParam) => {
+  const { ts: enableTemporalSubsetting } = pgParam
+
+  return enableTemporalSubsetting
 }
 
 /**
@@ -288,6 +312,8 @@ export const encodeCollections = (props) => {
     // Encode selected output format
     pg.of = encodeOutputFormat(projectCollection)
 
+    pg.ts = encodeTemoralSubsetting(projectCollection)
+
     // Encode selected output projection
     pg.of = encodeOutputProjection(projectCollection)
 
@@ -345,6 +371,7 @@ export const decodeCollections = (params) => {
     // Project
     let addedGranuleIds = []
     let addedIsOpenSearch
+    let enableTemporalSubsetting
     let isVisible = true
     let removedGranuleIds = []
     let removedIsOpenSearch
@@ -418,6 +445,9 @@ export const decodeCollections = (params) => {
       // Decode output projection
       selectedOutputProjection = decodedOutputProjection(pCollection)
 
+      // Decode temporal subsetting
+      enableTemporalSubsetting = decodedTemporalSubsetting(pCollection)
+
       // Determine if the collection is a CWIC collection
       isOpenSearch = excludedIsOpenSearch || addedIsOpenSearch || removedIsOpenSearch
 
@@ -444,6 +474,7 @@ export const decodeCollections = (params) => {
         if (variableIds || selectedOutputFormat || selectedOutputProjection) {
           projectById[collectionId].accessMethods = {
             [selectedAccessMethod]: {
+              enableTemporalSubsetting,
               selectedOutputFormat,
               selectedOutputProjection,
               selectedVariables: variableIds


### PR DESCRIPTION
# Overview

### What is the feature?

Allows a user to disable temporal subsetting for Harmony orders

### What is the Solution?

Added a checkbox that disables temporal subsetting

### What areas of the application does this impact?

Project page

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:** C1234724470-POCLOUD

1. Add collection to project
2. Disable temporal subsetting
3. Confirm `time` parameter is not sent to Harmony and order is not subset

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
