### PR TITLE
EDSC-3060: Fixes drawing cartesian bounding boxes on hover

### DIFF
--- a/static/src/js/util/map/__tests__/layers.test.js
+++ b/static/src/js/util/map/__tests__/layers.test.js
@@ -225,8 +225,8 @@ describe('layers util', () => {
     })
 
     describe('with polygon spatial', () => {
-      test('returns a sphericalPolygon layer when polygon spatial is cartesian', () => {
-        const sphericalPolygonMock = jest.spyOn(L, 'sphericalPolygon').mockImplementation(point => ({ ...point }))
+      test('returns a polygon layer when polygon spatial is cartesian', () => {
+        const polygon = jest.spyOn(L, 'polygon').mockImplementation(point => ({ ...point }))
 
         const metadata = {
           coordinateSystem: 'CARTESIAN',
@@ -235,8 +235,8 @@ describe('layers util', () => {
 
         buildLayer({}, metadata)
 
-        expect(sphericalPolygonMock).toBeCalledTimes(1)
-        expect(sphericalPolygonMock).toBeCalledWith([
+        expect(polygon).toBeCalledTimes(1)
+        expect(polygon).toBeCalledWith([
           [
             { lat: -10, lng: -162.4683 },
             { lat: -10.013, lng: -151.7155 },

--- a/static/src/js/util/map/layers.js
+++ b/static/src/js/util/map/layers.js
@@ -115,7 +115,7 @@ export const buildLayer = (options, metadata) => {
     castArray(polygons).forEach((polygon) => {
       let polyLayer
       if (cartesian) {
-        polyLayer = new L.sphericalPolygon(polygon)
+        polyLayer = new L.polygon(polygon)
         polyLayer._interpolationFn = 'cartesian'
       } else {
         polyLayer = new L.sphericalPolygon(polygon, options)


### PR DESCRIPTION
# Overview

### What is the feature?

For granules that have a cartesian bounding box, when hovering or selecting a granule, the horizontal bounding box lines follow great circle arcs, meaning it's drawing a geodetic bounding box.

### What is the Solution?

For bounding boxes using a cartesian coordinate system, use L.polygon instead of our custom L.sphericalPolygon

### What areas of the application does this impact?

Drawing granules on the map

# Testing

### Reproduction steps

In UAT, this collection has cartesian bounding box spatial, C1233860183-EEDTEST