### PR TITLE
EDSC-3514: Updates portal configs to use correct tagKey parameter

### DIFF
--- a/portals/amd/config.json
+++ b/portals/amd/config.json
@@ -9,7 +9,7 @@
   "pageTitle": "Antarctic Metadata Directory (AMD)",
   "parentConfig": "edsc",
   "query": {
-    "tagKey": "org.scar.amd",
+    "tagKey": ["org.scar.amd"],
     "hasGranulesOrCwic": null
   },
   "ui": {

--- a/portals/soos/config.json
+++ b/portals/soos/config.json
@@ -9,7 +9,7 @@
   "pageTitle": "Southern Ocean Observing System",
   "parentConfig": "edsc",
   "query": {
-    "tagKey": "aq.soos",
+    "tagKey": ["aq.soos"],
     "hasGranulesOrCwic": null
   },
   "ui": {

--- a/portals/standardproducts/config.json
+++ b/portals/standardproducts/config.json
@@ -3,7 +3,7 @@
   "pageTitle": "Standard Products",
   "parentConfig": "edsc",
   "query": {
-    "tagKey": "gov.nasa.eosdis.standardproduct",
+    "tagKey": ["gov.nasa.eosdis.standardproduct"],
     "hasGranulesOrCwic": null,
     "standardProduct": true
   },

--- a/static/src/js/actions/__tests__/portals.test.js
+++ b/static/src/js/actions/__tests__/portals.test.js
@@ -1,7 +1,8 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 
-import { ADD_PORTAL } from '../../constants/actionTypes'
+import { ADD_ERROR, ADD_PORTAL } from '../../constants/actionTypes'
+import { displayNotificationType } from '../../constants/enums'
 import { addPortal, loadPortalConfig } from '../portals'
 
 const mockStore = configureMockStore([thunk])
@@ -91,6 +92,29 @@ describe('loadPortalConfig', () => {
     expect(storeActions[0]).toEqual({
       type: ADD_PORTAL,
       payload
+    })
+  })
+
+  test('should call addError when unable to load portal config', () => {
+    const consoleMock = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const portalId = 'not-a-real-portal'
+
+    // mockStore with initialState
+    const store = mockStore()
+
+    // call the dispatch
+    store.dispatch(loadPortalConfig(portalId))
+
+    expect(consoleMock).toHaveBeenCalledTimes(1)
+
+    const storeActions = store.getActions()
+    expect(storeActions[0]).toEqual({
+      type: ADD_ERROR,
+      payload: {
+        id: portalId,
+        notificationType: displayNotificationType.banner,
+        title: `Portal ${portalId} could not be loaded`
+      }
     })
   })
 })

--- a/static/src/js/actions/portals.js
+++ b/static/src/js/actions/portals.js
@@ -1,7 +1,9 @@
 /* eslint-disable import/no-dynamic-require, global-require */
 
 import { ADD_PORTAL } from '../constants/actionTypes'
+import { displayNotificationType } from '../constants/enums'
 import { getPortalConfig } from '../util/portals'
+import { addError } from './errors'
 
 export const addPortal = (payload) => ({
   type: ADD_PORTAL,
@@ -31,5 +33,12 @@ export const loadPortalConfig = (portalId) => (dispatch) => {
     dispatch(addPortal({ portalId, ...json }))
   } catch (error) {
     console.error('Portal could not be loaded', error)
+    dispatch(
+      addError({
+        id: portalId,
+        notificationType: displayNotificationType.banner,
+        title: `Portal ${portalId} could not be loaded`
+      })
+    )
   }
 }

--- a/static/src/js/components/Banner/Banner.js
+++ b/static/src/js/components/Banner/Banner.js
@@ -23,10 +23,12 @@ export const Banner = ({
     <div className={bannerClassNames}>
       <div className="banner__content">
         <h2 className="banner__title">{title}</h2>
-        {' '}
         {
           message && (
-            <p className="banner__message">{message}</p>
+            <>
+              {' '}
+              <p className="banner__message">{message}</p>
+            </>
           )
         }
       </div>

--- a/static/src/js/components/Banner/Banner.js
+++ b/static/src/js/components/Banner/Banner.js
@@ -24,7 +24,11 @@ export const Banner = ({
       <div className="banner__content">
         <h2 className="banner__title">{title}</h2>
         {' '}
-        <p className="banner__message">{message}</p>
+        {
+          message && (
+            <p className="banner__message">{message}</p>
+          )
+        }
       </div>
       <Button
         className="banner__close"
@@ -36,11 +40,15 @@ export const Banner = ({
   )
 }
 
+Banner.defaultProps = {
+  message: null
+}
+
 Banner.propTypes = {
   message: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node
-  ]).isRequired,
+  ]),
   title: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node

--- a/static/src/js/components/Banner/__tests__/Banner.test.js
+++ b/static/src/js/components/Banner/__tests__/Banner.test.js
@@ -6,12 +6,13 @@ import Button from '../../Button/Button'
 
 Enzyme.configure({ adapter: new Adapter() })
 
-function setup() {
+function setup(overrideProps = {}) {
   const props = {
     title: 'title',
     message: 'message',
     onClose: jest.fn(),
-    type: 'error'
+    type: 'error',
+    ...overrideProps
   }
 
   const enzymeWrapper = shallow(<Bannner {...props} />)
@@ -44,5 +45,13 @@ describe('Bannner component', () => {
     const { enzymeWrapper } = setup()
 
     expect(enzymeWrapper.hasClass('banner--error')).toEqual(true)
+  })
+
+  test('does not render a message when no message was provided', () => {
+    const { enzymeWrapper } = setup({
+      message: undefined
+    })
+
+    expect(enzymeWrapper.find('.banner__message').exists()).toBeFalsy()
   })
 })

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -696,9 +696,11 @@ class SearchPanels extends PureComponent {
         onPanelClose={this.onPanelClose}
       >
         <PanelItem>
-          <AuthRequiredContainer noRedirect>
-            <SubscriptionsBodyContainer subscriptionType="granule" />
-          </AuthRequiredContainer>
+          <PortalFeatureContainer authentication>
+            <AuthRequiredContainer noRedirect>
+              <SubscriptionsBodyContainer subscriptionType="granule" />
+            </AuthRequiredContainer>
+          </PortalFeatureContainer>
         </PanelItem>
       </PanelGroup>
     )
@@ -720,9 +722,11 @@ class SearchPanels extends PureComponent {
         onPanelClose={this.onPanelClose}
       >
         <PanelItem>
-          <AuthRequiredContainer noRedirect>
-            <SubscriptionsBodyContainer subscriptionType="collection" />
-          </AuthRequiredContainer>
+          <PortalFeatureContainer authentication>
+            <AuthRequiredContainer noRedirect>
+              <SubscriptionsBodyContainer subscriptionType="collection" />
+            </AuthRequiredContainer>
+          </PortalFeatureContainer>
         </PanelItem>
       </PanelGroup>
     )

--- a/static/src/js/util/__tests__/queryToHumanizedList.test.js
+++ b/static/src/js/util/__tests__/queryToHumanizedList.test.js
@@ -32,10 +32,42 @@ describe('queryToHumanizedList', () => {
     }])
   })
 
