### PR TITLE
EDSC-3361: Adds external link styling to wiki link in modal

### DIFF
--- a/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
+++ b/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
@@ -36,9 +36,10 @@ export class DeprecatedParameterModal extends Component {
             className="link link--external"
             target="_blank"
             rel="noreferrer"
-            href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters">
-              Earthdata Search URL Parameters
-            </a>
+            href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters"
+          >
+            Earthdata Search URL Parameters
+          </a>
           {' wiki page for more information on the supported URL parameters.'}
         </p>
       </>

--- a/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
+++ b/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
@@ -32,7 +32,13 @@ export class DeprecatedParameterModal extends Component {
         </p>
         <p className="mb-0">
           {'Please visit the '}
-          <a className="link link--external" target="_blank" href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters">Earthdata Search URL Parameters</a>
+          <a
+            className="link link--external"
+            target="_blank"
+            rel="noreferrer"
+            href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters">
+              Earthdata Search URL Parameters
+            </a>
           {' wiki page for more information on the supported URL parameters.'}
         </p>
       </>

--- a/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
+++ b/static/src/js/components/DeprecatedParameterModal/DeprecatedParameterModal.js
@@ -32,7 +32,7 @@ export class DeprecatedParameterModal extends Component {
         </p>
         <p className="mb-0">
           {'Please visit the '}
-          <a href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters">Earthdata Search URL Parameters</a>
+          <a className="link link--external" target="_blank" href="https://wiki.earthdata.nasa.gov/display/EDSC/Earthdata+Search+URL+Parameters">Earthdata Search URL Parameters</a>
           {' wiki page for more information on the supported URL parameters.'}
         </p>
       </>


### PR DESCRIPTION
# Overview

### What is the feature?

Adds external link styling to wiki link in modal

### What is the Solution?

Add external link styling to wiki link in modal

### What areas of the application does this impact?

Deprecated parameter modal

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
