### PR TITLE
EDSC-3219: Enables temporal subsetting by default, updates package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32423,7 +32423,8 @@
         },
         "normalize-url": {
           "version": "4.5.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
           "dev": true
         },
         "p-cancelable": {
@@ -32972,7 +32973,8 @@
         },
         "normalize-url": {
           "version": "4.5.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
           "dev": true
         },
         "p-cancelable": {

--- a/serverless/src/getAccessMethods/__tests__/handler.test.js
+++ b/serverless/src/getAccessMethods/__tests__/handler.test.js
@@ -129,6 +129,7 @@ describe('getAccessMethods', () => {
       body: JSON.stringify({
         accessMethods: {
           harmony0: {
+            enableTemporalSubsetting: true,
             hierarchyMappings: [],
             id: 'umm-s-record-1',
             isValid: true,
@@ -160,6 +161,53 @@ describe('getAccessMethods', () => {
       isBase64Encoded: false,
       statusCode: 200
     })
+  })
+
+  test('sets enableTemporalSubsetting to true for harmony access methods', async () => {
+    dbTracker.on('query', (query) => {
+      query.response([])
+    })
+
+    const event = {
+      body: JSON.stringify({
+        params: {
+          collectionId: 'collectionId',
+          services: {
+            count: 1,
+            items: [{
+              conceptId: 'umm-s-record-1',
+              type: 'Harmony',
+              serviceOptions: {},
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: ['GEOTIFF', 'PNG', 'GIF']
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: ['GEOTIFF', 'PNG', 'GIF']
+              }],
+              supportedOutputProjections: [{
+                projectionAuthority: 'EPSG:4326'
+              }],
+              url: {
+                urlValue: 'https://harmony.earthdata.nas.gov'
+              }
+            }]
+          },
+          variables: {
+            count: 0,
+            items: null
+          }
+        }
+      })
+    }
+
+    const result = await getAccessMethods(event, {})
+    const { body } = result
+    const { accessMethods } = JSON.parse(body)
+    const { harmony0: harmonyAccessMethod } = accessMethods
+    const { enableTemporalSubsetting } = harmonyAccessMethod
+
+    expect(enableTemporalSubsetting).toBe(true)
   })
 
   test('populates a echoOrder method', async () => {

--- a/serverless/src/getAccessMethods/handler.js
+++ b/serverless/src/getAccessMethods/handler.js
@@ -257,6 +257,7 @@ const getAccessMethods = async (event, context) => {
         }
 
         accessMethods[`harmony${index}`] = {
+          enableTemporalSubsetting: true,
           hierarchyMappings,
           id: conceptId,
           isValid: true,

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -483,7 +483,7 @@ export class AccessMethod extends Component {
                         {
                           !(startDate || endDate) && (
                             <p className="access-method__section-status mb-0">
-                              No temporal range selected. Make a temporal selection to enable temporal subsetting.
+                              {'No temporal range selected. Make a temporal selection to enable temporal subsetting.'}
                             </p>
                           )
                         }


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes issue where, by default, a harmony order would not enable temporal subsetting

### What is the Solution?

Sets the enableTemporalSubsetting property when the access method is created

### What areas of the application does this impact?

Ordering data with a harmony access method

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** C1234724470-POCLOUD in UAT

1. Set a temporal bounds and order granules with collection C1234724470-POCLOUD
2. Confirm the project page defaults to enable temporal subsetting
3. Confirm output harmony granules are subset temporally


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
