### PR TITLE
EDSC-3518: Fix Related Urls Modal Error

### DIFF
--- a/static/src/js/components/CollectionDetails/RelatedUrlsModal.js
+++ b/static/src/js/components/CollectionDetails/RelatedUrlsModal.js
@@ -28,29 +28,34 @@ export class RelatedUrlsModal extends Component {
     const { relatedUrls = [] } = collectionMetadata
 
     const body = (
-      relatedUrls && relatedUrls.map((category, i) => {
-        if (category.urls.length) {
-          const key = `modal_related_url_${i}`
-          return (
-            <div key={key} className="related-urls-modal__group">
-              <h4 className="related-urls-modal__group-title">{pluralize(category.label, category.urls)}</h4>
-              {
-                category.urls.map((url, j) => {
-                  const key = `modal_related_url_${i}-${j}`
-                  return (
-                    <ul key={key} className="related-urls-modal__url">
-                      <ArrowTags tags={[url.type, url.subtype]} />
-                      {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                      <a className="related-urls-modal__link" href={url.url} target="_blank">{url.url}</a>
-                    </ul>
-                  )
-                })
-              }
-            </div>
-          )
+      // eslint-disable-next-line react/jsx-no-useless-fragment
+      <>
+        {
+          relatedUrls && relatedUrls.map((category, i) => {
+            if (category.urls.length) {
+              const key = `modal_related_url_${i}`
+              return (
+                <div key={key} className="related-urls-modal__group">
+                  <h4 className="related-urls-modal__group-title">{pluralize(category.label, category.urls)}</h4>
+                  {
+                  category.urls.map((url, j) => {
+                    const key = `modal_related_url_${i}-${j}`
+                    return (
+                      <ul key={key} className="related-urls-modal__url">
+                        <ArrowTags tags={[url.type, url.subtype]} />
+                        {/* eslint-disable-next-line react/jsx-no-target-blank */}
+                        <a className="related-urls-modal__link" href={url.url} target="_blank">{url.url}</a>
+                      </ul>
+                    )
+                  })
+                }
+                </div>
+              )
+            }
+            return null
+          })
         }
-        return null
-      })
+      </>
     )
 
     return (


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes error page appearing when you click on "View all Related Urls"

### What is the Solution?

Reverted body element to be a fragment instead of an array of elements, so it'll work with the rest of the code that processes it.

### What areas of the application does this impact?

/search/granules/collection-details

# Testing

### Reproduction steps

1. go to /search
2. type in ASCAT
3. click on the first result
4. click on the kebab menu and click Collection Details
5. click view all related urls and the modal should appear now

<img width="702" alt="Screen Shot 2022-07-12 at 1 34 19 AM" src="https://user-images.githubusercontent.com/4313463/178416130-55b98c98-0df6-4398-8020-f668ec635c43.png">

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

# Notes
Supersedes https://github.com/nasa/earthdata-search/pull/1532/files
