### PR TITLE
EDSC-3300: Rectify placeholder value in keyword search

### DIFF
--- a/static/src/js/components/SearchForm/SearchForm.js
+++ b/static/src/js/components/SearchForm/SearchForm.js
@@ -324,7 +324,7 @@ class SearchForm extends Component {
                 name: 'keywordSearch',
                 'data-test-id': 'keyword-search-input',
                 className: 'search-form__input',
-                placeholder: 'Search for collections or topics',
+                placeholder: 'Type text to search for data',
                 value: keywordSearch,
                 onChange: this.onAutoSuggestChange
               }}


### PR DESCRIPTION
# Overview

### What is the feature?

* [#1542](https://github.com/nasa/earthdata-search/issues/1542) - Rectify placeholder value in keyword search


### What is the Solution?

* Renamed phrase **`Search for collections or topics`** to **`Type text to search for data`**

### What areas of the application does this impact?

* SearchForm Component

# Testing

### Reproduction steps

1. Start the server
2. Placeholder in keyword search should be **`Type text to search for data`**

### Attachments

**⬇️ UI Snapshot Before the change**

![beforeChange](https://user-images.githubusercontent.com/101206240/190896578-0c6e1fab-6cea-4a02-97cd-01c1bfb3cedd.png)

**⬇️ UI Snapshot After the change** 

![afterChange](https://user-images.githubusercontent.com/101206240/190896595-c50bf92d-597b-4252-8fa5-922b8cae0a7c.png)

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
