### PR TITLE
EDSC-3252: Fixes granule outlines when the granule has a polygon bordering the antimeridian

### DIFF
--- a/static/src/js/util/map/geo.js
+++ b/static/src/js/util/map/geo.js
@@ -392,7 +392,7 @@ export const dividePolygon = (latlngs) => {
   let end
   let j
   const interiors = []
-  const boundaries = []
+  let boundaries = []
   const holes = []
 
   // Handle a list containing holes
@@ -551,10 +551,11 @@ export const dividePolygon = (latlngs) => {
         }
       }
 
+      // If we needed to insert points at the antimeridian, and
       // If we joined the east and west side of the polygon by going across the pole
       // above, we want to keep adding to our current interior shape.  Otherwise,
       // we're stopping the interior at the antimeridian and adding it to our list.
-      if (!hasPole) {
+      if (hasInsertions && !hasPole) {
         if (!dir || (dir === (latlng.lng - next.lng))) {
           // We're crossing in the same direction we crossed last time, so the shape isn't complete
           interiorStack.push(interior)
@@ -592,6 +593,9 @@ export const dividePolygon = (latlngs) => {
     }
     interiors.unshift(interior)
   }
+
+  // If we didn't need to insert points at the antimeridian, boundries should match interiors
+  if (!hasInsertions) boundaries = interiors
 
   return {
     interiors,


### PR DESCRIPTION
# Overview

### What is the feature?

Granules that have multiple polygons already split on the antimeridian were not being drawn correctly on the map.

### What is the Solution?

The code we have to handle spatial crossing the antimeridian assumed any points on the antimeridian were added by our earlier code. Using the `hasInsertions` variable we are able to ignore the logic when the spatial itself runs along the antimeridian

### What areas of the application does this impact?

Granule drawing on the map

# Testing

Viewing the problem [here](https://search.uat.earthdata.nasa.gov/search/granules?p=C1238538219-POCLOUD&pg[0][v]=f&pg[0][id]=S6A_P4_1B_HR______20210818T002624_20210818T012237_20210818T164734_3373_028_145_072_EUM__OPE_ST_F03.SEN6&pg[0][gsk]=-start_date&tl=1629906614.793!3!!&m=-53.72767434562516!-236.638916015625!0!1!0!0%2C2),

and the working code locally [here](http://localhost:8080/search/granules?p=C1238538219-POCLOUD&pg[0][v]=f&pg[0][id]=S6A_P4_1B_HR______20210818T002624_20210818T012237_20210818T164734_3373_028_145_072_EUM__OPE_ST_F03.SEN6&pg[0][gsk]=-start_date&ee=uat&q=C1238538219-POCLOUD&tl=1634737273!3!!&m=-56.291275007094214!135.984375!3!1!0!0%2C2)