### PR TITLE
EDSC-3245: Fixes bug when XML is parsed with incorrect granule

### DIFF
--- a/static/src/js/util/request/openSearchGranuleRequest.js
+++ b/static/src/js/util/request/openSearchGranuleRequest.js
@@ -113,6 +113,10 @@ export default class OpenSearchGranuleRequest extends Request {
       const granuleResults = [].concat(entry)
 
       granuleResults.map((granule) => {
+        // Sometimes parseXml is returning a granule as "" when there should be no data.
+        // Return undefined if granule doesn't exist then filter granuleResults below
+        if (!granule) return undefined
+
         const updatedGranule = granule
 
         updatedGranule.isOpenSearch = true
@@ -214,7 +218,7 @@ export default class OpenSearchGranuleRequest extends Request {
 
       return {
         feed: {
-          entry: granuleResults,
+          entry: granuleResults.filter(Boolean),
           hits: totalResults
         }
       }


### PR DESCRIPTION
# Overview

### What is the feature?

`fast-xml-parser` is parsing the OpenSearchGranule search response and adding an extra value to the end of the `entry` array, which is being returned as an empty string instead of an object. This fix accounts for that and removes the processing from that array item

I was not able to figure out why the xml parser is returning that data. As far as I could tell everything looks good in the XML

To replicate: https://search.earthdata.nasa.gov/search/granules?p=C1597990351-NOAA_NCEI&pg[0][v]=f&pg[0][gsk]=-start_date&q=C1597990351-NOAA_NCEI&tl=1629128131!3!!&m=-0.0703125!0!2!1!0!0%2C2
