### PR TITLE
EDSC-3398: Removes EDL client id from JWT token

### DIFF
--- a/serverless/src/conceptMetadata/__tests__/handler.test.js
+++ b/serverless/src/conceptMetadata/__tests__/handler.test.js
@@ -1,16 +1,9 @@
 import conceptMetadata from '../handler'
 
 import * as getAccessTokenFromJwtToken from '../../util/urs/getAccessTokenFromJwtToken'
-import * as getEdlConfig from '../../util/getEdlConfig'
 
 beforeEach(() => {
   jest.clearAllMocks()
-
-  jest.spyOn(getEdlConfig, 'getEdlConfig').mockImplementation(() => ({
-    client: {
-      id: 'clientId'
-    }
-  }))
 })
 
 describe('conceptMetadata', () => {
@@ -26,7 +19,7 @@ describe('conceptMetadata', () => {
 
     const result = await conceptMetadata(event)
 
-    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?token=access_token:clientId' })
+    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?token=access_token' })
     expect(result.statusCode).toBe(307)
   })
 
@@ -42,7 +35,7 @@ describe('conceptMetadata', () => {
 
     const result = await conceptMetadata(event)
 
-    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?id=42&token=access_token:clientId' })
+    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?id=42&token=access_token' })
     expect(result.statusCode).toBe(307)
   })
 })

--- a/serverless/src/conceptMetadata/handler.js
+++ b/serverless/src/conceptMetadata/handler.js
@@ -1,5 +1,4 @@
 import { parse, stringify } from 'qs'
-import { getEdlConfig } from '../util/getEdlConfig'
 import { getAccessTokenFromJwtToken } from '../util/urs/getAccessTokenFromJwtToken'
 
 /**
@@ -22,12 +21,8 @@ const conceptMetadata = async (event) => {
     access_token: accessToken
   } = await getAccessTokenFromJwtToken(jwtToken, earthdataEnvironment)
 
-  const edlConfig = await getEdlConfig(earthdataEnvironment)
-  const { client } = edlConfig
-  const { id: clientId } = client
-
   // Access tokens used in the URL still require the client id
-  const conceptUrl = `${desiredPath}?${stringify({ ...parsedQueryParams, token: `${accessToken}:${clientId}` }, { encode: false })}`
+  const conceptUrl = `${desiredPath}?${stringify({ ...parsedQueryParams, token: `${accessToken}` }, { encode: false })}`
 
   return {
     statusCode: 307,


### PR DESCRIPTION
# Overview

### What is the feature?

Removes EDL client id from JWT token to work around CMR bug.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
