### PR TITLE
EDSC-3296: Display consortiums

### DIFF
--- a/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
@@ -421,8 +421,11 @@ export const CollectionDetailsBody = ({
           </div>
           <div className="row collection-details-body__row">
             {
-              !!(dataCenters && dataCenters.length) && (
-                <ul className="col collection-details-body__provider-list" data-test-id="collection-details-body__provider-list">
+              dataCenters && dataCenters.length > 0 && (
+                <ul
+                  className="col collection-details-body__provider-list"
+                  data-test-id="collection-details-body__provider-list"
+                >
                   {
                     dataCenters.map((dataCenter, i) => {
                       const key = `data_center_${i}`

--- a/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsBody.js
@@ -421,7 +421,7 @@ export const CollectionDetailsBody = ({
           </div>
           <div className="row collection-details-body__row">
             {
-              dataCenters.length && (
+              !!(dataCenters && dataCenters.length) && (
                 <ul className="col collection-details-body__provider-list" data-test-id="collection-details-body__provider-list">
                   {
                     dataCenters.map((dataCenter, i) => {

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.js
@@ -41,6 +41,7 @@ export const CollectionResultsItem = forwardRef(({
   onViewCollectionGranules
 }, ref) => {
   const {
+    consortiums = [],
     collectionId,
     datasetId,
     summary,
@@ -69,6 +70,21 @@ export const CollectionResultsItem = forwardRef(({
   } = thumbnailSize
 
   const customizeBadges = []
+
+  const consortiumMeta = {
+    GEOSS: 'Global Earth Observation System of Systems',
+    CWIC: 'CEOS WGISS Integrated Catalog',
+    FEDEO: 'Federated EO Gateway',
+    CEOS: 'Committee on Earth Observation Satellites'
+  }
+
+  const getConsortiumTooltipText = (consortium) => {
+    let tooltip = ''
+    if (consortiumMeta[consortium]) tooltip = consortiumMeta[consortium]
+    return tooltip
+  }
+
+  const filteredConsortiums = consortiums.filter(consortium => consortium !== 'EOSDIS')
 
   const popperOffset = {
     modifiers: [{
@@ -320,24 +336,46 @@ export const CollectionResultsItem = forwardRef(({
           </div>
           <div className="collection-results-item__body-secondary">
             {
-              isOpenSearch && (
-                <OverlayTrigger
-                  placement="top"
-                  overlay={(
-                    <Tooltip
-                      id="tooltip__quic-badge"
-                      className="collection-results-item__badge-tooltip"
-                    >
-                      Int&apos;l / Interagency Data
-                    </Tooltip>
-                  )}
+              !!(filteredConsortiums && filteredConsortiums.length) && (
+                <Badge
+                  className="collection-results-item__badge collection-results-item__badge--external-broker"
+                  variant="secondary"
                 >
-                  <Badge
-                    className="collection-results-item__badge collection-results-item__badge--cwic"
-                  >
-                    CWIC
-                  </Badge>
-                </OverlayTrigger>
+                  <ul className="collection-results-item__badge-list">
+                    {
+                      filteredConsortiums.map((consortium) => {
+                        let consortiumDisplay = consortium
+                        const consortiumTooltip = getConsortiumTooltipText(consortium)
+
+                        if (consortiumTooltip) {
+                          consortiumDisplay = (
+                            <OverlayTrigger
+                              placement="top"
+                              overlay={(
+                                <Tooltip
+                                  className={`collection-results-item__badge-tooltip collection-results-item__badge-tooltip--${consortium}`}
+                                >
+                                  {consortiumTooltip}
+                                </Tooltip>
+                              )}
+                            >
+                              <span className="collection-results-item__badge-list-text">{consortiumDisplay}</span>
+                            </OverlayTrigger>
+                          )
+                        }
+
+                        return (
+                          <li
+                            key={`${collectionId}__consortium--${consortium}`}
+                            className="collection-results-item__badge-list-item"
+                          >
+                            {consortiumDisplay}
+                          </li>
+                        )
+                      })
+                    }
+                  </ul>
+                </Badge>
               )
             }
             {

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.js
@@ -336,7 +336,7 @@ export const CollectionResultsItem = forwardRef(({
           </div>
           <div className="collection-results-item__body-secondary">
             {
-              !!(filteredConsortiums && filteredConsortiums.length) && (
+              filteredConsortiums && filteredConsortiums.length > 0 && (
                 <Badge
                   className="collection-results-item__badge collection-results-item__badge--external-broker"
                   variant="secondary"

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.scss
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.scss
@@ -193,6 +193,33 @@
     }
   }
 
+  &__badge-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: row;
+  }
+
+  &__badge-list-text {
+    display: inline-block;
+  }
+
+  &__badge-list-item {
+    &:after {
+      display: inline-block;
+      content: '•';
+      margin-left: 0.125rem;
+      margin-right: 0.125rem;
+    }
+
+    &:last-child {
+      &:after {
+        display: none;
+      }
+    }
+  }
+
   &__badge-icon {
     margin-right: 0.25rem;
     position: relative;
@@ -208,7 +235,7 @@
     text-transform: none;
   }
 
-  &__badge--cwic {
+  &__badge--external-broker {
     background-color: $color__yellow;
   }
 

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsBody.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsBody.test.js
@@ -20,6 +20,7 @@ function setup(overrideProps) {
     },
     collectionsMetadata: {
       collectionId: {
+        consortiums: [],
         summary: 'test summary',
         datasetId: 'test dataset id',
         granuleCount: 42,

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.js
@@ -112,7 +112,7 @@ describe('CollectionResultsList component', () => {
     test('renders a cwic collection correctly', () => {
       const { enzymeWrapper } = setup({
         collectionMetadata: {
-          ...collectionListItemProps.collection,
+          ...collectionListItemProps.collectionMetadata,
           isOpenSearch: true
         }
       })
@@ -123,7 +123,7 @@ describe('CollectionResultsList component', () => {
     test('renders single granule correctly', () => {
       const { enzymeWrapper } = setup({
         collectionMetadata: {
-          ...collectionListItemProps.collection,
+          ...collectionListItemProps.collectionMetadata,
           granuleCount: 1
         }
       })
@@ -134,7 +134,7 @@ describe('CollectionResultsList component', () => {
     test('renders no granules correctly', () => {
       const { enzymeWrapper } = setup({
         collectionMetadata: {
-          ...collectionListItemProps.collection,
+          ...collectionListItemProps.collectionMetadata,
           granuleCount: 0
         }
       })
@@ -152,7 +152,7 @@ describe('CollectionResultsList component', () => {
       test('with no end time', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             temporalRange: '2010-10-10 ongoing'
           }
         })
@@ -163,7 +163,7 @@ describe('CollectionResultsList component', () => {
       test('with no start time', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             temporalRange: 'Up to 2011-10-10'
           }
         })
@@ -199,35 +199,191 @@ describe('CollectionResultsList component', () => {
       })
     })
 
-    describe('cwic badge', () => {
-      test('does not render when isOpenSearch is not set', () => {
+    describe('consortium badge', () => {
+      test('does not render when the consortium is not set', () => {
         const { enzymeWrapper } = setup()
         expect(enzymeWrapper.find('.collection-results-item__badge--cwic').length).toEqual(0)
       })
 
-      describe('renders correctly when set', () => {
+      describe('with a single consortium', () => {
+        describe('renders correctly when set', () => {
+          test('renders the badge correctly', () => {
+            const { enzymeWrapper } = setup({
+              collectionMetadata: {
+                ...collectionListItemProps.collectionMetadata,
+                consortiums: ['CWIC']
+              }
+            })
+  
+            const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+            expect(overlayWrapper.length).toEqual(1)
+            const overlay = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+            expect(overlay.text()).toEqual('CWIC')
+          })
+  
+          test('renders a tooltip correctly', () => {
+            const { enzymeWrapper } = setup({
+              collectionMetadata: {
+                ...collectionListItemProps.collectionMetadata,
+                consortiums: ['CWIC']
+              }
+            })
+  
+            const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+            const overlayText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+            expect(overlayText).toEqual('CEOS WGISS Integrated Catalog')
+          })
+        })
+      })
+
+      describe('with a multiple consortiums', () => {
+        describe('renders correctly when set', () => {
+          test('renders the badge correctly', () => {
+            const { enzymeWrapper } = setup({
+              collectionMetadata: {
+                ...collectionListItemProps.collectionMetadata,
+                consortiums: ['CWIC', 'GEOSS']
+              }
+            })
+  
+            const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+            expect(overlayWrapper.length).toEqual(1)
+            const consortiumOne = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+            const consortiumTwo = shallow(shallow(overlayWrapper.props().children.props.children[1]).props().children).childAt(0).childAt(0)
+            expect(consortiumOne.text()).toEqual('CWIC')
+            expect(consortiumTwo.text()).toEqual('GEOSS')
+          })
+  
+          test('renders a tooltips correctly', () => {
+            const { enzymeWrapper } = setup({
+              collectionMetadata: {
+                ...collectionListItemProps.collectionMetadata,
+                consortiums: ['CWIC', 'GEOSS']
+              }
+            })
+  
+            const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+            const overlayOneText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+            const overlayTwoText = shallow(shallow(overlay.props().children.props.children[1]).props().children).childAt(1).childAt(0).text()
+            expect(overlayOneText).toEqual('CEOS WGISS Integrated Catalog')
+            expect(overlayTwoText).toEqual('Global Earth Observation System of Systems')
+          })
+        })
+      })
+
+      describe('when CWIC is defined', () => {
         test('renders the badge correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
-              isOpenSearch: true
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['CWIC']
             }
           })
-          expect(enzymeWrapper.find('.collection-results-item__badge--cwic').length).toEqual(1)
-          expect(enzymeWrapper.find('.collection-results-item__badge--cwic').text()).toEqual('CWIC')
+
+          const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          expect(overlayWrapper.length).toEqual(1)
+          const overlay = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+          expect(overlay.text()).toEqual('CWIC')
         })
 
         test('renders a tooltip correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
-              isOpenSearch: true
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['CWIC']
             }
           })
 
-          const tooltipProps = enzymeWrapper.find(OverlayTrigger).props().overlay.props
-          expect(enzymeWrapper.find(OverlayTrigger).length).toEqual(1)
-          expect(tooltipProps.children).toEqual('Int\'l / Interagency Data')
+          const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          const overlayText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+          expect(overlayText).toEqual('CEOS WGISS Integrated Catalog')
+        })
+      })
+
+      describe('when GEOSS is defined', () => {
+        test('renders the badge correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['GEOSS']
+            }
+          })
+
+          const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          expect(overlayWrapper.length).toEqual(1)
+          const overlay = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+          expect(overlay.text()).toEqual('GEOSS')
+        })
+
+        test('renders a tooltip correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['GEOSS']
+            }
+          })
+
+          const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          const overlayText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+          expect(overlayText).toEqual('Global Earth Observation System of Systems')
+        })
+      })
+
+      describe('when FEDEO is defined', () => {
+        test('renders the badge correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['FEDEO']
+            }
+          })
+
+          const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          expect(overlayWrapper.length).toEqual(1)
+          const overlay = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+          expect(overlay.text()).toEqual('FEDEO')
+        })
+
+        test('renders a tooltip correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['FEDEO']
+            }
+          })
+
+          const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          const overlayText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+          expect(overlayText).toEqual('Federated EO Gateway')
+        })
+      })
+
+      describe('when CEOS is defined', () => {
+        test('renders the badge correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['CEOS']
+            }
+          })
+
+          const overlayWrapper = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          expect(overlayWrapper.length).toEqual(1)
+          const overlay = shallow(shallow(overlayWrapper.props().children.props.children[0]).props().children).childAt(0).childAt(0)
+          expect(overlay.text()).toEqual('CEOS')
+        })
+
+        test('renders a tooltip correctly', () => {
+          const { enzymeWrapper } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              consortiums: ['CEOS']
+            }
+          })
+
+          const overlay = enzymeWrapper.find('.collection-results-item__badge--external-broker')
+          const overlayText = shallow(shallow(overlay.props().children.props.children[0]).props().children).childAt(1).childAt(0).text()
+          expect(overlayText).toEqual('Committee on Earth Observation Satellites')
         })
       })
     })
@@ -242,7 +398,7 @@ describe('CollectionResultsList component', () => {
         test('renders the badge correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
+              ...collectionListItemProps.collectionMetadata,
               isCSDA: true
             }
           })
@@ -253,7 +409,7 @@ describe('CollectionResultsList component', () => {
         test('renders a tooltip correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
+              ...collectionListItemProps.collectionMetadata,
               isCSDA: true
             }
           })
@@ -276,7 +432,7 @@ describe('CollectionResultsList component', () => {
         test('renders the badge correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
+              ...collectionListItemProps.collectionMetadata,
               hasMapImagery: true
             }
           })
@@ -287,7 +443,7 @@ describe('CollectionResultsList component', () => {
         test('renders a tooltip correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
+              ...collectionListItemProps.collectionMetadata,
               hasMapImagery: true
             }
           })
@@ -309,7 +465,7 @@ describe('CollectionResultsList component', () => {
         test('renders the badge correctly', () => {
           const { enzymeWrapper } = setup({
             collectionMetadata: {
-              ...collectionListItemProps.collection,
+              ...collectionListItemProps.collectionMetadata,
               isNrt: true
             }
           })
@@ -321,7 +477,7 @@ describe('CollectionResultsList component', () => {
       test('renders a tooltip correctly', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             isNrt: true
           }
         })
@@ -335,7 +491,7 @@ describe('CollectionResultsList component', () => {
     describe('customize badge', () => {
       test('does not render when no customization flags are true', () => {
         const { enzymeWrapper } = setup({
-          collection: collectionListItemProps.collection
+          collection: collectionListItemProps.collectionMetadata
         })
         expect(enzymeWrapper.find('.collection-results-item__badge--customizable').length).toEqual(0)
       })
@@ -343,7 +499,7 @@ describe('CollectionResultsList component', () => {
       describe('spatial subsetting icon', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             hasSpatialSubsetting: true
           }
         })
@@ -370,7 +526,7 @@ describe('CollectionResultsList component', () => {
       describe('variables icon', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             hasVariables: true
           }
         })
@@ -397,7 +553,7 @@ describe('CollectionResultsList component', () => {
       describe('transforms icon', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             hasTransforms: true
           }
         })
@@ -424,7 +580,7 @@ describe('CollectionResultsList component', () => {
       describe('formats icon', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             hasFormats: true
           }
         })
@@ -451,7 +607,7 @@ describe('CollectionResultsList component', () => {
       describe('temporal subsetting icon', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
-            ...collectionListItemProps.collection,
+            ...collectionListItemProps.collectionMetadata,
             hasTemporalSubsetting: true
           }
         })
@@ -498,7 +654,7 @@ describe('CollectionResultsList component', () => {
     test('shows the remove button when the collection is in the project', () => {
       const { enzymeWrapper } = setup({
         collectionMetadata: {
-          ...collectionListItemProps.collection,
+          ...collectionListItemProps.collectionMetadata,
           isCollectionInProject: true
         }
       })
@@ -509,7 +665,7 @@ describe('CollectionResultsList component', () => {
     test('clicking the button removes the collection from the project', () => {
       const { enzymeWrapper, props } = setup({
         collectionMetadata: {
-          ...collectionListItemProps.collection,
+          ...collectionListItemProps.collectionMetadata,
           isCollectionInProject: true
         }
       })

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsListItem.test.js
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsListItem.test.js
@@ -13,6 +13,7 @@ const defaultProps = {
   data: {
     collectionsMetadata: [{
       collectionId: 'collectionId1',
+      consortiums: [],
       datasetId: 'Test Collection',
       description: 'This is a short summary.',
       displayOrganization: 'TESTORG',

--- a/static/src/js/components/CollectionResults/__tests__/mocks.js
+++ b/static/src/js/components/CollectionResults/__tests__/mocks.js
@@ -2,6 +2,7 @@ export const collectionListItemProps = {
   collectionMetadata: {
     summary: 'This is a short summary.',
     collectionId: 'collectionId1',
+    consortiums: [],
     datasetId: 'Test Collection',
     displayOrganization: 'TESTORG',
     granuleCount: 10,
@@ -30,6 +31,7 @@ export const longSummary = 'Lorem ipsum dolor sit amet, consectetur adipiscing e
 export const collectionResultsBodyData = {
   summary: 'test summary',
   collectionId: 'collectionId',
+  consortiums: [], 
   datasetId: 'test dataset id',
   displayOrganization: 'test/org',
   granuleCount: 42,

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -195,7 +195,7 @@ class SearchPanels extends PureComponent {
     } = collectionMetadata
 
     // Do not display the international/interagency data message for EOSDIS or CWIC collections
-    const displayConsortiums = consortiums.filter(consortium => consortium !== 'EOSDIS' && consortium !== 'GEOSS')
+    const isInternationalInteragency = consortiums.filter(consortium => consortium !== 'EOSDIS' && consortium !== 'GEOSS').length > 0
 
     const { title: granuleTitle = '' } = granuleMetadata
 
@@ -410,14 +410,14 @@ class SearchPanels extends PureComponent {
 
     let consortiumInfo = null
 
-    if (displayConsortiums && displayConsortiums.length) {
+    if (isInternationalInteragency) {
       consortiumInfo = (
         <Col className="search-panels__note">
           {'This is '}
           <span className="search-panels__note-emph search-panels__note-emph--opensearch">Int&apos;l / Interagency Data</span>
           {' data. Searches will be performed by external services which may vary in performance and available features. '}
           {
-            displayConsortiums.indexOf('CWIC') > -1 && (
+            collectionIsOpenSearch && (
               <Button
                 className="search-panels__header-message-link"
                 onClick={() => onToggleAboutCwicModal(true)}

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -187,11 +187,15 @@ class SearchPanels extends PureComponent {
     const { panelState } = preferences
 
     const {
+      consortiums = [],
       hasAllMetadata: hasAllCollectionMetadata = false,
       title: collectionTitle = '',
       isCSDA: collectionIsCSDA,
       isOpenSearch: collectionIsOpenSearch
     } = collectionMetadata
+
+    // Do not display the international/interagency data message for EOSDIS or CWIC collections
+    const displayConsortiums = consortiums.filter(consortium => consortium !== 'EOSDIS' && consortium !== 'GEOSS')
 
     const { title: granuleTitle = '' } = granuleMetadata
 
@@ -404,6 +408,32 @@ class SearchPanels extends PureComponent {
       </PanelGroup>
     )
 
+    let consortiumInfo = null
+
+    if (displayConsortiums && displayConsortiums.length) {
+      consortiumInfo = (
+        <Col className="search-panels__note">
+          {'This is '}
+          <span className="search-panels__note-emph search-panels__note-emph--opensearch">Int&apos;l / Interagency Data</span>
+          {' data. Searches will be performed by external services which may vary in performance and available features. '}
+          {
+            displayConsortiums.indexOf('CWIC') > -1 && (
+              <Button
+                className="search-panels__header-message-link"
+                onClick={() => onToggleAboutCwicModal(true)}
+                variant="link"
+                bootstrapVariant="link"
+                icon={FaQuestionCircle}
+                label="More details"
+              >
+                More Details
+              </Button>
+            )
+          }
+        </Col>
+      )
+    }
+
     panelSection.push(
       <PanelGroup
         key="granule-results-panel"
@@ -411,25 +441,7 @@ class SearchPanels extends PureComponent {
         handoffLinks={handoffLinks}
         headerMessage={(
           <>
-            {
-              collectionIsOpenSearch && (
-                <Col className="search-panels__note">
-                  {'This is '}
-                  <span className="search-panels__note-emph search-panels__note-emph--opensearch">Int&apos;l / Interagency Data</span>
-                  {' data. Searches will be performed by external services which may vary in performance and available features. '}
-                  <Button
-                    className="search-panels__header-message-link"
-                    onClick={() => onToggleAboutCwicModal(true)}
-                    variant="link"
-                    bootstrapVariant="link"
-                    icon={FaQuestionCircle}
-                    label="More details"
-                  >
-                    More Details
-                  </Button>
-                </Col>
-              )
-            }
+            {consortiumInfo}
             {
               collectionIsCSDA && (
                 <Col className="search-panels__note">

--- a/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
+++ b/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
@@ -522,7 +522,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
 
         expect(granuleResultsPanelProps.headerMessage.props.children).toEqual([
-          false,
+          null,
           false
         ])
       })
@@ -546,65 +546,206 @@ describe('SearchPanels component', () => {
         expect(granuleResultsPanelProps.secondaryHeading.props.className).toContain('badge--purple')
         expect(granuleResultsPanelProps.secondaryHeading.props.children[1]).toEqual('CSDA')
       })
+
+      test('displays a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCSDA: true,
+            isOpenSearch: false
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+  
+        expect(messageProps.className).toEqual('search-panels__note')
+        expect(shallow(messageProps.children[1]).text()).toContain('NASA Commercial Smallsat Data Acquisition (CSDA) Program')
+      })
+  
+      test('displays a link to open a modal for more information', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCSDA: true,
+            isOpenSearch: false
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+  
+        expect(shallow(messageProps.children[3]).text()).toContain('More Details')
+      })
+
+      describe('when the modal button is clicked', () => {
+        test('opens the modal', () => {
+          const { enzymeWrapper, props } = setup({
+            collectionMetadata: {
+              hasAllMetadata: true,
+              title: 'Collection Title',
+              isCSDA: true,
+              isOpenSearch: false
+            }
+          }, '/search/granules')
+          const panels = enzymeWrapper.find(Panels)
+          const granuleResultsPanel = panels.find(PanelGroup).at(1)
+          const granuleResultsPanelProps = granuleResultsPanel.props()
+          const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+    
+          const moreDetailsButton = shallow(messageProps.children[3])
+    
+          moreDetailsButton.simulate('click')
+    
+          expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
+          expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
+        })
+      })
     })
 
-    test('displays a header message', () => {
-      const { enzymeWrapper } = setup({
-        collectionMetadata: {
-          hasAllMetadata: true,
-          title: 'Collection Title',
-          isCSDA: true,
-          isOpenSearch: false
-        }
-      }, '/search/granules')
-      const panels = enzymeWrapper.find(Panels)
-      const granuleResultsPanel = panels.find(PanelGroup).at(1)
-      const granuleResultsPanelProps = granuleResultsPanel.props()
-      const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+    describe('on a CWIC collection', () => {
+      test('displays a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            title: 'Collection Title',
+            isCSDA: false,
+            isOpenSearch: false,
+            consortiums: ['CWIC']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+  
+        expect(messageProps.className).toEqual('search-panels__note')
+        expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
+      })
 
-      expect(messageProps.className).toEqual('search-panels__note')
-      expect(shallow(messageProps.children[1]).text()).toContain('NASA Commercial Smallsat Data Acquisition (CSDA) Program')
+      test('displays a link to open a modal for more information', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['CWIC']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+  
+        expect(shallow(messageProps.children[3]).text()).toContain('More Details')
+      })
+  
+      describe('when the modal button is clicked', () => {
+        test('opens the modal', () => {
+          const { enzymeWrapper, props } = setup({
+            collectionMetadata: {
+              hasAllMetadata: true,
+              consortiums: ['CWIC']
+            }
+          }, '/search/granules')
+          const panels = enzymeWrapper.find(Panels)
+          const granuleResultsPanel = panels.find(PanelGroup).at(1)
+          const granuleResultsPanelProps = granuleResultsPanel.props()
+          const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+          const moreDetailsButton = shallow(messageProps.children[3])
+    
+          moreDetailsButton.simulate('click')
+    
+          expect(props.onToggleAboutCwicModal).toHaveBeenCalledTimes(1)
+          expect(props.onToggleAboutCwicModal).toHaveBeenCalledWith(true)
+        })
+      })
     })
 
-    test('displays a link to open a modal for more information', () => {
-      const { enzymeWrapper } = setup({
-        collectionMetadata: {
-          hasAllMetadata: true,
-          title: 'Collection Title',
-          isCSDA: true,
-          isOpenSearch: false
-        }
-      }, '/search/granules')
-      const panels = enzymeWrapper.find(Panels)
-      const granuleResultsPanel = panels.find(PanelGroup).at(1)
-      const granuleResultsPanelProps = granuleResultsPanel.props()
-      const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
-
-      expect(shallow(messageProps.children[3]).text()).toContain('More Details')
+    describe('on a CEOS collection', () => {
+      test('displays a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['CEOS']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+  
+        expect(messageProps.className).toEqual('search-panels__note')
+        expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
+      })
+  
+      test('does not display a link to open a modal for more information', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['CEOS']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+  
+        expect(messageProps.children[3]).toBe(false)
+      })
     })
-  })
 
-  describe('when the modal button is clicked', () => {
-    test('opens the modal', () => {
-      const { enzymeWrapper, props } = setup({
-        collectionMetadata: {
-          hasAllMetadata: true,
-          title: 'Collection Title',
-          isCSDA: true,
-          isOpenSearch: false
-        }
-      }, '/search/granules')
-      const panels = enzymeWrapper.find(Panels)
-      const granuleResultsPanel = panels.find(PanelGroup).at(1)
-      const granuleResultsPanelProps = granuleResultsPanel.props()
-      const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
+    describe('on a FEDEO collection', () => {
+      test('displays a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['FEDEO']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+        console.log('enzymeWrapper', messageProps)
+  
+        expect(messageProps.className).toEqual('search-panels__note')
+        expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
+      })
+  
+      test('does not display a link to open a modal for more information', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['FEDEO']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+  
+        expect(messageProps.children[3]).toBe(false)
+      })
+    })
 
-      const moreDetailsButton = shallow(messageProps.children[3])
+    describe('on a GEOSS collection', () => {
+      test('does not display a header message', () => {
+        const { enzymeWrapper } = setup({
+          collectionMetadata: {
+            hasAllMetadata: true,
+            consortiums: ['GEOSS']
+          }
+        }, '/search/granules')
+        const panels = enzymeWrapper.find(Panels)
+        const granuleResultsPanel = panels.find(PanelGroup).at(1)
+        const granuleResultsPanelProps = granuleResultsPanel.props()
+        const messageProps = granuleResultsPanelProps.headerMessage.props.children[0]
 
-      moreDetailsButton.simulate('click')
-
-      expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
-      expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
+        expect(messageProps).toBe(null)
+      })
     })
   })
 

--- a/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
+++ b/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.js
@@ -612,9 +612,7 @@ describe('SearchPanels component', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
             hasAllMetadata: true,
-            title: 'Collection Title',
-            isCSDA: false,
-            isOpenSearch: false,
+            isOpenSearch: true,
             consortiums: ['CWIC']
           }
         }, '/search/granules')
@@ -631,7 +629,8 @@ describe('SearchPanels component', () => {
         const { enzymeWrapper } = setup({
           collectionMetadata: {
             hasAllMetadata: true,
-            consortiums: ['CWIC']
+            consortiums: ['CWIC'],
+            isOpenSearch: true
           }
         }, '/search/granules')
         const panels = enzymeWrapper.find(Panels)
@@ -647,7 +646,8 @@ describe('SearchPanels component', () => {
           const { enzymeWrapper, props } = setup({
             collectionMetadata: {
               hasAllMetadata: true,
-              consortiums: ['CWIC']
+              consortiums: ['CWIC'],
+              isOpenSearch: true
             }
           }, '/search/granules')
           const panels = enzymeWrapper.find(Panels)
@@ -676,6 +676,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanel = panels.find(PanelGroup).at(1)
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
+
   
         expect(messageProps.className).toEqual('search-panels__note')
         expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
@@ -693,7 +694,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
   
-        expect(messageProps.children[3]).toBe(false)
+        expect(messageProps.children[3]).toBe(undefined)
       })
     })
 
@@ -709,7 +710,6 @@ describe('SearchPanels component', () => {
         const granuleResultsPanel = panels.find(PanelGroup).at(1)
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
-        console.log('enzymeWrapper', messageProps)
   
         expect(messageProps.className).toEqual('search-panels__note')
         expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
@@ -727,7 +727,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
   
-        expect(messageProps.children[3]).toBe(false)
+        expect(messageProps.children[3]).toBe(undefined)
       })
     })
 

--- a/static/src/js/util/__tests__/formatCollectionList.test.js
+++ b/static/src/js/util/__tests__/formatCollectionList.test.js
@@ -8,6 +8,7 @@ describe('formatCollectionList', () => {
     const metadata = {
       collectionId: {
         summary: 'test summary',
+        consortiums: [],
         datasetId: 'test dataset id',
         granuleCount: 42,
         hasMapImagery: false,
@@ -52,6 +53,7 @@ describe('formatCollectionList', () => {
     const expectedResult = {
       summary: 'test summary',
       collectionId: 'collectionId',
+      consortiums: [],
       datasetId: 'test dataset id',
       displayOrganization: 'test/org',
       granuleCount: 42,
@@ -94,6 +96,7 @@ describe('formatCollectionList', () => {
     const expectedResult = {
       summary: '',
       collectionId: 'collectionId',
+      consortiums: [],
       datasetId: null,
       displayOrganization: '',
       granuleCount: 0,
@@ -220,6 +223,7 @@ describe('formatCollectionList', () => {
     const expectedResult = {
       summary: 'test summary',
       collectionId: 'collectionId',
+      consortiums: [],
       datasetId: 'test dataset id',
       displayOrganization: 'test/org',
       granuleCount: 42,

--- a/static/src/js/util/formatCollectionList.js
+++ b/static/src/js/util/formatCollectionList.js
@@ -13,16 +13,17 @@ export const formatCollectionList = (collections, metadata, projectIds = [], bro
     const { [collectionId]: collectionMetadata = {} } = metadata
 
     const {
-      summary = '',
+      consortiums = [],
       datasetId = null,
       granuleCount = 0,
       hasMapImagery = false,
       isCSDA = false,
-      isOpenSearch = false,
       isNrt = false,
+      isOpenSearch = false,
       organizations = [],
       serviceFeatures = {},
       shortName,
+      summary = '',
       thumbnail = null,
       timeEnd = null,
       timeStart = null,
@@ -112,29 +113,30 @@ export const formatCollectionList = (collections, metadata, projectIds = [], bro
     })
 
     return {
-      summary: truncatedAbstract,
+      consortiums,
       collectionId,
       datasetId,
       displayOrganization,
       granuleCount,
       hasFormats,
+      hasMapImagery,
       hasSpatialSubsetting,
       hasTemporalSubsetting,
       hasTransforms,
       hasVariables,
-      hasMapImagery,
+      isCollectionInProject,
       isCSDA,
-      isOpenSearch,
+      isLast,
       isNrt,
+      isOpenSearch,
       organizations,
       shortName,
+      summary: truncatedAbstract,
       temporalEnd,
       temporalRange,
       temporalStart,
       thumbnail,
-      versionId,
-      isCollectionInProject,
-      isLast
+      versionId
     }
   })
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Displays additional consortiums on the search results and granule results lists where appropriate

### What is the Solution?

Leverage messaging in place for CWIC collections, which can now be pulled from the consortiums array on the CMR JSON response

### What areas of the application does this impact?

 - Search results list item
 - Granule results list header note

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
