### PR TITLE
EDSC-3346: Ensures correct header is being sent

### DIFF
--- a/cypress/integration/map/__mocks__/opensearch_granules/graphql.body.json
+++ b/cypress/integration/map/__mocks__/opensearch_granules/graphql.body.json
@@ -157,7 +157,8 @@
       "services": { "count": 0, "items": null },
       "granules": { "count": 0, "items": [] },
       "subscriptions": { "count": 0, "items": [] },
-      "variables": { "count": 0, "items": null }
+      "variables": { "count": 0, "items": null },
+      "tools": { "count": 0, "items": null }
     }
   }
 }

--- a/cypress/integration/map/map_spec.js
+++ b/cypress/integration/map/map_spec.js
@@ -1510,7 +1510,7 @@ describe('Map interactions', () => {
           url: '**/api'
         },
         (req) => {
-          expect(req.body).to.eq(graphQlGetCollection(conceptId))
+          expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
           req.reply({
             body: cmrGranulesCollectionGraphQlBody,
@@ -1569,7 +1569,7 @@ describe('Map interactions', () => {
             url: '**/api'
           },
           (req) => {
-            expect(req.body).to.eq('{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G2061183408-ASF"}}')
+            expect(JSON.stringify(req.body)).to.eq('{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G2061183408-ASF"}}')
 
             req.reply({
               body: granuleGraphQlBody,
@@ -1668,7 +1668,7 @@ describe('Map interactions', () => {
           url: '**/api'
         },
         (req) => {
-          expect(req.body).to.eq(graphQlGetCollection(conceptId))
+          expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
           req.reply({
             body: opensearchGranulesCollectionGraphQlBody,

--- a/cypress/integration/paths/search/granules/collection_details/collection_details_spec.js
+++ b/cypress/integration/paths/search/granules/collection_details/collection_details_spec.js
@@ -311,7 +311,7 @@ describe('Path /search/granules/collection-details', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: reformattingGraphQlBody,

--- a/cypress/integration/paths/search/granules/granule_details/granule_details_spec.js
+++ b/cypress/integration/paths/search/granules/granule_details/granule_details_spec.js
@@ -55,14 +55,14 @@ describe('Path /search/granules/granule-details', () => {
       },
       (req) => {
         // If these requests change and are failing tests, console.log req.body to see the actual request being called
-        if (req.body === graphQlGetCollection(collectionId)) {
+        if (JSON.stringify(req.body) === graphQlGetCollection(collectionId)) {
           req.alias = 'graphQlCollectionQuery'
           req.reply({
             body: getCollectionGraphQlBody,
             headers: graphQlHeaders
           })
         }
-        if (req.body === '{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G1287941210-ASF"}}') {
+        if (JSON.stringify(req.body) === '{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G1287941210-ASF"}}') {
           req.alias = 'graphQlGranuleQuery'
           req.reply({
             body: getGranuleGraphQlBody,

--- a/cypress/integration/paths/search/granules/granules_spec.js
+++ b/cypress/integration/paths/search/granules/granules_spec.js
@@ -165,7 +165,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: noParamsGraphQlBody,
@@ -224,7 +224,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: readableGranuleNameGraphQlBody,
@@ -284,7 +284,7 @@ describe('Path /search/granules', () => {
           url: '**/api'
         },
         (req) => {
-          expect(req.body).to.eq(graphQlGetCollection(conceptId))
+          expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
           req.reply({
             body: temporalGraphQlBody,
@@ -347,7 +347,7 @@ describe('Path /search/granules', () => {
           url: '**/api'
         },
         (req) => {
-          expect(req.body).to.eq(graphQlGetCollection(conceptId))
+          expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
           req.reply({
             body: temporalGraphQlBody,
@@ -413,7 +413,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: browseOnlyGraphQlBody,
@@ -473,7 +473,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: onlineOnlyGraphQlBody,
@@ -533,7 +533,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: orbitNumberGraphQlBody,
@@ -593,7 +593,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: equatorialCrossingLongitudeGraphQlBody,
@@ -653,7 +653,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: equatorialCrossingDateGraphQlBody,
@@ -713,7 +713,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: sortKeyGraphQlBody,
@@ -773,7 +773,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: cloudCoverGraphQlBody,
@@ -833,7 +833,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: dayNightGraphQlBody,
@@ -892,7 +892,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: gridCoordsGraphQlBody,
@@ -963,7 +963,7 @@ describe('Path /search/granules', () => {
         url: '**/api'
       },
       (req) => {
-        expect(req.body).to.eq(graphQlGetCollection(conceptId))
+        expect(JSON.stringify(req.body)).to.eq(graphQlGetCollection(conceptId))
 
         req.reply({
           body: timelineGraphQlBody,
@@ -1028,14 +1028,14 @@ describe('Path /search/granules', () => {
       },
       (req) => {
         // If these requests change and are failing tests, console.log req.body to see the actual request being called
-        if (req.body === graphQlGetCollection(conceptId)) {
+        if (JSON.stringify(req.body) === graphQlGetCollection(conceptId)) {
           req.alias = 'graphQlCollectionQuery'
           req.reply({
             body: focusedGranuleCollectionGraphQlBody,
             headers: focusedGranuleGraphQlHeaders
           })
         }
-        if (req.body === '{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G2058417402-LPDAAC_ECS"}}') {
+        if (JSON.stringify(req.body) === '{"query":"\\n    query GetGranule(\\n      $id: String!\\n    ) {\\n      granule(\\n        conceptId: $id\\n      ) {\\n        granuleUr\\n        granuleSize\\n        title\\n        onlineAccessFlag\\n        dayNightFlag\\n        timeStart\\n        timeEnd\\n        dataCenter\\n        originalFormat\\n        conceptId\\n        collectionConceptId\\n        spatialExtent\\n        temporalExtent\\n        relatedUrls\\n        dataGranule\\n        measuredParameters\\n        providerDates\\n      }\\n    }","variables":{"id":"G2058417402-LPDAAC_ECS"}}') {
           req.alias = 'graphQlGranuleQuery'
           req.reply({
             body: focusedGranuleGranuleGraphQlBody,
@@ -1111,14 +1111,14 @@ describe('Path /search/granules', () => {
       },
       (req) => {
         // If these requests change and are failing tests, console.log req.body to see the actual request being called
-        if (req.body === graphQlGetCollection(conceptId)) {
+        if (JSON.stringify(req.body) === graphQlGetCollection(conceptId)) {
           req.alias = 'graphQlCollectionQuery'
           req.reply({
             body: projectGranuleCollectionGraphQlBody,
             headers: projectGranuleGraphQlHeaders
           })
         }
-        if (req.body === graphQlGetCollections('C194001210-LPDAAC_ECS')) {
+        if (JSON.stringify(req.body) === graphQlGetCollections('C194001210-LPDAAC_ECS')) {
           req.alias = 'graphQlCollectionsQuery'
           req.reply({
             body: projectGranuleCollectionsGraphQlBody,
@@ -1184,14 +1184,14 @@ describe('Path /search/granules', () => {
       },
       (req) => {
         // If these requests change and are failing tests, console.log req.body to see the actual request being called
-        if (req.body === graphQlGetCollection(conceptId)) {
+        if (JSON.stringify(req.body) === graphQlGetCollection(conceptId)) {
           req.alias = 'graphQlCollectionQuery'
           req.reply({
             body: projectCollectionCollectionGraphQlBody,
             headers: projectCollectionGraphQlHeaders
           })
         }
-        if (req.body === graphQlGetCollections('C194001210-LPDAAC_ECS')) {
+        if (JSON.stringify(req.body) === graphQlGetCollections('C194001210-LPDAAC_ECS')) {
           req.alias = 'graphQlCollectionsQuery'
           req.reply({
             body: projectCollectionCollectionsGraphQlBody,

--- a/static/src/js/util/request/__tests__/graphQlRequest.test.js
+++ b/static/src/js/util/request/__tests__/graphQlRequest.test.js
@@ -1,0 +1,126 @@
+import GraphQlRequest from '../graphQlRequest'
+
+import * as getClientId from '../../../../../../sharedUtils/getClientId'
+import * as getEarthdataConfig from '../../../../../../sharedUtils/config'
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
+
+describe('GraphQlRequest#constructor', () => {
+  test('sets the default values when authenticated', () => {
+    const token = '123'
+    const request = new GraphQlRequest(token)
+
+    expect(request.authenticated).toBeTruthy()
+    expect(request.authToken).toEqual(token)
+    expect(request.baseUrl).toEqual('http://localhost:3000')
+    expect(request.searchPath).toEqual('graphql')
+  })
+
+  test('sets the default values when unauthenticated', () => {
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({ graphQlHost: 'https://graphql.earthdata.nasa.gov' }))
+
+    const request = new GraphQlRequest(undefined, 'prod')
+
+    expect(request.authenticated).toBeFalsy()
+    expect(request.baseUrl).toEqual('https://graphql.earthdata.nasa.gov')
+    expect(request.searchPath).toEqual('api')
+  })
+})
+
+describe('GraphQlRequest#transformRequest', () => {
+  test('adds authorization header when authenticated', () => {
+    const request = new GraphQlRequest(undefined, 'prod')
+    const token = '123'
+
+    request.authenticated = true
+    request.authToken = token
+
+    const data = { param1: 123 }
+    const headers = {}
+
+    request.transformRequest(data, headers)
+
+    expect(headers).toEqual(expect.objectContaining({
+      Authorization: 'Bearer 123'
+    }))
+  })
+
+  test('adds client-id header when not authenticated', () => {
+    jest.spyOn(getClientId, 'getClientId').mockImplementation(() => ({ client: 'eed-edsc-test-serverless-client' }))
+
+    const request = new GraphQlRequest(undefined, 'prod')
+
+    request.authenticated = false
+
+    const data = { param1: 123 }
+    const headers = {}
+
+    request.transformRequest(data, headers)
+
+    expect(headers).toEqual(expect.objectContaining({
+      'Client-Id': 'eed-edsc-test-serverless-client'
+    }))
+  })
+
+  test('correctly transforms data for CMR requests', () => {
+    const request = new GraphQlRequest(undefined, 'prod')
+
+    const data = { ParamName: 123 }
+
+    const transformedData = request.transformRequest(data, {})
+
+    expect(transformedData).toEqual('{"ParamName":123}')
+  })
+
+  test('correctly transforms data for Lambda requests', () => {
+    const request = new GraphQlRequest(undefined, 'prod')
+    request.lambda = true
+    request.startTime = 1576855756
+
+    const data = { paramName: 123 }
+
+    const transformedData = request.transformRequest(data, {})
+
+    const parsedData = JSON.parse(transformedData)
+    expect(parsedData).toEqual({
+      data: {
+        paramName: 123
+      },
+      requestId: expect.any(String)
+    })
+  })
+
+  test('adds content type header when making direct calls', () => {
+    const request = new GraphQlRequest(undefined, 'prod')
+
+    const data = { param1: 123 }
+    const headers = {}
+
+    request.transformRequest(data, headers)
+
+    expect(headers).toEqual(expect.objectContaining({
+      'Content-Type': 'application/json'
+    }))
+  })
+})
+
+describe('GraphQlRequest#transformResponse', () => {
+  beforeEach(() => {
+    jest.spyOn(GraphQlRequest.prototype, 'handleUnauthorized').mockImplementation()
+  })
+
+  test('returns data if response is not successful', () => {
+    const request = new GraphQlRequest(undefined, 'prod')
+
+    const data = {
+      statusCode: 404
+    }
+
+    const result = request.transformResponse(data)
+
+    expect(result).toEqual(data)
+  })
+})

--- a/static/src/js/util/request/graphQlRequest.js
+++ b/static/src/js/util/request/graphQlRequest.js
@@ -42,7 +42,7 @@ export default class GraphQlRequest extends Request {
     }
 
     // If contacting GraphQL directly, add the content type
-    if (!this.authenticated && !this.optionallyAuthenticated && this.lambda) {
+    if (!this.authenticated && !this.optionallyAuthenticated && !this.lambda) {
       // eslint-disable-next-line no-param-reassign
       headers['Content-Type'] = 'application/json'
     }


### PR DESCRIPTION
Added a missing `!` and tests for the graphQl request utility.