### PR TITLE
EDSC-2460: Use CMR scrolling for granule download links

### DIFF
--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -972,6 +972,7 @@ describe('fetchLinks', () => {
       .reply(200, {
         data: {
           granules: {
+            cursor: 'mock-cursor',
             items: [
               {
                 links: [
@@ -1008,6 +1009,7 @@ describe('fetchLinks', () => {
       .reply(200, {
         data: {
           granules: {
+            cursor: 'mock-cursor',
             items: [
               {
                 links: [
@@ -1025,6 +1027,16 @@ describe('fetchLinks', () => {
         }
       })
 
+    nock(/localhost/)
+      .post(/graphql/)
+      .reply(200, {
+        data: {
+          granules: {
+            cursor: 'mock-cursor',
+            items: []
+          }
+        }
+      })
     const store = mockStore({
       authToken: 'token'
     })
@@ -1080,6 +1092,17 @@ describe('fetchLinks', () => {
       .reply(200, {
         data: {
           granules: {
+            cursor: 'mock-cursor',
+            items: null
+          }
+        }
+      })
+    nock(/localhost/)
+      .post(/graphql/)
+      .reply(200, {
+        data: {
+          granules: {
+            cursor: 'mock-cursor',
             items: null
           }
         }
@@ -1116,6 +1139,7 @@ describe('fetchLinks', () => {
         .reply(200, {
           data: {
             granules: {
+              cursor: 'mock-cursor',
               items: [
                 {
                   links: [
@@ -1159,6 +1183,7 @@ describe('fetchLinks', () => {
         .reply(200, {
           data: {
             granules: {
+              cursor: 'mock-cursor',
               items: [
                 {
                   links: [
@@ -1179,6 +1204,17 @@ describe('fetchLinks', () => {
                   ]
                 }
               ]
+            }
+          }
+        })
+
+      nock(/localhost/)
+        .post(/graphql/)
+        .reply(200, {
+          data: {
+            granules: {
+              cursor: 'mock-cursor',
+              items: []
             }
           }
         })

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1093,17 +1093,7 @@ describe('fetchLinks', () => {
         data: {
           granules: {
             cursor: 'mock-cursor',
-            items: null
-          }
-        }
-      })
-    nock(/localhost/)
-      .post(/graphql/)
-      .reply(200, {
-        data: {
-          granules: {
-            cursor: 'mock-cursor',
-            items: null
+            items: []
           }
         }
       })

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1049,6 +1049,7 @@ describe('fetchLinks', () => {
     expect(storeActions[0]).toEqual({
       payload: {
         id: 3,
+        percentDone: '50',
         links: {
           download: [
             'https://e4ftl01.cr.usgs.gov//MODV6_Dal_E/MOLT/MOD11A1.006/2000.02.24/MOD11A1.A2000055.h20v06.006.2015057071542.hdf'
@@ -1061,6 +1062,7 @@ describe('fetchLinks', () => {
     expect(storeActions[1]).toEqual({
       payload: {
         id: 3,
+        percentDone: '100',
         links: {
           download: [
             'https://e4ftl01.cr.usgs.gov//MODV6_Dal_E/MOLT/MOD11A1.006/2000.02.24/MOD11A1.A2000055.h30v12.006.2015057072109.hdf'
@@ -1205,6 +1207,7 @@ describe('fetchLinks', () => {
       expect(storeActions[0]).toEqual({
         payload: {
           id: 3,
+          percentDone: '50',
           links: {
             download: [
               'https://e4ftl01.cr.usgs.gov//MODV6_Dal_E/MOLT/MOD11A1.006/2000.02.24/MOD11A1.A2000055.h20v06.006.2015057071542.hdf'
@@ -1219,6 +1222,7 @@ describe('fetchLinks', () => {
       expect(storeActions[1]).toEqual({
         payload: {
           id: 3,
+          percentDone: '100',
           links: {
             download: [
               'https://e4ftl01.cr.usgs.gov//MODV6_Dal_E/MOLT/MOD11A1.006/2000.02.24/MOD11A1.A2000055.h30v12.006.2015057072109.hdf'

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1320,11 +1320,13 @@ describe('fetchOpendapLinks', () => {
     expect(storeActions[0]).toEqual({
       payload: {
         id: 3,
-        links: [
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
-          'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
-        ]
+        links: {
+          download: [
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
+            'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
+          ]
+        }
       },
       type: UPDATE_GRANULE_LINKS
     })
@@ -1386,11 +1388,13 @@ describe('fetchOpendapLinks', () => {
     expect(storeActions[0]).toEqual({
       payload: {
         id: 3,
-        links: [
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
-          'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
-        ]
+        links: {
+          download: [
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
+            'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
+          ]
+        }
       },
       type: UPDATE_GRANULE_LINKS
     })
@@ -1447,9 +1451,11 @@ describe('fetchOpendapLinks', () => {
     expect(storeActions[0]).toEqual({
       payload: {
         id: 3,
-        links: [
-          'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
-        ]
+        links: {
+          download: [
+            'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
+          ]
+        }
       },
       type: UPDATE_GRANULE_LINKS
     })
@@ -1504,11 +1510,13 @@ describe('fetchOpendapLinks', () => {
     expect(storeActions[0]).toEqual({
       payload: {
         id: 3,
-        links: [
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
-          'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
-          'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
-        ]
+        links: {
+          download: [
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.003.L2.RetStd.v6.0.7.0.G13075064534.hdf.nc',
+            'https://f5eil01.edn.ecs.nasa.gov/opendap/DEV01/FS2/AIRS/AIRX2RET.006/2009.01.08/AIRS.2009.01.08.004.L2.RetStd.v6.0.7.0.G13075064644.hdf.nc',
+            'https://airsl2.gesdisc.eosdis.nasa.gov/opendap/Aqua_AIRS_Level2/AIRX2RET.006/2009/008/AIRS.2009.01.08.005.L2.RetStd.v6.0.7.0.G13075064139.hdf.nc'
+          ]
+        }
       },
       type: UPDATE_GRANULE_LINKS
     })

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -237,7 +237,8 @@ export const fetchLinks = retrievalCollectionData => async (dispatch, getState) 
   let response
 
   try {
-    await Array.from(Array(totalPages)).forEachAsync(async (_, currentPage) => {
+    // Request an additional page (totalPages + 1) when scrolling to force GraphQL to clear the scroll session
+    await Array.from(Array(totalPages + 1)).forEachAsync(async (_, currentPage) => {
       response = await graphQlRequestObject.search(graphQlQuery, {
         ...preparedGranuleParams,
         limit: pageSize,

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -259,8 +259,7 @@ export const fetchLinks = retrievalCollectionData => async (dispatch, getState) 
       }
 
       if (items.length) {
-        const percentDone = (currentPage + 1) / totalPages
-        console.log('🚀 ~ file: granules.js ~ line 250 ~ .then ~ percentDone', collectionId, percentDone)
+        const percentDone = (((currentPage + 1) / totalPages) * 100).toFixed()
 
         // Fetch the download links from the granule metadata
         const granuleDownloadLinks = getDownloadUrls(items)
@@ -268,6 +267,7 @@ export const fetchLinks = retrievalCollectionData => async (dispatch, getState) 
 
         dispatch(updateGranuleLinks({
           id,
+          percentDone,
           links: {
             download: granuleDownloadLinks.map(lnk => lnk.href),
             s3: granuleS3Links.map(lnk => lnk.href)

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -376,7 +376,9 @@ export const fetchOpendapLinks = retrievalCollectionData => (dispatch, getState)
 
       dispatch(updateGranuleLinks({
         id,
-        links: items
+        links: {
+          download: items
+        }
       }))
     })
     .catch((error) => {

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -200,6 +200,7 @@ export class OrderStatusItem extends PureComponent {
       let s3Urls = []
       let totalOrders = 0
       let totalCompleteOrders = 0
+      let percentDoneDownloadLinks
       let progressPercentage = 0
       let contactName = null
       let contactEmail = null
@@ -209,10 +210,12 @@ export class OrderStatusItem extends PureComponent {
       if (isDownload) {
         progressPercentage = 100
         orderInfo = 'Download your data directly from the links below, or use the provided download script.'
+        const { links: granuleDownloadLinks = {} } = granuleLinks
         const {
           download: downloadLinks = [],
           s3: s3Links = []
-        } = granuleLinks
+        } = granuleDownloadLinks;
+        ({ percentDone: percentDoneDownloadLinks } = granuleLinks)
         if (downloadLinks.length > 0) downloadUrls = [...downloadLinks]
         if (s3Links.length > 0) s3Urls = [...s3Links]
       }
@@ -570,9 +573,10 @@ export class OrderStatusItem extends PureComponent {
                         <DownloadFilesPanel
                           accessMethodType={accessMethodType}
                           downloadLinks={downloadUrls}
-                          retrievalId={retrievalId}
                           granuleCount={granuleCount}
                           granuleLinksIsLoading={granuleLinksIsLoading}
+                          percentDoneDownloadLinks={percentDoneDownloadLinks}
+                          retrievalId={retrievalId}
                           showTextWindowActions={!isEsi}
                         />
                       </Tab>

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -223,10 +223,11 @@ export class OrderStatusItem extends PureComponent {
       if (isOpendap) {
         progressPercentage = 100
         orderInfo = 'Download your data directly from the links below, or use the provided download script.'
+        const { links: granuleDownloadLinks = {} } = granuleLinks
         const {
           download: downloadLinks = [],
           s3: s3Links = []
-        } = granuleLinks
+        } = granuleDownloadLinks
         if (downloadLinks.length > 0) downloadUrls = [...downloadLinks]
         if (s3Links.length > 0) s3Urls = [...s3Links]
       }

--- a/static/src/js/components/OrderStatus/OrderStatusItem.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.scss
@@ -289,6 +289,8 @@ $item-height: 3rem;
     font-style: italic;
     font-size: 0.825rem;
     color: $color__black--500;
+    display: block;
+    margin-bottom: 0.5rem;
   }
 
   .text-window-actions {

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { ProgressBar } from 'react-bootstrap'
 
 import { pluralize } from '../../../util/pluralize'
 import { commafy } from '../../../util/commafy'
@@ -14,14 +15,16 @@ import TextWindowActions from '../../TextWindowActions/TextWindowActions'
  * @param {String} arg0.retrievalId - The retrieval id.
  * @param {Number} arg0.granuleCount - The retrieval collection granule count.
  * @param {Boolean} arg0.granuleLinksIsLoading - A flag set when the granule links are loading.
+ * @param {Boolean} arg0.percentDoneDownloadLinks - Percentage of the download links that have been fetched.
  * @param {Boolean} arg0.showTextWindowActions - A flag set when the text window actions should be set.
 */
 export const DownloadFilesPanel = ({
   accessMethodType,
   downloadLinks,
-  retrievalId,
   granuleCount,
   granuleLinksIsLoading,
+  percentDoneDownloadLinks,
+  retrievalId,
   showTextWindowActions
 }) => {
   const downloadFileName = `${retrievalId}-${accessMethodType}.txt`
@@ -33,9 +36,17 @@ export const DownloadFilesPanel = ({
           {
             granuleLinksIsLoading
               ? `Retrieving files for ${commafy(granuleCount)} ${pluralize('granule', granuleCount)}...`
-              : `Retrieved ${downloadLinks.length} ${pluralize('file', downloadLinks.length)} for ${commafy(granuleCount)} ${pluralize('granule', granuleCount)}`
+              : `Retrieved ${commafy(downloadLinks.length)} ${pluralize('file', downloadLinks.length)} for ${commafy(granuleCount)} ${pluralize('granule', granuleCount)}`
           }
         </span>
+        {
+          percentDoneDownloadLinks && (
+            <ProgressBar
+              now={percentDoneDownloadLinks}
+              label={`${percentDoneDownloadLinks}%`}
+            />
+          )
+        }
       </div>
       <TextWindowActions
         id={`links-${retrievalId}`}
@@ -69,6 +80,7 @@ export const DownloadFilesPanel = ({
 }
 
 DownloadFilesPanel.defaultProps = {
+  percentDoneDownloadLinks: null,
   showTextWindowActions: true
 }
 
@@ -80,6 +92,7 @@ DownloadFilesPanel.propTypes = {
   retrievalId: PropTypes.string.isRequired,
   granuleCount: PropTypes.number.isRequired,
   granuleLinksIsLoading: PropTypes.bool.isRequired,
+  percentDoneDownloadLinks: PropTypes.string,
   showTextWindowActions: PropTypes.bool
 }
 

--- a/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
+import { ProgressBar } from 'react-bootstrap'
 
 import { DownloadFilesPanel } from '../DownloadFilesPanel'
 import { TextWindowActions } from '../../../TextWindowActions/TextWindowActions'
@@ -42,10 +43,13 @@ describe('DownloadFilesPanel', () => {
           retrievalId="1"
           granuleCount={10}
           granuleLinksIsLoading
+          percentDoneDownloadLinks="25"
         />
       )
 
       expect(enzymeWrapper.find('.order-status-item__tab-intro').text()).toEqual('Retrieving files for 10 granules...')
+      expect(enzymeWrapper.find(ProgressBar).props().now).toEqual('25')
+      expect(enzymeWrapper.find(ProgressBar).props().label).toEqual('25%')
 
       const windowActions = enzymeWrapper.find(TextWindowActions)
       expect(windowActions.props().id).toEqual('links-1')

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -414,6 +414,16 @@ describe('OrderStatusItem', () => {
           granule_count: 100,
           orders: [],
           isLoaded: true
+        },
+        granuleDownload: {
+          1: {
+            links: {
+              download: [
+                'http://example.com'
+              ]
+            }
+          },
+          isLoading: true
         }
       })
 
@@ -458,12 +468,12 @@ describe('OrderStatusItem', () => {
       const linksTab = tabs.childAt(0)
       expect(linksTab.props().title).toEqual('Download Files')
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
-      expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
+      expect(linksTab.childAt(0).props().downloadLinks).toEqual(['http://example.com'])
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
       expect(scriptTab.childAt(0).props().granuleCount).toEqual(100)
-      expect(scriptTab.childAt(0).props().downloadLinks).toEqual([])
+      expect(scriptTab.childAt(0).props().downloadLinks).toEqual(['http://example.com'])
     })
   })
 

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -273,6 +273,13 @@ describe('OrderStatusItem', () => {
           granule_count: 100,
           orders: [],
           isLoaded: true
+        },
+        granuleDownload: {
+          1: {
+            percentDone: '50',
+            links: []
+          },
+          isLoading: true
         }
       })
 
@@ -317,6 +324,7 @@ describe('OrderStatusItem', () => {
       const linksTab = tabs.childAt(0)
       expect(linksTab.props().title).toEqual('Download Files')
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
+      expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
 
       const scriptTab = tabs.childAt(1)

--- a/static/src/js/reducers/__tests__/granuleDownload.test.js
+++ b/static/src/js/reducers/__tests__/granuleDownload.test.js
@@ -22,6 +22,7 @@ describe('UPDATE_GRANULE_LINKS', () => {
       type: UPDATE_GRANULE_LINKS,
       payload: {
         id: 1,
+        percentDone: '100',
         links: {
           download: ['http://google.jp']
         }
@@ -30,8 +31,11 @@ describe('UPDATE_GRANULE_LINKS', () => {
 
     const expectedState = {
       1: {
-        download: ['http://google.jp'],
-        s3: []
+        percentDone: '100',
+        links: {
+          download: ['http://google.jp'],
+          s3: []
+        }
       },
       isLoaded: false,
       isLoading: false
@@ -45,6 +49,7 @@ describe('UPDATE_GRANULE_LINKS', () => {
       type: UPDATE_GRANULE_LINKS,
       payload: {
         id: 1,
+        percentDone: '100',
         links: {
           download: ['http://google.jp']
         }
@@ -53,20 +58,26 @@ describe('UPDATE_GRANULE_LINKS', () => {
 
     const initial = {
       1: {
-        download: [
-          'http://google.com'
-        ],
-        s3: []
+        percentDone: '50',
+        links: {
+          download: [
+            'http://google.com'
+          ],
+          s3: []
+        }
       }
     }
 
     const expectedState = {
       1: {
-        download: [
-          'http://google.com',
-          'http://google.jp'
-        ],
-        s3: []
+        percentDone: '100',
+        links: {
+          download: [
+            'http://google.com',
+            'http://google.jp'
+          ],
+          s3: []
+        }
       }
     }
 
@@ -79,6 +90,7 @@ describe('UPDATE_GRANULE_LINKS', () => {
         type: UPDATE_GRANULE_LINKS,
         payload: {
           id: 1,
+          percentDone: '100',
           links: {
             download: ['http://google.jp'],
             s3: ['s3://google.jp']
@@ -88,25 +100,31 @@ describe('UPDATE_GRANULE_LINKS', () => {
 
       const initial = {
         1: {
-          download: [
-            'http://google.com'
-          ],
-          s3: [
-            's3://google.com'
-          ]
+          percentDone: '50',
+          links: {
+            download: [
+              'http://google.com'
+            ],
+            s3: [
+              's3://google.com'
+            ]
+          }
         }
       }
 
       const expectedState = {
         1: {
-          download: [
-            'http://google.com',
-            'http://google.jp'
-          ],
-          s3: [
-            's3://google.com',
-            's3://google.jp'
-          ]
+          percentDone: '100',
+          links: {
+            download: [
+              'http://google.com',
+              'http://google.jp'
+            ],
+            s3: [
+              's3://google.com',
+              's3://google.jp'
+            ]
+          }
         }
       }
 

--- a/static/src/js/reducers/granuleDownload.js
+++ b/static/src/js/reducers/granuleDownload.js
@@ -8,27 +8,33 @@ const initialState = {
 const updateGranuleDownloadParamsReducer = (state = initialState, action) => {
   switch (action.type) {
     case UPDATE_GRANULE_LINKS: {
-      const { [action.payload.id]: currentLinks = {} } = state
+      const { [action.payload.id]: asdf = {} } = state
+      const { links: currentLinks = {} } = asdf
       const {
         download: currentDownloadLinks = [],
         s3: currentS3Links = []
       } = currentLinks
+
+      const { links = {}, percentDone } = action.payload
       const {
         download: newDownloadLinks = [],
         s3: newS3Links = []
-      } = action.payload.links
+      } = links
 
       return {
         ...state,
         [action.payload.id]: {
-          download: [
-            ...currentDownloadLinks,
-            ...newDownloadLinks
-          ],
-          s3: [
-            ...currentS3Links,
-            ...newS3Links
-          ]
+          percentDone,
+          links: {
+            download: [
+              ...currentDownloadLinks,
+              ...newDownloadLinks
+            ],
+            s3: [
+              ...currentS3Links,
+              ...newS3Links
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
# Overview

### What is the feature?

This PR changes the granule downloads page from sending off parallel requests with `pageNum` to using CMR's scrolling requests to fetch the granule download links. It also adds a progress bar to the `DownloadFilesPanel` component to show the user their progress while waiting to fetch all the links.