### PR TITLE
EDSC-3547: Removing collections search results layout A/B test code

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -19,8 +19,6 @@ config="`jq '.application.granuleLinksPageSize = $newValue' --arg newValue $bamb
 config="`jq '.application.openSearchGranuleLinksPageSize = $newValue' --arg newValue $bamboo_OPEN_SEARCH_GRANULE_LINKS_PAGE_SIZE <<< $config`"
 config="`jq '.environment.production.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.environment.production.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
-config="`jq '.experiments.collectionSearchResultsLayout.experimentId = $newValue' --arg newValue $bamboo_COLLECTION_SEARCH_RESULTS_EXPERIMENT_ID <<< $config`"
-config="`jq '.experiments.collectionSearchResultsLayout.variants = $newValue' --arg newValue $bamboo_COLLECTION_SEARCH_RESULTS_EXPERIMENT_VARIANTS <<< $config`"
 
 # overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json

--- a/static.config.json
+++ b/static.config.json
@@ -107,10 +107,5 @@
       "redirectUriPath": "/urs_callback"
     }
   },
-  "experiments": {
-    "collectionSearchResultsLayout": {
-      "experimentId": "",
-      "variants": ""
-    }
-  }
+  "experiments": {}
 }

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.js
@@ -44,8 +44,7 @@ export const CollectionResultsItem = forwardRef(({
   onAddProjectCollection,
   onRemoveCollectionFromProject,
   onViewCollectionDetails,
-  onViewCollectionGranules,
-  variant
+  onViewCollectionGranules
 }, ref) => {
   const {
     collectionId,
@@ -361,13 +360,9 @@ export const CollectionResultsItem = forwardRef(({
                   )
                 }
               </div>
-              {
-                variant !== 'thumb-only' && (
-                  <p className="collection-results-item__desc">
-                    {summary}
-                  </p>
-                )
-              }
+              <p className="collection-results-item__desc">
+                {summary}
+              </p>
             </div>
             {
               thumbnail && (
@@ -514,17 +509,12 @@ export const CollectionResultsItem = forwardRef(({
 
 CollectionResultsItem.displayName = 'CollectionResultsItem'
 
-CollectionResultsItem.defaultProps = {
-  variant: ''
-}
-
 CollectionResultsItem.propTypes = {
   collectionMetadata: collectionMetadataPropType.isRequired,
   onAddProjectCollection: PropTypes.func.isRequired,
   onRemoveCollectionFromProject: PropTypes.func.isRequired,
   onViewCollectionDetails: PropTypes.func.isRequired,
-  onViewCollectionGranules: PropTypes.func.isRequired,
-  variant: PropTypes.string
+  onViewCollectionGranules: PropTypes.func.isRequired
 }
 
 export default CollectionResultsItem

--- a/static/src/js/components/CollectionResults/CollectionResultsList.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsList.js
@@ -9,18 +9,9 @@ import { VariableSizeList as List } from 'react-window'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import InfiniteLoader from 'react-window-infinite-loader'
 
-import { getExperimentsConfig } from '../../../../../sharedUtils/config'
-
-import ABExperiment from '../ABExperiment/ABExperiment'
 import CollectionResultsListItem from './CollectionResultsListItem'
 
 import './CollectionResultsList.scss'
-
-const { collectionSearchResultsLayout = {} } = getExperimentsConfig()
-const {
-  experimentId: collectionSearchResultsLayoutExperimentId = '',
-  variants: collectionSearchResultsLayoutExperimentVariants = ''
-} = collectionSearchResultsLayout
 
 /**
  * Renders innerElementType to override the default react window behavior so sticky columns can be used.
@@ -104,73 +95,65 @@ export const CollectionResultsList = ({
   const getSize = useCallback((index) => sizeMap.current[index] || 162, [])
 
   return (
-    <ABExperiment
-      experimentId={collectionSearchResultsLayoutExperimentId}
-      variants={collectionSearchResultsLayoutExperimentVariants}
-    >
-      {({ variant: itemVariant }) => (
-        <div className="collection-results-list">
-          <AutoSizer style={{ position: 'relative', height: '100%', width: '100%' }}>
-            {
-              ({ height, width }) => (
-                <InfiniteLoader
-                  ref={infiniteLoaderRef}
-                  isItemLoaded={isItemLoaded}
-                  itemCount={itemCount}
-                  loadMoreItems={loadMoreItems}
-                  threshold={4}
-                >
-                  {
-                    ({ onItemsRendered, ref }) => (
-                      <List
-                        ref={(list) => {
-                          ref(list)
-                          listRef.current = list
-                        }}
-                        height={height}
-                        width={width}
-                        innerElementType={innerElementType}
-                        itemCount={itemCount}
-                        itemSize={getSize}
-                        itemData={{
-                          windowHeight: height,
-                          windowWidth: width,
-                          collectionsMetadata,
-                          onAddProjectCollection,
-                          onRemoveCollectionFromProject,
-                          onViewCollectionGranules,
-                          onViewCollectionDetails,
-                          isItemLoaded,
-                          itemVariant,
-                          setSize
-                        }}
-                        onItemsRendered={
-                          (data) => {
-                            const {
-                              visibleStartIndex,
-                              visibleStopIndex
-                            } = data
+    <div className="collection-results-list">
+      <AutoSizer style={{ position: 'relative', height: '100%', width: '100%' }}>
+        {
+          ({ height, width }) => (
+            <InfiniteLoader
+              ref={infiniteLoaderRef}
+              isItemLoaded={isItemLoaded}
+              itemCount={itemCount}
+              loadMoreItems={loadMoreItems}
+              threshold={4}
+            >
+              {
+                ({ onItemsRendered, ref }) => (
+                  <List
+                    ref={(list) => {
+                      ref(list)
+                      listRef.current = list
+                    }}
+                    height={height}
+                    width={width}
+                    innerElementType={innerElementType}
+                    itemCount={itemCount}
+                    itemSize={getSize}
+                    itemData={{
+                      windowHeight: height,
+                      windowWidth: width,
+                      collectionsMetadata,
+                      onAddProjectCollection,
+                      onRemoveCollectionFromProject,
+                      onViewCollectionGranules,
+                      onViewCollectionDetails,
+                      isItemLoaded,
+                      setSize
+                    }}
+                    onItemsRendered={
+                      (data) => {
+                        const {
+                          visibleStartIndex,
+                          visibleStopIndex
+                        } = data
 
-                            const middleIndex = Math.round(
-                              (visibleStartIndex + visibleStopIndex) / 2
-                            )
+                        const middleIndex = Math.round(
+                          (visibleStartIndex + visibleStopIndex) / 2
+                        )
 
-                            if (middleIndex) setVisibleMiddleIndex(middleIndex)
-                            onItemsRendered(data)
-                          }
-                        }
-                      >
-                        {CollectionResultsListItem}
-                      </List>
-                    )
-                  }
-                </InfiniteLoader>
-              )
-            }
-          </AutoSizer>
-        </div>
-      )}
-    </ABExperiment>
+                        if (middleIndex) setVisibleMiddleIndex(middleIndex)
+                        onItemsRendered(data)
+                      }
+                    }
+                  >
+                    {CollectionResultsListItem}
+                  </List>
+                )
+              }
+            </InfiniteLoader>
+          )
+        }
+      </AutoSizer>
+    </div>
   )
 }
 

--- a/static/src/js/components/CollectionResults/CollectionResultsListItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsListItem.js
@@ -30,7 +30,6 @@ export const CollectionResultsListItem = memo(({
   const {
     collectionsMetadata,
     isItemLoaded,
-    itemVariant,
     onAddProjectCollection,
     onRemoveCollectionFromProject,
     onViewCollectionDetails,
@@ -79,7 +78,6 @@ export const CollectionResultsListItem = memo(({
         onViewCollectionDetails={onViewCollectionDetails}
         onViewCollectionGranules={onViewCollectionGranules}
         ref={element}
-        variant={itemVariant}
       />
     </li>
   )
@@ -93,7 +91,6 @@ CollectionResultsListItem.propTypes = {
       collectionMetadataPropType
     ),
     isItemLoaded: PropTypes.func,
-    itemVariant: PropTypes.string,
     onAddProjectCollection: PropTypes.func,
     onRemoveCollectionFromProject: PropTypes.func,
     onViewCollectionDetails: PropTypes.func,


### PR DESCRIPTION
# Overview

### What is the feature?

Removes remaining A/B test code leaving the default experience for the collection search results layout, which contains both a thumbnail (where possible) and a text description

### What is the Solution?

Deleted some code.

### What areas of the application does this impact?

Collection search results

# Testing

### Reproduction steps

- **Environment for testing:** any
- **Collection to test with:** n/a

1. Load the collection search results
2. Confirm the search results look as expected; containing both a thumbnail (where possible) and a text description

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
