### PR TITLE
EDSC-3513: Provides granule temporal to the EchoForm component when necessary

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -165,8 +165,7 @@ export class AccessMethod extends Component {
       selectedAccessMethod,
       shapefileId,
       spatial,
-      temporal,
-      overrideTemporal
+      temporal
     } = this.props
 
     const { conceptId: collectionId } = metadata
@@ -436,7 +435,6 @@ export class AccessMethod extends Component {
                           shapefileId={shapefileId}
                           spatial={spatial}
                           temporal={temporal}
-                          overrideTemporal={overrideTemporal}
                           onUpdateAccessMethod={onUpdateAccessMethod}
                         />
                       </Suspense>
@@ -589,6 +587,7 @@ export class AccessMethod extends Component {
 
 AccessMethod.defaultProps = {
   accessMethods: {},
+  granulesQuery: {},
   index: null,
   isActive: false,
   metadata: {},
@@ -601,6 +600,7 @@ AccessMethod.defaultProps = {
 
 AccessMethod.propTypes = {
   accessMethods: PropTypes.shape({}),
+  granulesQuery: PropTypes.shape({}),
   index: PropTypes.number,
   isActive: PropTypes.bool,
   metadata: PropTypes.shape({
@@ -619,8 +619,7 @@ AccessMethod.propTypes = {
     endDate: PropTypes.string,
     isRecurring: PropTypes.bool,
     startDate: PropTypes.string
-  }).isRequired,
-  overrideTemporal: PropTypes.shape({}).isRequired
+  }).isRequired
 }
 
 export default AccessMethod

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -587,7 +587,6 @@ export class AccessMethod extends Component {
 
 AccessMethod.defaultProps = {
   accessMethods: {},
-  granulesQuery: {},
   index: null,
   isActive: false,
   metadata: {},
@@ -600,7 +599,6 @@ AccessMethod.defaultProps = {
 
 AccessMethod.propTypes = {
   accessMethods: PropTypes.shape({}),
-  granulesQuery: PropTypes.shape({}),
   index: PropTypes.number,
   isActive: PropTypes.bool,
   metadata: PropTypes.shape({

--- a/static/src/js/components/AccessMethod/EchoForm.js
+++ b/static/src/js/components/AccessMethod/EchoForm.js
@@ -15,7 +15,6 @@ export const EchoForm = ({
   shapefileId,
   spatial,
   temporal,
-  overrideTemporal,
   onUpdateAccessMethod
 }) => {
   // Get the MBR of the spatial for prepopulated values
@@ -54,23 +53,11 @@ export const EchoForm = ({
   const formatDate = (date) => moment.utc(date).format('YYYY-MM-DDTHH:mm:ss')
 
   // Get the temporal prepopulated values
-  const getTemporalPrepopulateValues = (temporal, overrideTemporal) => {
-    const {
-      endDate: overrideEndDate,
-      startDate: overrideStartDate
-    } = overrideTemporal
-
+  const getTemporalPrepopulateValues = (temporal) => {
     const {
       endDate,
       startDate
     } = temporal
-
-    if (overrideEndDate || overrideStartDate) {
-      return {
-        TEMPORAL_START: formatDate(overrideStartDate),
-        TEMPORAL_END: formatDate(overrideEndDate)
-      }
-    }
 
     if (endDate || startDate) {
       return {
@@ -87,7 +74,7 @@ export const EchoForm = ({
 
   const calculatePrepopulateValues = () => {
     const spatialPrepopulateValues = getMbr(spatial)
-    const temporalPrepopulateValues = getTemporalPrepopulateValues(temporal, overrideTemporal)
+    const temporalPrepopulateValues = getTemporalPrepopulateValues(temporal)
 
     const values = {
       ...spatialPrepopulateValues,
@@ -135,7 +122,7 @@ export const EchoForm = ({
     if (!isEqual(newValues, prepopulateValues)) {
       setPrepopulateValues(newValues)
     }
-  }, [spatial, temporal, overrideTemporal])
+  }, [spatial, temporal])
 
   // EDSCEchoforms doesn't care about the shapefileId, just is there a shapefileId or not
   const hasShapefile = !!(shapefileId)
@@ -165,10 +152,6 @@ EchoForm.propTypes = {
   form: PropTypes.string.isRequired,
   methodKey: PropTypes.string.isRequired,
   onUpdateAccessMethod: PropTypes.func.isRequired,
-  overrideTemporal: PropTypes.shape({
-    endDate: PropTypes.string,
-    startDate: PropTypes.string
-  }).isRequired,
   rawModel: PropTypes.string,
   shapefileId: PropTypes.string,
   spatial: PropTypes.shape({

--- a/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/EchoForm.test.js
@@ -17,7 +17,6 @@ function setup(overrideProps) {
     shapefileId: null,
     spatial: {},
     temporal: {},
-    overrideTemporal: {},
     onUpdateAccessMethod: jest.fn(),
     ...overrideProps
   }
@@ -57,24 +56,6 @@ describe('EchoForm component', () => {
   test('renders an EDSCEchoform with temporal prepopulated', () => {
     const { enzymeWrapper } = setup({
       temporal: {
-        endDate: '2020-03-05T17:49:07.369Z',
-        startDate: '2019-12-06T07:34:12.613Z'
-      }
-    })
-
-    expect(enzymeWrapper.find(EDSCEchoform).props().prepopulateValues).toEqual({
-      TEMPORAL_START: '2019-12-06T07:34:12',
-      TEMPORAL_END: '2020-03-05T17:49:07'
-    })
-  })
-
-  test('renders an EDSCEchoform with overrideTemporal prepopulated', () => {
-    const { enzymeWrapper } = setup({
-      temporal: {
-        endDate: '2020-12-31T59:59:59.999Z',
-        startDate: '1990-01-01T00:00:00.000Z'
-      },
-      overrideTemporal: {
         endDate: '2020-03-05T17:49:07.369Z',
         startDate: '2019-12-06T07:34:12.613Z'
       }

--- a/static/src/js/components/ProjectPanels/ProjectPanels.js
+++ b/static/src/js/components/ProjectPanels/ProjectPanels.js
@@ -567,7 +567,6 @@ class ProjectPanels extends PureComponent {
             <AccessMethod
               accessMethods={accessMethods}
               granuleMetadata={granulesMetadata}
-              granulesQuery={granulesQuery}
               index={index}
               metadata={collectionMetadata}
               onSelectAccessMethod={onSelectAccessMethod}

--- a/static/src/js/components/ProjectPanels/ProjectPanels.js
+++ b/static/src/js/components/ProjectPanels/ProjectPanels.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { parse } from 'qs'
-import { uniq } from 'lodash'
+import { isEmpty, uniq } from 'lodash'
 import {
   FaCheckCircle,
   FaCog,
@@ -276,6 +276,7 @@ class ProjectPanels extends PureComponent {
       dataQualitySummaries,
       focusedGranuleId,
       granulesMetadata,
+      granulesQueries,
       location,
       onChangePath,
       onChangeProjectGranulePageNum,
@@ -341,6 +342,17 @@ class ProjectPanels extends PureComponent {
         cloudHosted,
         duplicateCollections = []
       } = collectionMetadata
+
+      const { granules: granulesQuery = {} } = granulesQueries[collectionId] || {}
+      const { temporal: granuleTemporal = {} } = granulesQuery
+
+      // Default the preferredTemporal to global temporal
+      let preferredTemporal = temporal
+
+      // If overrideTemporal is provided, use that value
+      if (!isEmpty(overrideTemporal)) preferredTemporal = overrideTemporal
+      // If granuleTemporal is provided, use that value
+      if (!isEmpty(granuleTemporal)) preferredTemporal = granuleTemporal
 
       let { [collectionId]: collectionDataQualitySummaries = [] } = dataQualitySummaries
 
@@ -555,6 +567,7 @@ class ProjectPanels extends PureComponent {
             <AccessMethod
               accessMethods={accessMethods}
               granuleMetadata={granulesMetadata}
+              granulesQuery={granulesQuery}
               index={index}
               metadata={collectionMetadata}
               onSelectAccessMethod={onSelectAccessMethod}
@@ -564,8 +577,7 @@ class ProjectPanels extends PureComponent {
               selectedAccessMethod={selectedAccessMethod}
               shapefileId={shapefileId}
               spatial={spatial}
-              temporal={temporal}
-              overrideTemporal={overrideTemporal}
+              temporal={preferredTemporal}
             />
           </PanelItem>
           <PanelItem
@@ -674,6 +686,7 @@ ProjectPanels.propTypes = {
   focusedCollectionId: PropTypes.string.isRequired,
   focusedGranuleId: PropTypes.string.isRequired,
   granulesMetadata: PropTypes.shape({}).isRequired,
+  granulesQueries: PropTypes.shape({}).isRequired,
   location: locationPropType.isRequired,
   onChangePath: PropTypes.func.isRequired,
   onChangeProjectGranulePageNum: PropTypes.func.isRequired,

--- a/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/ProjectPanels.test.js
@@ -6,6 +6,7 @@ import ProjectPanels from '../ProjectPanels'
 import PanelItem from '../../Panels/PanelItem'
 import PanelGroup from '../../Panels/PanelGroup'
 import PanelSection from '../../Panels/PanelSection'
+import AccessMethod from '../../AccessMethod/AccessMethod'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -56,7 +57,7 @@ function setup(overrideProps) {
     focusedCollectionId: '',
     focusedGranuleId: '',
     granulesMetadata: {},
-    granuleQuery: {},
+    granulesQueries: {},
     portal: {},
     project: {
       collections: {
@@ -473,6 +474,98 @@ describe('ProjectPanels component', () => {
 
         expect(props.onToggleAboutCSDAModal).toHaveBeenCalledTimes(1)
         expect(props.onToggleAboutCSDAModal).toHaveBeenCalledWith(true)
+      })
+    })
+
+    describe('when only global temporal is provided', () => {
+      test('passes the temporal to AccessMethod', () => {
+        const expectedTemporal = {
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        }
+
+        const { enzymeWrapper } = setup({
+          temporal: expectedTemporal
+        })
+
+        expect(enzymeWrapper.find(AccessMethod).props().temporal).toEqual({
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        })
+      })
+    })
+
+    describe('when overrideTemporal is provided', () => {
+      test('passes the overrideTemporal to AccessMethod', () => {
+        const expectedTemporal = {
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        }
+
+        const { enzymeWrapper } = setup({
+          overrideTemporal: expectedTemporal,
+          temporal: {
+            endDate: '2022-01-31T23:59:59.999Z',
+            startDate: '2022-01-01T00:00:00.000Z',
+            recurringDayStart: '',
+            recurringDayEnd: '',
+            isRecurring: false
+          }
+        })
+
+        expect(enzymeWrapper.find(AccessMethod).props().temporal).toEqual({
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        })
+      })
+    })
+
+    describe('when granuleTemporal is provided', () => {
+      test('passes the granuleTemporal to AccessMethod', () => {
+        const expectedTemporal = {
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        }
+
+        const { enzymeWrapper } = setup({
+          granulesQueries: {
+            collectionId: {
+              granules: {
+                temporal: expectedTemporal
+              }
+            }
+          },
+          temporal: {
+            endDate: '2022-01-31T23:59:59.999Z',
+            startDate: '2022-01-01T00:00:00.000Z',
+            recurringDayStart: '',
+            recurringDayEnd: '',
+            isRecurring: false
+          }
+        })
+
+        expect(enzymeWrapper.find(AccessMethod).props().temporal).toEqual({
+          endDate: '2022-01-15T23:59:59.999Z',
+          startDate: '2022-01-10T00:00:00.000Z',
+          recurringDayStart: '',
+          recurringDayEnd: '',
+          isRecurring: false
+        })
       })
     })
   })

--- a/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
+++ b/static/src/js/containers/ProjectPanelsContainer/ProjectPanelsContainer.js
@@ -16,15 +16,16 @@ export const mapStateToProps = (state) => ({
   focusedCollectionId: getFocusedCollectionId(state),
   focusedGranuleId: getFocusedGranuleId(state),
   granulesMetadata: state.metadata.granules,
+  granulesQueries: state.query.collection.byId,
   location: state.router.location,
+  overrideTemporal: state.query.collection.overrideTemporal,
   panels: state.panels,
   portal: state.portal,
   project: state.project,
   projectCollectionsMetadata: getProjectCollectionsMetadata(state),
   shapefileId: state.shapefile.shapefileId,
   spatial: state.query.collection.spatial,
-  temporal: state.query.collection.temporal,
-  overrideTemporal: state.query.collection.overrideTemporal
+  temporal: state.query.collection.temporal
 })
 
 export const mapDispatchToProps = (dispatch) => ({
@@ -89,6 +90,7 @@ export const ProjectPanelsContainer = ({
   focusedCollectionId,
   focusedGranuleId,
   granulesMetadata,
+  granulesQueries,
   location,
   onAddGranuleToProjectCollection,
   onChangePath,
@@ -117,6 +119,7 @@ export const ProjectPanelsContainer = ({
     focusedCollectionId={focusedCollectionId}
     focusedGranuleId={focusedGranuleId}
     granulesMetadata={granulesMetadata}
+    granulesQueries={granulesQueries}
     location={location}
     onAddGranuleToProjectCollection={onAddGranuleToProjectCollection}
     onChangePath={onChangePath}
@@ -143,6 +146,7 @@ export const ProjectPanelsContainer = ({
 )
 
 ProjectPanelsContainer.defaultProps = {
+  granulesQueries: {},
   shapefileId: null,
   temporal: {},
   overrideTemporal: {}
@@ -153,6 +157,7 @@ ProjectPanelsContainer.propTypes = {
   focusedCollectionId: PropTypes.string.isRequired,
   focusedGranuleId: PropTypes.string.isRequired,
   granulesMetadata: PropTypes.shape({}).isRequired,
+  granulesQueries: PropTypes.shape({}),
   location: locationPropType.isRequired,
   onAddGranuleToProjectCollection: PropTypes.func.isRequired,
   onChangePath: PropTypes.func.isRequired,


### PR DESCRIPTION
# Overview

### What is the feature?

Some ECHO forms allow for temporal subsetting when a temporal constraint is applied to the user's search. This was not working when the user had only applied a granule level temporal constraint.

### What is the Solution?

Previously we supplied temporal and overrideTemporal to the EchoForm component and it sorted out which should be passed to the echoforms plugin. This change moves that logic into ProjectPanels, and only passes a single temporal object through to EchoForm. It also looks for granule temporal and prefers that temporal over the global temporal and the overrideTemporal

### What areas of the application does this impact?

ESI Access Methods with temporal subsetting.

# Testing

### Reproduction steps

Should work in any environment:

- Search for ATL22
- View granules for a collections with the customizable icons
- Apply a temporal filter within the granule filters
- Click Download All
- On the project page select the Customize ESI access method
- Check the "Click to enable" checkbox under Temporal Subsetting.
- Ensure that dates are populated directly under that checkbox, and that they match the granule temporal filter you applied

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