+  test('returns a humanized param for EOSDIS collections tag when tagKey is not an array', () => {
+    const query = {
+      hasGranulesOrCwic: true,
+      tagKey: 'gov.nasa.eosdis'
+    }
+
+    const subscriptionType = 'collection'
+
+    const result = queryToHumanizedList(query, subscriptionType)
+
+    expect(result).toEqual([{
+      key: 'tagKey-gov.nasa.eosdis',
+      humanizedKey: 'Include only EOSDIS datasets'
+    }])
+  })
+
   test('returns a humanized param for Map Imagery tag', () => {
     const query = {
       hasGranulesOrCwic: true,
       tagKey: ['edsc.extra.serverless.gibs']
+    }
+
+    const subscriptionType = 'collection'
+
+    const result = queryToHumanizedList(query, subscriptionType)
+
+    expect(result).toEqual([{
+      key: 'tagKey-edsc.extra.serverless.gibs',
+      humanizedKey: 'Include only datasets with map imagery'
+    }])
+  })
+
+  test('returns a humanized param for Map Imagery tag when tagKey is not an array', () => {
+    const query = {
+      hasGranulesOrCwic: true,
+      tagKey: 'edsc.extra.serverless.gibs'
     }
 
     const subscriptionType = 'collection'

--- a/static/src/js/util/queryToHumanizedList.js
+++ b/static/src/js/util/queryToHumanizedList.js
@@ -1,3 +1,5 @@
+import { castArray } from 'lodash'
+
 import { humanizedQueryValueFormattingMap } from './humanizedQueryValueFormattingMap'
 
 /**
@@ -25,7 +27,7 @@ export const queryToHumanizedList = (subscriptionsQuery, subscriptionQueryType) 
         key: 'tagKey-gov.nasa.eosdis',
         humanizedKey: 'Include only EOSDIS datasets'
       })
-      subscriptionsQueryTemp.tagKey = subscriptionsQueryTemp.tagKey.filter((tagKey) => tagKey !== 'gov.nasa.eosdis')
+      subscriptionsQueryTemp.tagKey = castArray(subscriptionsQueryTemp.tagKey).filter((tagKey) => tagKey !== 'gov.nasa.eosdis')
     }
 
     // If only displaying collections with Map Imagery, add a key of "Map Imagery"
@@ -34,7 +36,7 @@ export const queryToHumanizedList = (subscriptionsQuery, subscriptionQueryType) 
         key: 'tagKey-edsc.extra.serverless.gibs',
         humanizedKey: 'Include only datasets with map imagery'
       })
-      subscriptionsQueryTemp.tagKey = subscriptionsQueryTemp.tagKey.filter((tagKey) => tagKey !== 'edsc.extra.serverless.gibs')
+      subscriptionsQueryTemp.tagKey = castArray(subscriptionsQueryTemp.tagKey).filter((tagKey) => tagKey !== 'edsc.extra.serverless.gibs')
     }
 
     // If only displaying customizable collections, add a key of "Customizable"


### PR DESCRIPTION
# Overview

### What is the feature?

Some of the portals that use the `tagKey` parameter were using a string parameter and not an array of strings. This was causing some of the new subscriptions code to error when performing `.filter(` on that parameter.

### What is the Solution?

Use lodash `castArray` to ensure that `tagKey` is always an array.
Updated the portal configs to use the correct array type parameter.
Ensured that any portals that do not have authentication enabled do not load the `SubscriptionsBodyContainer`

### What areas of the application does this impact?

The following portals will error when logged in:
Antarctic Metadata Directory (AMD) (portal/amd)
Southern Ocean Observing System (portal/soos)
Standard Products (/portal/standardproducts)

# Testing

### Reproduction steps

Any environment
1. Login to EDSC with no portal applied
2. Visit the portal URL for one of the portals listed above

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
