### PR TITLE
EDSC-3483: Fixes platforms values in collections CSV export

### DIFF
--- a/serverless/src/exportSearch/__tests__/handler.test.js
+++ b/serverless/src/exportSearch/__tests__/handler.test.js
@@ -31,11 +31,11 @@ describe('exportSearch', () => {
             items: [{
               conceptId: 'C100000-EDSC',
               title: 'Test collection',
-              platforms: ['platform']
+              platforms: [{ shortName: 'platform' }]
             }, {
               conceptId: 'C100001-EDSC',
               title: 'Test collection 1',
-              platforms: ['platform']
+              platforms: [{ shortName: 'platform' }]
             }]
           }
         }
@@ -82,11 +82,11 @@ describe('exportSearch', () => {
             items: [{
               conceptId: 'C100000-EDSC',
               title: 'Test collection',
-              platforms: ['platform']
+              platforms: [{ shortName: 'platform' }]
             }, {
               conceptId: 'C100001-EDSC',
               title: 'Test collection 1',
-              platforms: ['platform']
+              platforms: [{ shortName: 'platform' }]
             }]
           }
         }
@@ -115,7 +115,7 @@ describe('exportSearch', () => {
 
     const result = await exportSearch(event, {})
 
-    expect(result.body).toEqual('[{"conceptId":"C100000-EDSC","title":"Test collection","platforms":["platform"]},{"conceptId":"C100001-EDSC","title":"Test collection 1","platforms":["platform"]}]')
+    expect(result.body).toEqual('[{"conceptId":"C100000-EDSC","title":"Test collection","platforms":[{"shortName":"platform"}]},{"conceptId":"C100001-EDSC","title":"Test collection 1","platforms":[{"shortName":"platform"}]}]')
   })
 
   test('responds correctly on http error', async () => {

--- a/serverless/src/exportSearch/__tests__/jsonToCsv.test.js
+++ b/serverless/src/exportSearch/__tests__/jsonToCsv.test.js
@@ -8,7 +8,7 @@ describe('jsonToCsv', () => {
       versionId: 'test versionId',
       title: 'test title',
       processingLevelId: 'test processingLevelId',
-      platforms: ['test platforms'],
+      platforms: [{ shortName: 'test platforms' }],
       timeStart: 'test timeStart',
       timeEnd: 'test timeEnd'
     }]
@@ -25,7 +25,11 @@ describe('jsonToCsv', () => {
       versionId: 'test versionId',
       title: 'test title',
       processingLevelId: 'test processingLevelId',
-      platforms: ['test platform 1', 'test platform 2'],
+      platforms: [{
+        shortName: 'test platform 1'
+      }, {
+        shortName: 'test platform 2'
+      }],
       timeStart: 'test timeStart',
       timeEnd: null
     }]
@@ -42,7 +46,7 @@ describe('jsonToCsv', () => {
       versionId: 'test versionId',
       title: 'test title',
       processingLevelId: 'test processingLevelId',
-      platforms: ['test platforms'],
+      platforms: [{ shortName: 'test platforms' }],
       timeStart: 'test timeStart',
       timeEnd: null
     }]

--- a/serverless/src/exportSearch/jsonToCsv.js
+++ b/serverless/src/exportSearch/jsonToCsv.js
@@ -43,7 +43,9 @@ export const jsonToCsv = (jsonArray) => {
     keysToMap.forEach((key) => {
       // If the key is platforms, join the array of shortnames
       if (key === 'platforms') {
-        collectionValues.push(JSON.stringify(collection[key].join(', '), replacer))
+        const shortNames = collection[key].map((platform) => platform.shortName)
+
+        collectionValues.push(JSON.stringify(shortNames.join(', '), replacer))
       } else {
         collectionValues.push(JSON.stringify(collection[key], replacer))
       }


### PR DESCRIPTION
# Overview

### What is the feature?

Platforms values are returned from GraphQL as an array of objects, not as an array of short name strings. This PR adjusts the `jsonToCSV.js` code to account for that difference.