### PR TITLE
EDSC-3303: Fixes bug with loading pages in portals

### DIFF
--- a/static/src/js/actions/__tests__/urlQuery.test.js
+++ b/static/src/js/actions/__tests__/urlQuery.test.js
@@ -450,6 +450,163 @@ describe('changePath', () => {
       })
     })
   })
+
+  describe('when a portal path is provided', () => {
+    describe('when the path matches granule search', () => {
+      test('calls getFocusedCollection action', () => {
+        const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+        const getFocusedCollectionMock = jest.spyOn(actions, 'getFocusedCollection').mockImplementation(() => jest.fn())
+
+        const newPath = '/portal/fakeportal/search/granules?p=C00001-EDSC'
+
+        const store = mockStore({
+          earthdataEnvironment: 'prod',
+          project: {
+            collections: {
+              allIds: [],
+              byId: {}
+            }
+          },
+          providers: [],
+          query: {
+            collection: {
+              spatial: {}
+            }
+          },
+          router: {
+            location: {
+              pathname: '/search'
+            }
+          },
+          timeline: {
+            query: {}
+          }
+        })
+
+        store.dispatch(urlQuery.changePath(newPath))
+
+        expect(getCollectionsMock).toBeCalledTimes(1)
+        expect(getFocusedCollectionMock).toBeCalledTimes(1)
+      })
+    })
+
+    describe('when the path matches collection details', () => {
+      test('calls getFocusedCollection action', () => {
+        const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+        const getFocusedCollectionMock = jest.spyOn(actions, 'getFocusedCollection').mockImplementation(() => jest.fn())
+
+        const newPath = '/portal/fakeportal/search/granules/collection-details?p=C00001-EDSC'
+
+        const store = mockStore({
+          earthdataEnvironment: 'prod',
+          project: {
+            collections: {
+              allIds: [],
+              byId: {}
+            }
+          },
+          providers: [],
+          query: {
+            collection: {
+              spatial: {}
+            }
+          },
+          router: {
+            location: {
+              pathname: '/search'
+            }
+          },
+          timeline: {
+            query: {}
+          }
+        })
+
+        store.dispatch(urlQuery.changePath(newPath))
+
+        expect(getCollectionsMock).toBeCalledTimes(1)
+        expect(getFocusedCollectionMock).toBeCalledTimes(1)
+      })
+    })
+
+    describe('when the path matches subscription list', () => {
+      test('calls getFocusedCollection action', () => {
+        const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+        const getFocusedCollectionMock = jest.spyOn(actions, 'getFocusedCollection').mockImplementation(() => jest.fn())
+
+        const newPath = '/portal/fakeportal/search/granules/subscriptions?p=C00001-EDSC'
+
+        const store = mockStore({
+          earthdataEnvironment: 'prod',
+          project: {
+            collections: {
+              allIds: [],
+              byId: {}
+            }
+          },
+          providers: [],
+          query: {
+            collection: {
+              spatial: {}
+            }
+          },
+          router: {
+            location: {
+              pathname: '/search'
+            }
+          },
+          timeline: {
+            query: {}
+          }
+        })
+
+        store.dispatch(urlQuery.changePath(newPath))
+
+        expect(getCollectionsMock).toBeCalledTimes(1)
+        expect(getFocusedCollectionMock).toBeCalledTimes(1)
+      })
+    })
+
+    describe('when the path matches granule details', () => {
+      test('calls getFocusedCollection action', () => {
+        const getCollectionsMock = jest.spyOn(actions, 'getCollections').mockImplementation(() => jest.fn())
+        const getFocusedCollectionMock = jest.spyOn(actions, 'getFocusedCollection').mockImplementation(() => jest.fn())
+        const getFocusedGranuleMock = jest.spyOn(actions, 'getFocusedGranule').mockImplementation(() => jest.fn())
+
+        const newPath = '/portal/fakeportal/search/granules/granule-details?p=C00001-EDSC'
+
+        const store = mockStore({
+          earthdataEnvironment: 'prod',
+          focusedGranule: 'G00001-EDSC',
+          project: {
+            collections: {
+              allIds: [],
+              byId: {}
+            }
+          },
+          providers: [],
+          query: {
+            collection: {
+              spatial: {}
+            }
+          },
+          router: {
+            location: {
+              pathname: '/search'
+            }
+          },
+          timeline: {
+            query: {}
+          }
+        })
+
+        store.dispatch(urlQuery.changePath(newPath))
+
+        expect(getCollectionsMock).toBeCalledTimes(1)
+        expect(getFocusedCollectionMock).toBeCalledTimes(1)
+        expect(getFocusedGranuleMock).toBeCalledTimes(1)
+      })
+    })
+  })
 })
 
 describe('changeUrl', () => {

--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -138,22 +138,34 @@ export const changePath = (path = '') => async (dispatch, getState) => {
     dispatch(actions.getCollections())
 
     // Granules Search
-    if (pathname === '/search/granules') {
+    if (
+      pathname === '/search/granules'
+      || pathname.match(/\/portal\/\w*\/search\/granules$/)
+    ) {
       dispatch(actions.getFocusedCollection())
     }
 
     // Collection Details
-    if (pathname === '/search/granules/collection-details') {
+    if (
+      pathname === '/search/granules/collection-details'
+      || pathname.match(/\/portal\/\w*\/search\/granules\/collection-details$/)
+    ) {
       dispatch(actions.getFocusedCollection())
     }
 
     // Subscription Details
-    if (pathname === '/search/granules/subscriptions') {
+    if (
+      pathname === '/search/granules/subscriptions'
+      || pathname.match(/\/portal\/\w*\/search\/granules\/subscriptions$/)
+    ) {
       dispatch(actions.getFocusedCollection())
     }
 
     // Granule Details
-    if (pathname === '/search/granules/granule-details') {
+    if (
+      pathname === '/search/granules/granule-details'
+      || pathname.match(/\/portal\/\w*\/search\/granules\/granule-details$/)
+    ) {
       dispatch(actions.getFocusedCollection())
 
       dispatch(actions.getFocusedGranule())


### PR DESCRIPTION
Loading pages like `/search/granules` in portals was not accounting for the portal section of the url so it wasn't calling the necessary actions to load the data needed on each page.