### PR TITLE
EDSC-3522: Moves `Include only EOSDIS collections` to use consortium instead of tags

### DIFF
--- a/cypress/integration/paths/search/__mocks__/non_eosdis.body.json
+++ b/cypress/integration/paths/search/__mocks__/non_eosdis.body.json
@@ -1,10 +1,11 @@
 {
   "feed": {
-    "updated": "2021-05-27T17:35:49.322Z",
-    "id": "https://cmr.earthdata.nasa.gov:443/search/collections.json?has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.extra.%2A%2Copensearch.granule.osdd&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Bspatial%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&page_num=1&page_size=20&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&tag_key%5B%5D=gov.nasa.eosdis",
+    "updated": "2022-10-06T17:33:12.685Z",
+    "id": "https://cmr.earthdata.nasa.gov:443/search/collections.json?has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.*,opensearch.granule.osdd&page_num=1&page_size=20&consortium[]=EOSDIS&sort_key[]=has_granules_or_cwic&sort_key[]=-usage_score",
     "title": "ECHO dataset metadata",
     "entry": [
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -12,38 +13,58 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:51.487Z"
+              "updated_at": "2022-10-06T12:43:43.522Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2014-04-03T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-18T21:13:23.000Z",
+        "updated": "2021-07-15T19:16:39.000Z",
         "dataset_id": "SENTINEL-1A_SLC",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
         "short_name": "SENTINEL-1A_SLC",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
+        "organizations": ["ASF", "ESA/CS1CGS"],
         "title": "SENTINEL-1A_SLC",
         "coordinate_system": "CARTESIAN",
         "summary": "Sentinel-1A slant-range product",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1214470488-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 1056528,
+        "granule_count": 1336883,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
         "online_access_flag": true,
         "links": [
           {
@@ -54,6 +75,7 @@
         ]
       },
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -61,87 +83,58 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:52.812Z"
+              "updated_at": "2022-10-06T12:43:41.589Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2016-04-25T00:00:00.000Z",
-        "version_id": "1",
-        "updated": "2021-05-24T18:56:48.000Z",
-        "dataset_id": "SENTINEL-1B_SLC",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "SENTINEL-1B_SLC",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1B_SLC",
-        "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1B slant-range product",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1327985661-ASF",
-        "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 693411,
-        "archive_center": "ASF",
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
-          }
-        ]
-      },
-      {
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:50.161Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2014-04-03T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:02:49.000Z",
+        "updated": "2021-07-15T19:15:56.000Z",
         "dataset_id": "SENTINEL-1A_DUAL_POL_GRD_HIGH_RES",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
         "short_name": "SENTINEL-1A_DP_GRD_HIGH",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
+        "organizations": ["ASF", "ESA/CS1CGS"],
         "title": "SENTINEL-1A_DUAL_POL_GRD_HIGH_RES",
         "coordinate_system": "CARTESIAN",
         "summary": "Sentinel-1A Dual-pol ground projected high and full resolution images",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1214470533-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 895914,
+        "granule_count": 1142671,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
         "online_access_flag": true,
         "links": [
           {
@@ -152,6 +145,7 @@
         ]
       },
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -159,38 +153,128 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:51.558Z"
+              "updated_at": "2022-10-06T12:43:45.579Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2016-04-25T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:09:25.000Z",
+        "updated": "2021-07-15T19:17:22.000Z",
+        "dataset_id": "SENTINEL-1B_SLC",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "ASF",
+        "short_name": "SENTINEL-1B_SLC",
+        "organizations": ["ASF", "ESA/CS1CGS"],
+        "title": "SENTINEL-1B_SLC",
+        "coordinate_system": "CARTESIAN",
+        "summary": "Sentinel-1B slant-range product",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1327985661-ASF",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "ECHO10",
+        "granule_count": 789393,
+        "archive_center": "ASF",
+        "has_temporal_subsetting": false,
+        "browse_flag": false,
+        "platforms": ["Sentinel-1B"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://vertex.daac.asf.alaska.edu/"
+          }
+        ]
+      },
+      {
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": true,
+              "updated_at": "2022-10-06T12:43:43.737Z"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2016-04-25T00:00:00.000Z",
+        "version_id": "1",
+        "updated": "2021-07-15T19:16:47.000Z",
         "dataset_id": "SENTINEL-1B_DUAL_POL_GRD_HIGH_RES",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
         "short_name": "SENTINEL-1B_DP_GRD_HIGH",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
+        "organizations": ["ASF", "ESA/CS1CGS"],
         "title": "SENTINEL-1B_DUAL_POL_GRD_HIGH_RES",
         "coordinate_system": "CARTESIAN",
         "summary": "Sentinel-1B Dual-pol ground projected high and full resolution images",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1327985645-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 612043,
+        "granule_count": 694859,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["Sentinel-1B"],
         "online_access_flag": true,
         "links": [
           {
@@ -201,232 +285,317 @@
         ]
       },
       {
-        "processing_level_id": "2",
+        "processing_level_id": "3",
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
               "cloud_cover": false,
-              "day_night_flag": false,
+              "day_night_flag": true,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": false,
-              "updated_at": "2021-05-27T12:16:23.463Z"
+              "updated_at": "2022-10-06T12:33:52.040Z"
             }
+          },
+          "edsc.extra.serverless.gibs": {
+            "data": [
+              {
+                "format": "png",
+                "antarctic": false,
+                "geographic": true,
+                "group": "overlays",
+                "geographic_resolution": "31.25m",
+                "arctic_resolution": null,
+                "source": "Sentinel 2A & 2B / MSI",
+                "arctic": false,
+                "title": "Reflectance (Nadir BRDF-Adjusted)",
+                "updated_at": "2022-10-06T12:45:21.994Z",
+                "antarctic_resolution": null,
+                "product": "HLS_S30_Nadir_BRDF_Adjusted_Reflectance",
+                "match": {
+                  "time_start": ">=2020-09-03T00:00:00Z",
+                  "day_night_flag": "day"
+                }
+              }
+            ]
           }
         },
-        "boxes": [
-          "-80 -180 80 180"
-        ],
-        "time_start": "2016-01-01T00:00:00.000Z",
-        "version_id": "2",
-        "dataset_id": "VIIRS (S-NPP) I Band 375 m Active Fire Product NRT (Vector data)",
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2015-11-28T00:00:00.000Z",
+        "version_id": "2.0",
+        "updated": "2020-03-04T07:19:53.396Z",
+        "dataset_id": "HLS Sentinel-2 Multi-spectral Instrument Surface Reflectance Daily Global 30m v2.0",
         "has_spatial_subsetting": false,
         "has_transforms": false,
+        "associations": { "tools": ["TL1860232272-LPDAAC_ECS"] },
         "has_variables": false,
-        "data_center": "LANCEMODIS",
-        "short_name": "VNP14IMGTDL_NRT",
-        "organizations": [
-          "NASA/GSFC/EOS/ESDIS/LANCE MODIS"
-        ],
-        "title": "VIIRS (S-NPP) I Band 375 m Active Fire Product NRT (Vector data)",
+        "data_center": "LPCLOUD",
+        "short_name": "HLSS30",
+        "organizations": ["LP DAAC", "NASA/IMPACT"],
+        "title": "HLS Sentinel-2 Multi-spectral Instrument Surface Reflectance Daily Global 30m v2.0",
         "coordinate_system": "CARTESIAN",
-        "summary": "Near real-time (NRT) Suomi National Polar-orbiting Partnership (Suomi NPP) Visible Infrared Imaging Radiometer Suite (VIIRS) Active Fire detection product is based on that instrument's 375 m nominal resolution data. Compared to other coarser resolution (≥1km) satellite fire detection products, the improved 375 m data provide greater response over fires of relatively small areas, as well as improved mapping of large fire perimeters. Consequently, the data are well suited for use in support of fire management (e.g., near real-time alert systems), as well as other science applications requiring improved fire mapping fidelity. The 375 m product complements the baseline Suomi NPP/VIIRS 750 m active fire detection and characterization data, which was originally designed to provide continuity to the existing 1 km Earth Observing System Moderate Resolution Imaging Spectroradiometer (EOS/MODIS) active fire data record. Due to frequent data saturation issues, the current 375 m fire product provides detection information only with no sub-pixel fire characterization.\r\n\r\nVNP14IMGTDL_NRT are available in the following formats: TXT, SHP, KML, WMS. These data are also provided through the LANCE FIRMS Fire Email Alerts. Please note only the TXT and SHP files contain all the attributes.",
+        "summary": "The Harmonized Landsat Sentinel-2 (HLS) project provides consistent surface reflectance data from the Operational Land Imager (OLI) aboard the joint NASA/USGS Landsat 8 satellite and the Multi-Spectral Instrument (MSI) aboard Europe’s Copernicus Sentinel-2A and Sentinel-2B satellites. The combined measurement enables global observations of the land every 2–3 days at 30-meter (m) spatial resolution. The HLS project uses a set of algorithms to obtain seamless products from OLI and MSI that include atmospheric correction, cloud and cloud-shadow masking, spatial co-registration and common gridding, illumination and view angle normalization, and spectral bandpass adjustment. \r\n\r\nThe HLSS30 product provides 30-m Nadir Bidirectional Reflectance Distribution Function (BRDF)-Adjusted Reflectance (NBAR) and is derived from Sentinel-2A and Sentinel-2B MSI data products. The HLSS30 and HLSL30 products are gridded to the same resolution and Military Grid Reference System (MGRS) (https://hls.gsfc.nasa.gov/products-description/tiling-system/) tiling system, and thus are “stackable” for time series analysis.\r\n\r\nThe HLSS30 product is provided in Cloud Optimized GeoTIFF (COG) format, and each band is distributed as a separate COG. There are 13 bands included in the HLSS30 product along with four angle bands and a quality assessment (QA) band. See the User Guide for a more detailed description of the individual bands provided in the HLSS30 product.\r\n",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
-        "id": "C1942970257-LANCEMODIS",
+        "id": "C2021957295-LPCLOUD",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "UMM_JSON",
-        "collection_data_type": "NEAR_REAL_TIME",
-        "granule_count": 7,
+        "collection_data_type": "OTHER",
+        "granule_count": 4560314,
+        "archive_center": "LP DAAC",
         "has_temporal_subsetting": false,
         "browse_flag": true,
+        "platforms": ["Sentinel-2A", "Sentinel-2B"],
         "online_access_flag": true,
         "links": [
           {
-            "length": "500.0KB",
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "https://nrt3.modaps.eosdis.nasa.gov/archive/FIRMS/suomi-npp-viirs-c2"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://earthdata.nasa.gov/earth-observation-data/near-real-time/firms/active-fire-data"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
-            "hreflang": "en-US",
-            "href": "https://firms.modaps.eosdis.nasa.gov/map/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
-            "hreflang": "en-US",
-            "href": "https://firms.modaps.eosdis.nasa.gov/alerts/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
-            "hreflang": "en-US",
-            "href": "https://firms.modaps.eosdis.nasa.gov/web-services/"
-          }
-        ]
-      },
-      {
-        "processing_level_id": "2",
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": false,
-              "updated_at": "2021-05-27T12:10:14.515Z"
-            }
-          }
-        },
-        "boxes": [
-          "-80 -180 80 180"
-        ],
-        "time_start": "2002-05-04T00:00:00.000Z",
-        "version_id": "6NRT",
-        "dataset_id": "MODIS/Aqua Terra Thermal Anomalies/Fire locations 1km FIRMS V006 NRT (Vector data)",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "LANCEMODIS",
-        "short_name": "MCD14DL",
-        "organizations": [
-          "NASA/GSFC/EOS/ESDIS/LANCE MODIS FIRMS"
-        ],
-        "title": "MODIS/Aqua Terra Thermal Anomalies/Fire locations 1km FIRMS V006 NRT (Vector data)",
-        "coordinate_system": "CARTESIAN",
-        "summary": "Near Real-Time (NRT) MODIS Thermal Anomalies / Fire locations processed by FIRMS (Fire Information for Resource Management System) - Land Atmosphere Near real time Capability for EOS (LANCE), using swath products (MOD14/MYD14) rather than the tiled MOD14A1 and MYD14A1 products. The thermal anomalies / active fire represent the center of a 1km pixel that is flagged by the MODIS MOD14/MYD14 Fire and Thermal Anomalies algorithm (Giglio 2003) as containing one or more fires within the pixel. This is the most basic fire product in which active fires and other thermal anomalies, such as volcanoes, are identified.MCD14DL are available in the following formats: TXT, SHP, KML, WMS. These data are also provided through the FIRMS Fire Email Alerts. Please note only the TXT and SHP files contain all the attributes.",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1227495594-LANCEMODIS",
-        "has_formats": false,
-        "original_format": "UMM_JSON",
-        "collection_data_type": "NEAR_REAL_TIME",
-        "granule_count": 7,
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
-        "online_access_flag": true,
-        "links": [
-          {
-            "length": "1.5MB",
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://firms.modaps.eosdis.nasa.gov/active_fire/"
+            "href": "https://search.earthdata.nasa.gov/search?q=C2021957295-LPCLOUD"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
             "hreflang": "en-US",
-            "href": "https://earthdata.nasa.gov/earth-observation-data/near-real-time/firms/active-fire-data"
+            "href": "https://doi.org/10.5067/HLS/HLSS30.002"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/1326/HLS_User_Guide_V2.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/769/HLS_ATBD_V15_provisional.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/1117/HLS_Quick_Guide_v02.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-tutorial/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-super-script/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://cmr.earthdata.nasa.gov/browse-scaler/browse_images/granules/G2095548655-LPCLOUD?h=512&w=512"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-bulk-download/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/resources/e-learning/getting-started-with-cloud-native-harmonized-landsat-sentinel-2-hls-data-in-r/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://wiki.earthdata.nasa.gov/pages/viewpage.action?pageId=195432390"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://worldview.earthdata.nasa.gov/?v=-191.12397594071413,-86.52209371542455,182.39111268571813,89.5139950740695&t=2020-10-15-T16%3A46%3A06Z&l=Reference_Labels(hidden),Reference_Features(hidden),Coastlines,HLS_S30_Nadir_BRDF_Adjusted_Reflectance(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&tr=hls_intro "
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "https://nrt3.modaps.eosdis.nasa.gov/archive/FIRMS/"
+            "href": "https://appeears.earthdatacloud.nasa.gov/"
           }
         ]
       },
       {
+        "processing_level_id": "3",
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
               "cloud_cover": false,
-              "day_night_flag": false,
+              "day_night_flag": true,
               "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:51.625Z"
+              "orbit_calculated_spatial_domains": false,
+              "updated_at": "2022-10-06T12:33:51.799Z"
             }
+          },
+          "edsc.extra.serverless.gibs": {
+            "data": [
+              {
+                "format": "png",
+                "antarctic": false,
+                "geographic": true,
+                "group": "overlays",
+                "geographic_resolution": "31.25m",
+                "arctic_resolution": null,
+                "source": "Landsat 8 & 9 / OLI",
+                "arctic": false,
+                "title": "Reflectance (Nadir BRDF-Adjusted)",
+                "updated_at": "2022-10-06T12:45:21.994Z",
+                "antarctic_resolution": null,
+                "product": "HLS_L30_Nadir_BRDF_Adjusted_Reflectance",
+                "match": {
+                  "time_start": ">=2020-08-11T00:00:00Z",
+                  "day_night_flag": "day"
+                }
+              }
+            ]
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2016-04-25T00:00:00.000Z",
-        "version_id": "1",
-        "updated": "2021-05-24T19:09:42.000Z",
-        "dataset_id": "SENTINEL-1B_DUAL_POL_GRD_MEDIUM_RES",
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2013-04-11T00:00:00.000Z",
+        "version_id": "2.0",
+        "updated": "2015-12-03T10:57:07.000Z",
+        "dataset_id": "HLS Landsat Operational Land Imager Surface Reflectance and TOA Brightness Daily Global 30m v2.0",
         "has_spatial_subsetting": false,
         "has_transforms": false,
+        "associations": { "tools": ["TL1860232272-LPDAAC_ECS"] },
         "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "SENTINEL-1B_DP_GRD_MEDIUM",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1B_DUAL_POL_GRD_MEDIUM_RES",
+        "data_center": "LPCLOUD",
+        "short_name": "HLSL30",
+        "organizations": ["LP DAAC", "NASA/IMPACT"],
+        "title": "HLS Landsat Operational Land Imager Surface Reflectance and TOA Brightness Daily Global 30m v2.0",
         "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1B Dual-pol ground projected medium resolution images",
+        "summary": "The Harmonized Landsat Sentinel-2 (HLS) project provides consistent surface reflectance (SR) and top of atmosphere (TOA) brightness data from a virtual constellation of satellite sensors. The Operational Land Imager (OLI) is housed aboard the joint NASA/USGS Landsat 8 and Landsat 9 satellites, while the Multi-Spectral Instrument (MSI) is mounted aboard Europe’s Copernicus Sentinel-2A and Sentinel-2B satellites. The combined measurement enables global observations of the land every 2–3 days at 30-meter (m) spatial resolution. The HLS project uses a set of algorithms to obtain seamless products from OLI and MSI that include atmospheric correction, cloud and cloud-shadow masking, spatial co-registration and common gridding, illumination and view angle normalization, and spectral bandpass adjustment.\r\n\r\nThe HLSL30 product provides 30-m Nadir Bidirectional Reflectance Distribution Function (BRDF)-Adjusted Reflectance (NBAR) and is derived from Landsat 8/9 OLI data products. The HLSS30 and HLSL30 products are gridded to the same resolution and Military Grid Reference System (MGRS)(https://hls.gsfc.nasa.gov/products-description/tiling-system/) tiling system, and thus are “stackable” for time series analysis.\r\n\r\nThe HLSL30 product is provided in Cloud Optimized GeoTIFF (COG) format, and each band is distributed as a separate file. There are 11 bands included in the HLSL30 product along with one quality assessment (QA) band and four angle bands. See the User Guide for a more detailed description of the individual bands provided in the HLSL30 product.",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
-        "id": "C1327985660-ASF",
+        "id": "C2021957657-LPCLOUD",
         "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 177136,
-        "archive_center": "ASF",
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "UMM_JSON",
+        "collection_data_type": "OTHER",
+        "granule_count": 8926337,
+        "archive_center": "LP DAAC",
         "has_temporal_subsetting": false,
-        "browse_flag": false,
+        "browse_flag": true,
+        "platforms": ["LANDSAT-8", "LANDSAT-9"],
         "online_access_flag": true,
         "links": [
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
-          }
-        ]
-      },
-      {
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:50.244Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2014-04-03T00:00:00.000Z",
-        "version_id": "1",
-        "updated": "2021-05-24T19:03:15.000Z",
-        "dataset_id": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "SENTINEL-1A_DP_GRD_MEDIUM",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
-        "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1A Dual-pol ground projected medium resolution images",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1214471521-ASF",
-        "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 157740,
-        "archive_center": "ASF",
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
-        "online_access_flag": true,
-        "links": [
+            "href": "https://search.earthdata.nasa.gov/search?q=C2021957657-LPCLOUD"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://doi.org/10.5067/HLS/HLSL30.002"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/1326/HLS_User_Guide_V2.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/769/HLS_ATBD_V15_provisional.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/1117/HLS_Quick_Guide_v02.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-tutorial/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-super-script/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://cmr.earthdata.nasa.gov/browse-scaler/browse_images/granules/G2095313663-LPCLOUD?h=512&w=512"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://git.earthdata.nasa.gov/projects/LPDUR/repos/hls-bulk-download/browse"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/resources/e-learning/getting-started-with-cloud-native-harmonized-landsat-sentinel-2-hls-data-in-r/"
+          },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
+            "href": "https://appeears.earthdatacloud.nasa.gov/"
           }
         ]
       },
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -434,38 +603,58 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:50.887Z"
+              "updated_at": "2022-10-06T12:43:42.818Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2014-04-03T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:05:59.000Z",
+        "updated": "2021-07-15T19:16:17.000Z",
         "dataset_id": "SENTINEL-1A_OCN",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
         "short_name": "SENTINEL-1A_OCN",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
+        "organizations": ["ASF", "ESA/CS1CGS"],
         "title": "SENTINEL-1A_OCN",
         "coordinate_system": "CARTESIAN",
         "summary": "SENTINEL-1A Level 2 Ocean wind, wave and current data",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1214472977-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 429208,
+        "granule_count": 604023,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
         "online_access_flag": true,
         "links": [
           {
@@ -477,6 +666,333 @@
       },
       {
         "processing_level_id": "2",
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": false,
+              "updated_at": "2022-10-06T12:29:59.575Z"
+            }
+          },
+          "edsc.extra.serverless.subset_service.opendap": {
+            "data": {
+              "updated_at": "2022-10-06T16:31:53.784Z",
+              "id": "S2004184019-POCLOUD",
+              "type": "OPeNDAP"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2002-07-04T00:00:00.000Z",
+        "version_id": "2019.0",
+        "updated": "2019-12-02T22:59:24.849Z",
+        "dataset_id": "GHRSST Level 2P Global Sea Surface Skin Temperature from the Moderate Resolution Imaging Spectroradiometer (MODIS) on the NASA Aqua satellite (GDS2)",
+        "has_spatial_subsetting": true,
+        "has_transforms": false,
+        "associations": {
+          "variables": [
+            "V1997812737-POCLOUD",
+            "V1997812697-POCLOUD",
+            "V2112014688-POCLOUD",
+            "V1997812756-POCLOUD",
+            "V1997812688-POCLOUD",
+            "V1997812670-POCLOUD",
+            "V1997812724-POCLOUD",
+            "V2112014684-POCLOUD",
+            "V1997812701-POCLOUD",
+            "V1997812681-POCLOUD",
+            "V2112014686-POCLOUD",
+            "V1997812663-POCLOUD",
+            "V1997812676-POCLOUD",
+            "V1997812744-POCLOUD",
+            "V1997812714-POCLOUD"
+          ],
+          "services": [
+            "S1962070864-POCLOUD",
+            "S2004184019-POCLOUD",
+            "S2153799015-POCLOUD",
+            "S2227193226-POCLOUD"
+          ],
+          "tools": ["TL2108419875-POCLOUD", "TL2092786348-POCLOUD"]
+        },
+        "has_variables": true,
+        "data_center": "POCLOUD",
+        "short_name": "MODIS_A-JPL-L2P-v2019.0",
+        "organizations": ["NASA/JPL/PODAAC"],
+        "title": "GHRSST Level 2P Global Sea Surface Skin Temperature from the Moderate Resolution Imaging Spectroradiometer (MODIS) on the NASA Aqua satellite (GDS2)",
+        "coordinate_system": "CARTESIAN",
+        "summary": "NASA produces skin sea surface temperature (SST) products from the Infrared (IR) channels of the Moderate-resolution Imaging Spectroradiometer (MODIS) onboard the Aqua satellite. Aqua was launched by NASA on May 4, 2002, into a sun synchronous, polar orbit with a daylight ascending node at 1:30 pm, formation flying in the A-train with other Earth Observation Satellites (EOS), to study the global dynamics of the Earth atmosphere, land and oceans. MODIS captures data in 36 spectral bands at a variety of spatial resolutions.  Two SST products can be present in these files. The first is a skin SST produced for both day and night (NSST) observations, derived from the long wave IR 11 and 12 micron wavelength channels, using a modified nonlinear SST algorithm intended to provide continuity of SST derived from heritage and current NASA sensors. At night, a second SST product is generated using the mid-infrared 3.95 and 4.05 micron  wavelength channels which are unique to MODIS; the SST derived from these measurements is identified as SST4. The SST4 product has lower uncertainty, but due to sun glint can only be used at night. MODIS L2P SST data have a 1 km spatial resolution at nadir and are stored in 288 five minute granules per day. Full global coverage is obtained every two days, with coverage poleward of 32.3 degree being complete each day.  The production of MODIS L2P SST files is part of the Group for High Resolution Sea Surface Temperature (GHRSST) project and is a joint collaboration between the NASA Jet Propulsion Laboratory (JPL), the NASA Ocean Biology Processing Group (OBPG), and the Rosenstiel School of Marine and Atmospheric Science (RSMAS). Researchers at RSMAS are responsible for SST algorithm development, error statistics and quality flagging, while the OBPG, as the NASA ground data system, is responsible for the production of daily MODIS ocean products. JPL acquires MODIS ocean granules from the OBPG and reformats them to the GHRSST L2P netCDF specification with complete metadata and ancillary variables, and distributes the data as the official Physical Oceanography Data Archive (PO.DAAC) for SST.  The R2019.0 supersedes the previous R2014.0 datasets which can be found at https://doi.org/10.5067/GHMDA-2PJ02",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "harmony": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {
+          "swath_width": "2330.0",
+          "period": "98.4",
+          "inclination_angle": "98.1",
+          "number_of_orbits": "1.0"
+        },
+        "id": "C1940473819-POCLOUD",
+        "has_formats": true,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "UMM_JSON",
+        "collection_data_type": "SCIENCE_QUALITY",
+        "granule_count": 2428866,
+        "archive_center": "NASA/JPL/PODAAC",
+        "has_temporal_subsetting": true,
+        "browse_flag": true,
+        "platforms": ["Aqua"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/Podaac/thumbnails/MODIS_A-JPL-L2P-v2019.0.jpg"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://github.com/podaac/data-readers"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ghrsst/open/docs/GDS20r5.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://ghrsst.jpl.nasa.gov"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst/flag/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/reprocessing/r2019/sst/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst4/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://modis.gsfc.nasa.gov/data/atbd/atbd_mod25.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "http://www.ghrsst.org"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/forum/viewforum.php?f=18&sid=e2d67e5a01815fc6e39fcd2087ed8bc8"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/CitingPODAAC"
+          },
+          {
+            "length": "75.0MB",
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://cmr.earthdata.nasa.gov/virtual-directory/collections/C1940473819-POCLOUD"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://github.com/podaac/tutorials/blob/master/notebooks/MODIS_L2P_SST_DataCube.ipynb"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://search.earthdata.nasa.gov/search/granules?p=C1940473819-POCLOUD"
+          }
+        ]
+      },
+      {
+        "processing_level_id": "3",
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": false,
+              "updated_at": "2022-10-06T12:22:45.570Z"
+            }
+          },
+          "edsc.extra.serverless.gibs": {
+            "data": [
+              {
+                "format": "png",
+                "antarctic": false,
+                "geographic": true,
+                "group": "overlays",
+                "geographic_resolution": "31.25m",
+                "arctic_resolution": null,
+                "source": "Terra / ASTER",
+                "arctic": false,
+                "title": "Global Digital Elevation Map (Color Index)",
+                "updated_at": "2022-10-06T12:45:21.992Z",
+                "antarctic_resolution": null,
+                "product": "ASTER_GDEM_Color_Index",
+                "match": {}
+              },
+              {
+                "format": "jpeg",
+                "antarctic": false,
+                "geographic": true,
+                "group": "baselayers",
+                "geographic_resolution": "31.25m",
+                "arctic_resolution": null,
+                "source": "Terra / ASTER",
+                "arctic": false,
+                "title": "Global Digital Elevation Map (Color Shaded Relief)",
+                "updated_at": "2022-10-06T12:45:21.992Z",
+                "antarctic_resolution": null,
+                "product": "ASTER_GDEM_Color_Shaded_Relief",
+                "match": {}
+              },
+              {
+                "format": "jpeg",
+                "antarctic": false,
+                "geographic": true,
+                "group": "baselayers",
+                "geographic_resolution": "31.25m",
+                "arctic_resolution": null,
+                "source": "Terra / ASTER",
+                "arctic": false,
+                "title": "Global Digital Elevation Map (Greyscale Shaded Relief)",
+                "updated_at": "2022-10-06T12:45:21.992Z",
+                "antarctic_resolution": null,
+                "product": "ASTER_GDEM_Greyscale_Shaded_Relief",
+                "match": {}
+              }
+            ]
+          }
+        },
+        "boxes": ["-83 -180 82 180"],
+        "time_start": "2000-03-01T00:00:00.000Z",
+        "version_id": "003",
+        "updated": "2015-09-30T10:42:35.418Z",
+        "dataset_id": "ASTER Global Digital Elevation Model V003",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "LPCLOUD",
+        "short_name": "ASTGTM",
+        "organizations": ["LP DAAC", "NASA/JPL/ASTER"],
+        "title": "ASTER Global Digital Elevation Model V003",
+        "coordinate_system": "CARTESIAN",
+        "summary": "The ASTER Global Digital Elevation Model (GDEM) Version 3 (ASTGTM) provides a global digital elevation model (DEM) of land areas on Earth at a spatial resolution of 1 arc second (approximately 30 meter horizontal posting at the equator).\r\n\r\nThe development of the ASTER GDEM data products is a collaborative effort between National Aeronautics and Space Administration (NASA) and Japan’s Ministry of Economy, Trade, and Industry (METI). The ASTER GDEM data products are created by the Sensor Information Laboratory Corporation (SILC) in Tokyo. \r\n\r\nThe ASTER GDEM Version 3 data product was created from the automated processing of the entire ASTER Level 1A (https://doi.org/10.5067/ASTER/AST_L1A.003) archive of scenes acquired between March 1, 2000, and November 30, 2013. Stereo correlation was used to produce over one million individual scene based ASTER DEMs, to which cloud masking was applied. All cloud screened DEMs and non-cloud screened DEMs were stacked. Residual bad values and outliers were removed. In areas with limited data stacking, several existing reference DEMs were used to supplement ASTER data to correct for residual anomalies. Selected data were averaged to create final pixel values before partitioning the data into 1 degree latitude by 1 degree longitude tiles with a one pixel overlap. To correct elevation values of water body surfaces, the ASTER Global Water Bodies Database (ASTWBD) (https://doi.org/10.5067/ASTER/ASTWBD.001) Version 1 data product was also generated. \r\n\r\nThe geographic coverage of the ASTER GDEM extends from 83° North to 83° South. Each tile is distributed in GeoTIFF format and projected on the 1984 World Geodetic System (WGS84)/1996 Earth Gravitational Model (EGM96) geoid. Each of the 22,912 tiles in the collection contain at least 0.01% land area. \r\n\r\nProvided in the ASTER GDEM product are layers for DEM and number of scenes (NUM). The NUM layer indicates the number of scenes that were processed for each pixel and the source of the data.\r\n\r\nWhile the ASTER GDEM Version 3 data products offer substantial improvements over Version 2, users are advised that the products still may contain anomalies and artifacts that will reduce its usability for certain applications. \r\n\r\nImprovements/Changes from Previous Versions \r\n• Expansion of acquisition coverage to increase the amount of cloud-free input scenes from about 1.5 million in Version 2 to about 1.88 million scenes in Version 3.\r\n• Separation of rivers from lakes in the water body processing. \r\n• Minimum water body detection size decreased from 1 km2 to 0.2 km2. ",
+        "has_granules": true,
+        "time_end": "2013-11-30T23:59:59.999Z",
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1711961296-LPCLOUD",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "UMM_JSON",
+        "granule_count": 22912,
+        "archive_center": "LP DAAC",
+        "has_temporal_subsetting": false,
+        "browse_flag": true,
+        "platforms": ["Terra"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://search.earthdata.nasa.gov/search?q= C1711961296-LPCLOUD"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://doi.org/10.5067/ASTER/ASTGTM.003"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
+            "hreflang": "en-US",
+            "href": "https://asterweb.jpl.nasa.gov/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://lpdaac.usgs.gov/documents/434/ASTGTM_User_Guide_V3.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-public/ASTGTM.003/ASTGTMV003_N03E021.1.jpg"
+          }
+        ]
+      },
+      {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -484,170 +1000,328 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:00:42.781Z"
+              "updated_at": "2022-10-06T12:43:42.933Z"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2014-04-03T00:00:00.000Z",
+        "version_id": "1",
+        "updated": "2021-07-15T19:16:20.000Z",
+        "dataset_id": "SENTINEL-1A_RAW",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "ASF",
+        "short_name": "SENTINEL-1A_RAW",
+        "organizations": ["ASF", "ESA/CS1CGS"],
+        "title": "SENTINEL-1A_RAW",
+        "coordinate_system": "CARTESIAN",
+        "summary": "Sentinel-1A level zero product",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1214470561-ASF",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "ECHO10",
+        "granule_count": 1507761,
+        "archive_center": "ASF",
+        "has_temporal_subsetting": false,
+        "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://vertex.daac.asf.alaska.edu/"
+          }
+        ]
+      },
+      {
+        "processing_level_id": "2",
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": false,
+              "updated_at": "2022-10-06T12:29:59.946Z"
+            }
+          },
+          "edsc.extra.serverless.subset_service.opendap": {
+            "data": {
+              "updated_at": "2022-10-06T16:31:53.784Z",
+              "id": "S2004184019-POCLOUD",
+              "type": "OPeNDAP"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2000-02-24T00:00:00.000Z",
+        "version_id": "2019.0",
+        "updated": "2019-12-31T19:19:57.627Z",
+        "dataset_id": "GHRSST Level 2P Global Sea Surface Skin Temperature from the Moderate Resolution Imaging Spectroradiometer (MODIS) on the NASA Terra satellite (GDS2)",
+        "has_spatial_subsetting": true,
+        "has_transforms": false,
+        "associations": {
+          "variables": [
+            "V1997811750-POCLOUD",
+            "V1997811794-POCLOUD",
+            "V2112014697-POCLOUD",
+            "V1997811877-POCLOUD",
+            "V1997811902-POCLOUD",
+            "V2028668027-POCLOUD",
+            "V2028632036-POCLOUD",
+            "V1997811775-POCLOUD",
+            "V1997811764-POCLOUD",
+            "V1997811783-POCLOUD",
+            "V2112014702-POCLOUD",
+            "V2028632034-POCLOUD",
+            "V2112014700-POCLOUD",
+            "V1997811759-POCLOUD",
+            "V2028632038-POCLOUD"
+          ],
+          "services": [
+            "S1962070864-POCLOUD",
+            "S2004184019-POCLOUD",
+            "S2153799015-POCLOUD",
+            "S2227193226-POCLOUD"
+          ],
+          "tools": ["TL2108419875-POCLOUD", "TL2092786348-POCLOUD"]
+        },
+        "has_variables": true,
+        "data_center": "POCLOUD",
+        "short_name": "MODIS_T-JPL-L2P-v2019.0",
+        "organizations": ["NASA/JPL/PODAAC"],
+        "title": "GHRSST Level 2P Global Sea Surface Skin Temperature from the Moderate Resolution Imaging Spectroradiometer (MODIS) on the NASA Terra satellite (GDS2)",
+        "coordinate_system": "CARTESIAN",
+        "summary": "NASA produces skin sea surface temperature (SST) products from the Infrared (IR) channels of the Moderate-resolution Imaging Spectroradiometer (MODIS) onboard the Terra satellite. Terra was launched by NASA on December 18, 1999, into a sun synchronous, polar orbit with a daylight descending node at 10:30 am, to study the global dynamics of the Earth atmosphere, land and oceans. The MODIS captures data in 36 spectral bands at a variety of spatial resolutions.  Two SST products can be present in these files. The first is a skin SST produced for both day and night observations, derived from the long wave IR 11 and 12 micron wavelength channels, using a modified nonlinear SST algorithm intended to provide continuity with SST derived from heritage and current NASA sensors. At night, a second SST product is produced using the mid-infrared 3.95 and 4.05 micron channels which are unique to MODIS; the SST derived from these measurements is identified as SST4. The SST4 product has lower uncertainty, but due to sun glint can only be produced at night. MODIS L2P SST data have a 1 km spatial resolution at nadir and are stored in 288 five minute granules per day. Full global coverage is obtained every two days, with coverage poleward of 32.3 degree being complete each day. The production of MODIS L2P SST files is part of the Group for High Resolution Sea Surface Temperature (GHRSST) project, and is a joint collaboration between the NASA Jet Propulsion Laboratory (JPL), the NASA Ocean Biology Processing Group (OBPG), and the Rosenstiel School of Marine and Atmospheric Science (RSMAS). Researchers at RSMAS are responsible for SST algorithm development, error statistics and quality flagging, while the OBPG, as the NASA ground data system, is responsible for the production of daily MODIS ocean products. JPL acquires MODIS ocean granules from the OBPG and reformats them to the GHRSST L2P netCDF specification with complete metadata and ancillary variables, and distributes the data as the official Physical Oceanography Data Archive (PO.DAAC) for SST.  The R2019.0 supersedes the previous R2014.0 datasets which can be found at  https://doi.org/10.5067/GHMDT-2PJ02",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "harmony": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {
+          "swath_width": "2330.0",
+          "period": "98.8",
+          "inclination_angle": "98.2",
+          "number_of_orbits": "1.0"
+        },
+        "id": "C1940475563-POCLOUD",
+        "has_formats": true,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "UMM_JSON",
+        "collection_data_type": "SCIENCE_QUALITY",
+        "granule_count": 2698574,
+        "archive_center": "NASA/JPL/PODAAC",
+        "has_temporal_subsetting": true,
+        "browse_flag": true,
+        "platforms": ["Terra"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ghrsst/open/docs/GDS20r5.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst4/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/reprocessing/r2019/sst/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst/flag/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://ghrsst.jpl.nasa.gov"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://modis.gsfc.nasa.gov/data/atbd/atbd_mod25.pdf"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/Podaac/thumbnails/MODIS_T-JPL-L2P-v2019.0.jpg"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/forum/viewforum.php?f=18&sid=e2d67e5a01815fc6e39fcd2087ed8bc8"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://oceancolor.gsfc.nasa.gov/atbd/sst/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://github.com/podaac/data-readers"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "http://www.ghrsst.org"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/CitingPODAAC"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": " https://cmr.earthdata.nasa.gov/virtual-directory/collections/C1940475563-POCLOUD"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://github.com/podaac/tutorials/blob/master/notebooks/MODIS_L2P_SST_DataCube.ipynb"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://search.earthdata.nasa.gov/search/granules?p=C1940475563-POCLOUD"
+          }
+        ]
+      },
+      {
+        "processing_level_id": "2",
+        "cloud_hosted": false,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": true,
+              "updated_at": "2022-10-06T12:21:16.905Z"
             }
           },
           "edsc.extra.serverless.collection_details": {
             "data": {
               "data_centers": [
+                { "shortname": "ASF", "roles": ["PROCESSOR"] },
                 {
                   "shortname": "ASF",
-                  "roles": [
-                    "PROCESSOR"
-                  ]
-                },
-                {
-                  "shortname": "ASF",
-                  "roles": [
-                    "ARCHIVER"
-                  ],
+                  "roles": ["ARCHIVER"],
                   "contactInformation": {
                     "ContactMechanisms": [
-                      {
-                        "Type": "Telephone",
-                        "Value": "907-474-5041"
-                      },
-                      {
-                        "Type": "Email",
-                        "Value": "uso@asf.alaska.edu"
-                      }
+                      { "Type": "Telephone", "Value": "907-474-5041" },
+                      { "Type": "Email", "Value": "uso@asf.alaska.edu" }
                     ]
                   }
                 },
                 {
                   "shortname": "ASF",
-                  "roles": [
-                    "DISTRIBUTOR"
-                  ],
+                  "roles": ["DISTRIBUTOR"],
                   "contactInformation": {
                     "ContactMechanisms": [
-                      {
-                        "Type": "Telephone",
-                        "Value": "907-474-5041"
-                      },
-                      {
-                        "Type": "Email",
-                        "Value": "uso@asf.alaska.edu"
-                      }
+                      { "Type": "Telephone", "Value": "907-474-5041" },
+                      { "Type": "Email", "Value": "uso@asf.alaska.edu" }
                     ]
                   }
                 }
               ],
               "relatedUrls": [],
               "scienceKeywords": [
-                [
-                  "Earth Science",
-                  "Agriculture",
-                  "Forest Science"
-                ],
-                [
-                  "Earth Science",
-                  "Biosphere",
-                  "Terrestrial Ecosystems"
-                ],
-                [
-                  "Earth Science",
-                  "Cryosphere",
-                  "Frozen Ground"
-                ],
-                [
-                  "Earth Science",
-                  "Cryosphere",
-                  "Glaciers Ice Sheets"
-                ],
-                [
-                  "Earth Science",
-                  "Cryosphere",
-                  "Sea Ice"
-                ],
-                [
-                  "Earth Science",
-                  "Cryosphere",
-                  "Snow Ice"
-                ],
-                [
-                  "Earth Science",
-                  "Land Surface",
-                  "Erosion Sedimentation"
-                ],
+                ["Earth Science", "Agriculture", "Forest Science"],
+                ["Earth Science", "Biosphere", "Terrestrial Ecosystems"],
+                ["Earth Science", "Cryosphere", "Frozen Ground"],
+                ["Earth Science", "Cryosphere", "Glaciers Ice Sheets"],
+                ["Earth Science", "Cryosphere", "Sea Ice"],
+                ["Earth Science", "Cryosphere", "Snow Ice"],
+                ["Earth Science", "Land Surface", "Erosion Sedimentation"],
                 [
                   "Earth Science",
                   "Land Surface",
                   "Geomorphic Landforms Processes"
                 ],
-                [
-                  "Earth Science",
-                  "Land Surface",
-                  "Land Use Land Cover"
-                ],
-                [
-                  "Earth Science",
-                  "Land Surface",
-                  "Landscape"
-                ],
-                [
-                  "Earth Science",
-                  "Land Surface",
-                  "Topography"
-                ],
-                [
-                  "Earth Science",
-                  "Oceans",
-                  "Coastal Processes"
-                ],
-                [
-                  "Earth Science",
-                  "Oceans",
-                  "Ocean Waves"
-                ],
-                [
-                  "Earth Science",
-                  "Oceans",
-                  "Ocean Winds"
-                ],
-                [
-                  "Earth Science",
-                  "Oceans",
-                  "Sea Ice"
-                ],
+                ["Earth Science", "Land Surface", "Land Use Land Cover"],
+                ["Earth Science", "Land Surface", "Landscape"],
+                ["Earth Science", "Land Surface", "Topography"],
+                ["Earth Science", "Oceans", "Coastal Processes"],
+                ["Earth Science", "Oceans", "Ocean Waves"],
+                ["Earth Science", "Oceans", "Ocean Winds"],
+                ["Earth Science", "Oceans", "Sea Ice"],
                 [
                   "Earth Science",
                   "Solid Earth",
                   "Geomorphic Landforms Processes"
                 ],
-                [
-                  "Earth Science",
-                  "Solid Earth",
-                  "Tectonics"
-                ],
+                ["Earth Science", "Solid Earth", "Tectonics"],
                 [
                   "Earth Science",
                   "Terrestrial Hydrosphere",
                   "Glaciers Ice Sheets"
                 ],
-                [
-                  "Earth Science",
-                  "Terrestrial Hydrosphere",
-                  "Snow Ice"
-                ],
-                [
-                  "Earth Science",
-                  "Terrestrial Hydrosphere",
-                  "Surface Water"
-                ]
+                ["Earth Science", "Terrestrial Hydrosphere", "Snow Ice"],
+                ["Earth Science", "Terrestrial Hydrosphere", "Surface Water"]
               ],
-              "temporal": [
-                "2006-05-16 to 2011-04-22"
-              ],
+              "temporal": ["2006-05-16 to 2011-04-22"],
               "spatial": [
                 "Bounding Rectangle: (90.0°, -180.0°, -90.0°, 180.0°)"
               ]
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2006-03-23T16:10:55.000Z",
         "version_id": "1",
         "updated": "2019-08-21T05:58:52.000Z",
@@ -668,22 +1342,185 @@
         "has_variables": true,
         "data_center": "ASF",
         "short_name": "ALOS_PSR_RTC_HIGH",
-        "organizations": [
-          "ASF"
-        ],
+        "organizations": ["ASF"],
         "title": "ALOS_PALSAR_RTC_HIGH_RES",
         "coordinate_system": "CARTESIAN",
         "summary": "PALSAR_Radiometric_Terrain_Corrected_high_res",
         "has_granules": true,
         "time_end": "2011-04-22T20:23:36.000Z",
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1206487504-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
         "granule_count": 506657,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["ALOS"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://vertex.daac.asf.alaska.edu/"
+          }
+        ]
+      },
+      {
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": true,
+              "updated_at": "2022-10-06T12:43:42.051Z"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2014-04-03T00:00:00.000Z",
+        "version_id": "1",
+        "updated": "2021-07-15T19:16:04.000Z",
+        "dataset_id": "SENTINEL-1A_DUAL_POL_METADATA_GRD_HIGH_RES",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "ASF",
+        "short_name": "SENTINEL-1A_DP_META_GRD_HIGH",
+        "organizations": ["ASF"],
+        "title": "SENTINEL-1A_DUAL_POL_METADATA_GRD_HIGH_RES",
+        "coordinate_system": "CARTESIAN",
+        "summary": "Sentinel-1A Dual-pol ground projected high and full resolution metadata",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1214470576-ASF",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "ECHO10",
+        "granule_count": 1142667,
+        "archive_center": "ASF",
+        "has_temporal_subsetting": false,
+        "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://vertex.daac.asf.alaska.edu/"
+          }
+        ]
+      },
+      {
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": true,
+              "updated_at": "2022-10-06T12:43:43.040Z"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2014-04-03T00:00:00.000Z",
+        "version_id": "1",
+        "updated": "2021-07-15T19:16:26.000Z",
+        "dataset_id": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "ASF",
+        "short_name": "SENTINEL-1A_SP_GRD_HIGH",
+        "organizations": ["ASF", "ESA/CS1CGS"],
+        "title": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
+        "coordinate_system": "CARTESIAN",
+        "summary": "Sentinel-1A Single-pol ground projected high and full resolution images",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1214470682-ASF",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "ECHO10",
+        "granule_count": 158324,
+        "archive_center": "ASF",
+        "has_temporal_subsetting": false,
+        "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
         "online_access_flag": true,
         "links": [
           {
@@ -695,6 +1532,7 @@
       },
       {
         "processing_level_id": "3",
+        "cloud_hosted": false,
         "tags": {
           "edsc.extra.gibs": {
             "data": [
@@ -717,9 +1555,7 @@
             ]
           },
           "edsc.extra.subset_service.esi": {
-            "data": [
-              "S1568897222-LPDAAC_ECS"
-            ]
+            "data": ["S1568897222-LPDAAC_ECS"]
           },
           "edsc.extra.serverless.gibs": {
             "data": [
@@ -733,7 +1569,7 @@
                 "source": "Space Shuttle Endeavour / STS-99",
                 "arctic": false,
                 "title": "Shuttle Radar Topography Mission (NASA SRTM v3, Color Index)",
-                "updated_at": "2021-05-27T12:00:15.422Z",
+                "updated_at": "2022-10-06T12:45:22.352Z",
                 "antarctic_resolution": null,
                 "product": "SRTM_Color_Index",
                 "match": {}
@@ -746,13 +1582,12 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": false,
-              "updated_at": "2021-05-27T12:11:40.427Z"
+              "updated_at": "2022-10-06T12:40:28.557Z"
             }
-          }
+          },
+          "edsc.portal.cwic.collections": {}
         },
-        "boxes": [
-          "-56 -180 60 180"
-        ],
+        "boxes": ["-56 -180 60 180"],
         "time_start": "2000-02-11T00:00:00.000Z",
         "version_id": "003",
         "updated": "2015-09-02T10:31:05.569Z",
@@ -762,23 +1597,45 @@
         "has_variables": false,
         "data_center": "LPDAAC_ECS",
         "short_name": "SRTMGL1",
-        "organizations": [
-          "LP DAAC",
-          "NASA/JPL/SRTM"
-        ],
+        "organizations": ["LP DAAC", "NASA/JPL/SRTM"],
         "title": "NASA Shuttle Radar Topography Mission Global 1 arc second V003",
         "coordinate_system": "CARTESIAN",
-        "summary": "The Land Processes Distributed Active Archive Center (LP DAAC) is responsible for the archive and distribution of the NASA Making Earth System Data Records for Use in Research Environments (MEaSUREs) (https://earthdata.nasa.gov/community/community-data-system-programs/measures-projects) version SRTM, which includes the global 1 arc second (~30 meter) product.\r\n\r\nNASA Shuttle Radar Topography Mission (SRTM) datasets result from a collaborative effort by the National Aeronautics and Space Administration (NASA) and the National Geospatial-Intelligence Agency (NGA - previously known as the National Imagery and Mapping Agency, or NIMA), as well as the participation of the German and Italian space agencies. The purpose of SRTM was to generate a near-global digital elevation model (DEM) of the Earth using radar interferometry. SRTM was a primary component of the payload on the Space Shuttle Endeavour during its STS-99 mission. Endeavour launched February 11, 2000 and ﬂew for 11 days.\r\n\r\nEach SRTMGL1 data tile contains a mosaic and blending of elevations generated by averaging all \"data takes\" that fall within that tile. These elevation files use the extension “.HGT”, meaning height (such as N37W105.SRTMGL1.HGT). The primary goal of creating the Version 3 data was to eliminate voids that were present in earlier versions of SRTM data. In areas with limited data, existing topographical data were used to supplement the SRTM data to fill the voids. The source of each elevation pixel is identified in the corresponding (SRTMGL1N) (http://dx.doi.org/10.5067/MEaSUREs/SRTM/SRTMGL1N.003) product (such as N37W105.SRTMGL1N.NUM).\r\n\r\nSRTM collected data in swaths, which extend from ~30 degrees off-nadir to ~58 degrees off-nadir from an altitude of 233 kilometers (km). These swaths are ~225 km wide, and consisted of all land between 60° N and 56° S latitude. This accounts for about 80% of Earth’s total landmass. \r\n\r\n",
+        "summary": "The Land Processes Distributed Active Archive Center (LP DAAC) is responsible for the archive and distribution of the NASA Making Earth System Data Records for Use in Research Environments (MEaSUREs) (https://earthdata.nasa.gov/community/community-data-system-programs/measures-projects) version SRTM, which includes the global 1 arc second (~30 meter) product.\r\n\r\nNASA Shuttle Radar Topography Mission (SRTM) datasets result from a collaborative effort by the National Aeronautics and Space Administration (NASA) and the National Geospatial-Intelligence Agency (NGA - previously known as the National Imagery and Mapping Agency, or NIMA), as well as the participation of the German and Italian space agencies. The purpose of SRTM was to generate a near-global digital elevation model (DEM) of the Earth using radar interferometry. SRTM was a primary component of the payload on the Space Shuttle Endeavour during its STS-99 mission. Endeavour launched February 11, 2000 and ﬂew for 11 days.\r\n\r\nEach SRTMGL1 data tile contains a mosaic and blending of elevations generated by averaging all \"data takes\" that fall within that tile. These elevation files use the extension “.HGT”, meaning height (such as N37W105.SRTMGL1.HGT). The primary goal of creating the Version 3 data was to eliminate voids that were present in earlier versions of SRTM data. In areas with limited data, existing topographical data were used to supplement the SRTM data to fill the voids. The source of each elevation pixel is identified in the corresponding (SRTMGL1N) (https://doi.org/10.5067/MEaSUREs/SRTM/SRTMGL1N.003) product (such as N37W105.SRTMGL1N.NUM).\r\n\r\nSRTM collected data in swaths, which extend from ~30 degrees off-nadir to ~58 degrees off-nadir from an altitude of 233 kilometers (km). These swaths are ~225 km wide, and consisted of all land between 60° N and 56° S latitude. This accounts for about 80% of Earth’s total landmass. \r\n\r\n",
         "has_granules": true,
         "time_end": "2000-02-21T23:59:59.000Z",
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1000000240-LPDAAC_ECS",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "UMM_JSON",
         "granule_count": 14297,
         "archive_center": "LP DAAC",
         "has_temporal_subsetting": false,
         "browse_flag": true,
+        "platforms": ["STS-99"],
         "online_access_flag": true,
         "links": [
           {
@@ -794,7 +1651,7 @@
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "http://earthexplorer.usgs.gov/"
+            "href": "https://earthexplorer.usgs.gov/"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
@@ -839,7 +1696,7 @@
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/service#",
             "hreflang": "en-US",
-            "href": "https://opendap.cr.usgs.gov/opendap/hyrax/SRTMGL1.003/contents.html"
+            "href": "https://opendap.cr.usgs.gov/opendap/hyrax/DP133/SRTM/SRTMGL1.003/contents.html"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
@@ -849,272 +1706,7 @@
         ]
       },
       {
-        "processing_level_id": "3",
-        "tags": {
-          "edsc.extra.gibs": {
-            "data": [
-              {
-                "geo_resolution": "500m",
-                "format": "png",
-                "antarctic": false,
-                "group": "overlays",
-                "arctic_resolution": null,
-                "geo": true,
-                "source": "Terra and Aqua / MODIS",
-                "arctic": false,
-                "title": "Albedo (L3, Daily)",
-                "resolution": "500m",
-                "antarctic_resolution": null,
-                "product": "MODIS_Combined_L3_Albedo_Daily",
-                "maxNativeZoom": 5,
-                "match": {
-                  "time_start": ">=2000-05-18T00:00:00Z"
-                }
-              }
-            ]
-          },
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": true,
-              "day_night_flag": true,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": false,
-              "updated_at": "2021-05-27T12:10:51.718Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2000-02-16T00:00:00.000Z",
-        "version_id": "061",
-        "updated": "2015-09-30T10:46:34.663Z",
-        "dataset_id": "MODIS/Terra+Aqua BRDF/Albedo Albedo Daily L3 Global - 500m V061",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "LPDAAC_ECS",
-        "short_name": "MCD43A3",
-        "organizations": [
-          "LP DAAC",
-          "NASA/GSFC/SED/ESD/TISL/MODAPS"
-        ],
-        "title": "MODIS/Terra+Aqua BRDF/Albedo Albedo Daily L3 Global - 500m V061",
-        "coordinate_system": "CARTESIAN",
-        "summary": "The Moderate Resolution Imaging Spectroradiometer (MODIS) MCD43A3 Version 6.1 Albedo Model dataset is produced daily using 16 days of Terra and Aqua MODIS data at 500 meter (m) resolution. Data are temporally weighted to the ninth day of the 16 day which is reflected in the Julian date in the file name.\r\n\r\nThe MCD43A3 provides black-sky albedo (directional hemispherical reflectance) and white-sky albedo (bihemispherical reflectance) data at local solar noon for MODIS bands 1 through 7 and the visible, near infrared (NIR), and shortwave bands. Along with the albedo layers are the quality layers for each of the 10 bands. \r\n\r\nThe MODIS BRDF/ALBEDO products have achieved stage 3 (https://modis-land.gsfc.nasa.gov/MODLAND_val.html) validation.\r\n\r\n* The Version 6.1 Level-1B (L1B) products have been improved by undergoing various calibration changes that include: changes to the response-versus-scan angle (RVS) approach that affects reflectance bands for Aqua and Terra MODIS, corrections to adjust for the optical crosstalk in Terra MODIS infrared (IR) bands, and corrections to the Terra MODIS forward look-up table (LUT) update for the period 2012 - 2017.\r\n* A polarization correction has been applied to the L1B Reflective Solar Bands (RSB).",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1620265701-LPDAAC_ECS",
-        "has_formats": false,
-        "original_format": "UMM_JSON",
-        "granule_count": 285335,
-        "archive_center": "LP DAAC",
-        "has_temporal_subsetting": false,
-        "browse_flag": true,
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "http://landweb.nascom.nasa.gov/cgi-bin/QA_WWW/qaFlagPage.cgi?sat=aquaTerra&ver=C6"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://doi.org/10.5067/MODIS/MCD43A3.061"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov/MOTA/MCD43A3.061/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://search.earthdata.nasa.gov/search?q=C1620265701-LPDAAC_ECS"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
-            "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2020.04.07/BROWSE.MCD43A3.A2002084.h17v05.061.2020087110802.1.jpg"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://www.umb.edu/spectralmass/terra_aqua_modis/v061"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/97/MCD43_ATBD.pdf"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/61/MCD43A3"
-          }
-        ]
-      },
-      {
-        "processing_level_id": "3",
-        "tags": {
-          "edsc.extra.gibs": {
-            "data": [
-              {
-                "geo_resolution": "500m",
-                "format": "png",
-                "antarctic": false,
-                "group": "overlays",
-                "arctic_resolution": null,
-                "geo": true,
-                "source": "Terra and Aqua / MODIS",
-                "arctic": false,
-                "title": "Albedo (L3, Daily)",
-                "resolution": "500m",
-                "antarctic_resolution": null,
-                "product": "MODIS_Combined_L3_Albedo_Daily",
-                "maxNativeZoom": 5,
-                "match": {
-                  "time_start": ">=2000-05-18T00:00:00Z"
-                }
-              }
-            ]
-          },
-          "edsc.extra.subset_service.esi": {
-            "data": [
-              "S1568897222-LPDAAC_ECS"
-            ]
-          },
-          "edsc.extra.serverless.gibs": {
-            "data": [
-              {
-                "format": "png",
-                "antarctic": false,
-                "geographic": true,
-                "group": "overlays",
-                "geographic_resolution": "500m",
-                "arctic_resolution": null,
-                "source": "Terra and Aqua / MODIS",
-                "arctic": false,
-                "title": "White Sky Albedo (L3, Daily)",
-                "updated_at": "2021-05-27T12:00:15.323Z",
-                "antarctic_resolution": null,
-                "product": "MODIS_Combined_L3_White_Sky_Albedo_Daily",
-                "match": {
-                  "time_start": ">=2000-05-18T00:00:00Z",
-                  "day_night_flag": "day"
-                }
-              }
-            ]
-          },
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": true,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": false,
-              "updated_at": "2021-05-27T12:10:51.613Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2000-02-16T00:00:00.000Z",
-        "version_id": "006",
-        "updated": "2015-09-30T10:46:34.663Z",
-        "dataset_id": "MODIS/Terra+Aqua BRDF/Albedo Albedo Daily L3 Global - 500m V006",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "LPDAAC_ECS",
-        "short_name": "MCD43A3",
-        "organizations": [
-          "LP DAAC",
-          "NASA/GSFC/SED/ESD/TISL/MODAPS"
-        ],
-        "title": "MODIS/Terra+Aqua BRDF/Albedo Albedo Daily L3 Global - 500m V006",
-        "coordinate_system": "CARTESIAN",
-        "summary": "The Moderate Resolution Imaging Spectroradiometer (MODIS) MCD43A3 Version 6 Albedo Model dataset is produced daily using 16 days of Terra and Aqua MODIS data at 500 meter (m) resolution. Data are temporally weighted to the ninth day of the 16 day which is reflected in the Julian date in the file name.\r\n\r\nThe MCD43A3 provides black-sky albedo (directional hemispherical reflectance) and white-sky albedo (bihemispherical reflectance) data at local solar noon for MODIS bands 1 through 7 and the visible, near infrared (NIR), and shortwave bands. Along with the albedo layers are the quality layers for each of the 10 bands. \r\n\r\nUsers are urged to use the band specific quality flags to isolate the highest quality full inversion results for their own science applications (https://www.umb.edu/spectralmass/terra_aqua_modis/v006).\r\n\r\nImprovements/Changes from Previous Versions\r\n\r\n*\tObservations are weighted to estimate the BRDF/Albedo on the ninth day of the 16-day period.\r\n*\tMCD43 products use the snow status weighted to the ninth day instead of the majority snow/no-snow observations from the 16-day period.\r\n*\tBetter quality at high latitudes from use of all available observations for the acquisition period. Collection 5 used only four observations per day.\r\n*\tThe MCD43 products use L2G-lite surface reflectance as input.\r\n*\tWhen there are insufficient high quality reflectances, a database with archetypal BRDF parameters is used to supplement the observational data and perform a lower quality magnitude inversion. This database is continually updated with the latest full inversion retrieval for each pixel.\r\n\r\nImportant Quality Information\r\nThe incorrect representation of the aerosol quantities (low average high) in the C6 MYD09 and MOD09 surface reflectance products may have impacted down stream products particularly over arid bright surfaces (https://landweb.modaps.eosdis.nasa.gov/cgi-bin/QA_WWW/displayCase.cgi?esdt=MOD09&caseNum=PM_MOD09_20010&caseLocation=cases_data&type=C6). This (and a few other issues) have been corrected for C6.1. Therefore users should avoid substantive use of the C6 MCD43 products and wait for the C6.1 products. In any event, users are always strongly encouraged to download and use the extensive QA data provided in MCD43A2, in addition to the briefer mandatory QAs provided as part of the MCD43A1, 3, and 4 products.\r\n\r\n",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1000000426-LPDAAC_ECS",
-        "has_formats": false,
-        "original_format": "UMM_JSON",
-        "granule_count": 2386311,
-        "archive_center": "LP DAAC",
-        "has_temporal_subsetting": false,
-        "browse_flag": true,
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "http://landweb.nascom.nasa.gov/cgi-bin/QA_WWW/qaFlagPage.cgi?sat=aquaTerra&ver=C6"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://doi.org/10.5067/MODIS/MCD43A3.006"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov/MOTA/MCD43A3.006/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "http://earthexplorer.usgs.gov/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://search.earthdata.nasa.gov/search?q=C1000000426-LPDAAC_ECS"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/service#",
-            "hreflang": "en-US",
-            "href": "https://opendap.cr.usgs.gov/opendap/hyrax/MCD43A3.006/contents.html"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
-            "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2018.03.07/BROWSE.MCD43A3.A2018057.h10v06.006.2018066170440.1.jpg"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://www.umb.edu/spectralmass/terra_aqua_modis/v006"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/97/MCD43_ATBD.pdf"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MCD43A3"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://lpdaacsvc.cr.usgs.gov/appeears/"
-          }
-        ]
-      },
-      {
+        "cloud_hosted": false,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -1122,38 +1714,125 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:52.251Z"
+              "updated_at": "2022-10-06T12:21:16.361Z"
+            }
+          },
+          "edsc.extra.serverless.collection_details": {
+            "data": {
+              "data_centers": [
+                { "shortname": "ASF", "roles": ["PROCESSOR"] },
+                {
+                  "shortname": "ASF",
+                  "roles": ["ARCHIVER"],
+                  "contactInformation": {
+                    "ContactMechanisms": [
+                      { "Type": "Telephone", "Value": "907-474-5041" },
+                      { "Type": "Email", "Value": "uso@asf.alaska.edu" }
+                    ]
+                  }
+                },
+                {
+                  "shortname": "ASF",
+                  "roles": ["DISTRIBUTOR"],
+                  "contactInformation": {
+                    "ContactMechanisms": [
+                      { "Type": "Telephone", "Value": "907-474-5041" },
+                      { "Type": "Email", "Value": "uso@asf.alaska.edu" }
+                    ]
+                  }
+                }
+              ],
+              "relatedUrls": [],
+              "scienceKeywords": [
+                ["Earth Science", "Agriculture", "Forest Science"],
+                ["Earth Science", "Biosphere", "Terrestrial Ecosystems"],
+                ["Earth Science", "Cryosphere", "Frozen Ground"],
+                ["Earth Science", "Cryosphere", "Glaciers Ice Sheets"],
+                ["Earth Science", "Cryosphere", "Sea Ice"],
+                ["Earth Science", "Cryosphere", "Snow Ice"],
+                ["Earth Science", "Land Surface", "Erosion Sedimentation"],
+                [
+                  "Earth Science",
+                  "Land Surface",
+                  "Geomorphic Landforms Processes"
+                ],
+                ["Earth Science", "Land Surface", "Land Use Land Cover"],
+                ["Earth Science", "Land Surface", "Landscape"],
+                ["Earth Science", "Land Surface", "Topography"],
+                ["Earth Science", "Oceans", "Coastal Processes"],
+                ["Earth Science", "Oceans", "Ocean Waves"],
+                ["Earth Science", "Oceans", "Ocean Winds"],
+                ["Earth Science", "Oceans", "Sea Ice"],
+                [
+                  "Earth Science",
+                  "Solid Earth",
+                  "Geomorphic Landforms Processes"
+                ],
+                ["Earth Science", "Solid Earth", "Tectonics"],
+                [
+                  "Earth Science",
+                  "Terrestrial Hydrosphere",
+                  "Glaciers Ice Sheets"
+                ],
+                ["Earth Science", "Terrestrial Hydrosphere", "Snow Ice"],
+                ["Earth Science", "Terrestrial Hydrosphere", "Surface Water"]
+              ],
+              "temporal": ["2006-05-16 to 2011-04-22"],
+              "spatial": [
+                "Bounding Rectangle: (90.0°, -180.0°, -90.0°, 180.0°)"
+              ]
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2016-04-25T00:00:00.000Z",
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2006-01-23T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:11:57.000Z",
-        "dataset_id": "SENTINEL-1B_OCN",
+        "updated": "2021-05-25T18:49:56.000Z",
+        "dataset_id": "ALOS_PALSAR_LEVEL1.1",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
-        "short_name": "SENTINEL-1B_OCN",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1B_OCN",
+        "short_name": "ALOS_PSR_L1.1",
+        "organizations": ["ASF"],
+        "title": "ALOS_PALSAR_LEVEL1.1",
         "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1B Level 2 Ocean wind, wave and current data",
+        "summary": "ALOS PALSAR Level 1.1",
         "has_granules": true,
+        "time_end": "2011-05-23T00:00:00.000Z",
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
-        "id": "C1327985579-ASF",
+        "id": "C1206485527-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 310510,
+        "granule_count": 949994,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["ALOS"],
         "online_access_flag": true,
         "links": [
           {
@@ -1164,6 +1843,7 @@
         ]
       },
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -1171,187 +1851,58 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:51.049Z"
+              "updated_at": "2022-10-06T12:43:42.677Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
+        "boxes": ["-90 -180 90 180"],
         "time_start": "2014-04-03T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:07:17.000Z",
-        "dataset_id": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "SENTINEL-1A_SP_GRD_HIGH",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1A_SINGLE_POL_GRD_HIGH_RES",
-        "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1A Single-pol ground projected high and full resolution images",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1214470682-ASF",
-        "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 144069,
-        "archive_center": "ASF",
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
-          }
-        ]
-      },
-      {
-        "processing_level_id": "1",
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:16:19.269Z"
-            }
-          }
-        },
-        "time_start": "2008-07-24T21:06:27.000Z",
-        "version_id": "1",
-        "updated": "2021-05-27T01:55:54.000Z",
-        "dataset_id": "UAVSAR_POLSAR_METADATA",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "UAVSAR_POL_META",
-        "organizations": [
-          "ASF",
-          "NASA/JPL/ESSD"
-        ],
-        "title": "UAVSAR_POLSAR_METADATA",
-        "coordinate_system": "GEODETIC",
-        "summary": "UAVSAR PolSAR Scene Metadata",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1214353986-ASF",
-        "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 8336,
-        "archive_center": "ASF",
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
-        "polygons": [
-          [
-            "64.623877 -9.140625 81.898451 -7.734375 83.84881 -34.453125 83.559717 -78.925781 77.915669 -124.804688 64.320872 -150.996094 55.776573 165.585938 45.58329 137.636719 36.456636 127.96875 29.840644 129.023438 18.646245 -159.433594 -47.989922 -76.640625 -47.989922 -64.6875 -37.160317 -52.382812 64.623877 -9.140625"
-          ]
-        ],
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
-          }
-        ]
-      },
-      {
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:50.799Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2014-04-03T00:00:00.000Z",
-        "version_id": "1",
-        "updated": "2021-05-24T19:05:36.000Z",
+        "updated": "2021-07-15T19:16:15.000Z",
         "dataset_id": "SENTINEL-1A_METADATA_SLC",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
         "short_name": "SENTINEL-1A_META_SLC",
-        "organizations": [
-          "ASF"
-        ],
+        "organizations": ["ASF"],
         "title": "SENTINEL-1A_METADATA_SLC",
         "coordinate_system": "CARTESIAN",
         "summary": "Metadata for Sentinel-1A slant-range product",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
         "id": "C1214470496-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 1056391,
+        "granule_count": 1336880,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
-        "online_access_flag": true,
-        "links": [
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://vertex.daac.asf.alaska.edu/"
-          }
-        ]
-      },
-      {
-        "tags": {
-          "edsc.extra.serverless.collection_capabilities": {
-            "data": {
-              "cloud_cover": false,
-              "day_night_flag": false,
-              "granule_online_access_flag": true,
-              "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:50.977Z"
-            }
-          }
-        },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2014-04-03T00:00:00.000Z",
-        "version_id": "1",
-        "updated": "2021-05-24T19:06:27.000Z",
-        "dataset_id": "SENTINEL-1A_RAW",
-        "has_spatial_subsetting": false,
-        "has_transforms": false,
-        "has_variables": false,
-        "data_center": "ASF",
-        "short_name": "SENTINEL-1A_RAW",
-        "organizations": [
-          "ASF",
-          "ESA/CS1CGS"
-        ],
-        "title": "SENTINEL-1A_RAW",
-        "coordinate_system": "CARTESIAN",
-        "summary": "Sentinel-1A level zero product",
-        "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1214470561-ASF",
-        "has_formats": false,
-        "original_format": "ECHO10",
-        "granule_count": 1208907,
-        "archive_center": "ASF",
-        "has_temporal_subsetting": false,
-        "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
         "online_access_flag": true,
         "links": [
           {
@@ -1363,119 +1914,170 @@
       },
       {
         "processing_level_id": "2",
+        "cloud_hosted": true,
         "tags": {
+          "edsc.extra.serverless.subset_service.opendap": {
+            "data": {
+              "updated_at": "2022-10-06T16:31:53.784Z",
+              "id": "S2004184019-POCLOUD",
+              "type": "OPeNDAP"
+            }
+          },
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
               "cloud_cover": false,
-              "day_night_flag": true,
+              "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:03:42.640Z"
+              "updated_at": "2022-10-06T12:36:07.312Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2018-07-09T00:00:00.000Z",
-        "version_id": "001",
-        "dataset_id": "ECOSTRESS Land Surface Temperature and Emissivity Daily L2 Global 70m V001",
-        "has_spatial_subsetting": false,
+        "boxes": ["-89.6 -180 89.6 180"],
+        "time_start": "2012-10-29T01:00:01.000Z",
+        "version_id": "Operational/Near-Real-Time",
+        "updated": "2017-04-28T05:01:45.000Z",
+        "dataset_id": "MetOp-B ASCAT Level 2 25.0km Ocean Surface Wind Vectors in Full Orbit Swath",
+        "has_spatial_subsetting": true,
         "has_transforms": false,
-        "has_variables": false,
-        "data_center": "LPDAAC_ECS",
-        "short_name": "ECO2LSTE",
-        "organizations": [
-          "LP DAAC",
-          "NASA/JPL/ECOSTRESS"
-        ],
-        "title": "ECOSTRESS Land Surface Temperature and Emissivity Daily L2 Global 70m V001",
+        "associations": {
+          "variables": [
+            "V2112017027-POCLOUD",
+            "V2112017042-POCLOUD",
+            "V2112017036-POCLOUD",
+            "V2112017016-POCLOUD",
+            "V2112017038-POCLOUD",
+            "V2112017025-POCLOUD",
+            "V2112017030-POCLOUD",
+            "V2112017034-POCLOUD",
+            "V2112017020-POCLOUD",
+            "V2112017044-POCLOUD",
+            "V2112017040-POCLOUD",
+            "V2112017032-POCLOUD"
+          ],
+          "services": ["S2004184019-POCLOUD", "S1962070864-POCLOUD"],
+          "tools": ["TL2108419875-POCLOUD"]
+        },
+        "has_variables": true,
+        "data_center": "POCLOUD",
+        "short_name": "ASCATB-L2-25km",
+        "organizations": ["NASA/JPL/PODAAC", "EUMETSAT/OSISAF"],
+        "title": "MetOp-B ASCAT Level 2 25.0km Ocean Surface Wind Vectors in Full Orbit Swath",
         "coordinate_system": "CARTESIAN",
-        "summary": "The ECOsystem Spaceborne Thermal Radiometer Experiment on Space Station (ECOSTRESS) mission measures the temperature of plants to better understand how much water plants need and how they respond to stress. ECOSTRESS is attached to the International Space Station (ISS) and collects data over the conterminous United States (CONUS) as well as key biomes and agricultural zones around the world and selected FLUXNET (http://fluxnet.fluxdata.org/about/) validation sites. A map of the acquisition coverage can be found on the ECOSTRESS website (https://ecostress.jpl.nasa.gov/science).\r\n\r\nThe ECO2LSTE Version 1 data product provides atmospherically corrected land surface temperature and emissivity (LST&E) values derived from five thermal infrared (TIR) bands. The ECO2LSTE data product was derived using a physics-based Temperature/Emissivity Separation (TES) algorithm. The ECO2LSTE is provided as swath data and has a spatial resolution of 70 meters (m).  The corresponding ECO1BGEO data product is required to georeference the ECO2LSTE data product. \r\n\r\nThe ECO2LSTE Version 1 data product contains layers of LST, emissivity for bands 1 through 5, quality control for LST&E, LST error, emissivity error for bands 1 through 5, wideband emissivity, and Precipitable Water Vapor (PWV). For acquisitions after May 15, 2019, data products contain data values for TIR bands 2, 4 and 5 only. TIR bands 1 and 3 contain fill values to accommodate direct streaming of data from the ISS as mentioned in the Known Issues section.\r\n\r\nData acquisition gaps: ECOSTRESS was launched on June 29, 2018 and moved to autonomous science operations on August 20, 2018 following a successful in-orbit checkout period. On September 29, 2018, ECOSTRESS experienced an anomaly with its primary mass storage unit (MSU). ECOSTRESS has a primary and secondary MSU (A and B). On December 5, 2018, the instrument was switched to the secondary MSU and science operations resumed. On March 14, 2019, the secondary MSU experienced a similar anomaly temporarily halting science acquisitions. On May 15, 2019, a new data acquisition approach was implemented and science acquisitions resumed. To optimize the new acquisition approach TIR bands 2, 4 and 5 are being downloaded. The data products are as previously, except the bands not downloaded contain fill values (L1 radiance and L2 emissivity).",
+        "summary": "This dataset contains operational near-real-time Level 2 ocean surface wind vector retrievals from the Advanced Scatterometer (ASCAT) on MetOp-B at 25 km sampling resolution (note: the effective resolution is 50 km). It is a product of the European Organization for the Exploitation of Meteorological Satellites (EUMETSAT) Ocean and Sea Ice Satellite Application Facility (OSI SAF) provided through the Royal Netherlands Meteorological Institute (KNMI). The wind vector retrievals are currently processed using the CMOD.n geophysical model function using a Hamming filter to spatially average the Sigma-0 data in the ASCAT L1B data. Each file is provided in netCDF version 3 format, and contains one full orbit derived from 3-minute orbit granules. Latency is approximately 2 hours from the latest measurement. The beginning of the orbit is defined by the first wind vector cell measurement within the first 3-minute orbit granule that starts north of the Equator in the ascending node. ASCAT is a C-band dual swath fan beam radar scatterometer providing two independent swaths of backscatter retrievals in sun-synchronous polar orbit aboard the MetOp-B platform. For more information on the MetOp-B mission, please visit: https://www.eumetsat.int/our-satellites/metop-series . For more timely announcements, users are encouraged to register with the KNMI scatterometer email list: scat@knmi.nl. Users are also highly advised to check the dataset user guide periodically for updates and new information on known problems and issues. All intellectual property rights of the OSI SAF products belong to EUMETSAT. The use of these products is granted to every interested user, free of charge. If you wish to use these products, EUMETSAT's copyright credit must be shown by displaying the words \"copyright (year) EUMETSAT\" on each of the products used.",
         "has_granules": true,
-        "orbit_parameters": {},
-        "id": "C1534729776-LPDAAC_ECS",
-        "has_formats": false,
+        "service_features": {
+          "opendap": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "harmony": {
+            "has_formats": true,
+            "has_variables": true,
+            "has_transforms": false,
+            "has_spatial_subsetting": true,
+            "has_temporal_subsetting": true
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {
+          "swath_width": "1800.0",
+          "period": "101.3",
+          "inclination_angle": "98.7",
+          "number_of_orbits": "1.0"
+        },
+        "id": "C2075141559-POCLOUD",
+        "has_formats": true,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "UMM_JSON",
-        "granule_count": 188990,
-        "archive_center": "LP DAAC",
-        "has_temporal_subsetting": false,
+        "collection_data_type": "NEAR_REAL_TIME",
+        "granule_count": 51439,
+        "archive_center": "NASA/JPL/PODAAC",
+        "has_temporal_subsetting": true,
         "browse_flag": true,
+        "platforms": ["METOP-B"],
         "online_access_flag": true,
         "links": [
           {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://search.earthdata.nasa.gov/search?q=C1534729776-LPDAAC_ECS"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
-            "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov/ECOSTRESS/ECO2LSTE.001/"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://doi.org/10.5067/ECOSTRESS/ECO2LSTE.001"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/"
+            "href": "https://scatterometer.knmi.nl/publications/pdf/ASCAT_Product_Manual.pdf"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/423/ECO2_User_Guide_V1.pdf"
+            "href": "https://github.com/podaac/data-readers"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/297/ECO2_LSTE_ATBD_V1.pdf"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/metadata#",
-            "hreflang": "en-US",
-            "href": "https://ecostress.jpl.nasa.gov/science"
+            "href": "https://scatterometer.knmi.nl/publications/"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/380/ECO2_PSD_V1.pdf"
+            "href": "https://scatterometer.knmi.nl/ascat_b_osi_25_prod/"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/299/ECO2_ASD_V1.pdf"
-          },
-          {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
-            "hreflang": "en-US",
-            "href": "https://lpdaac.usgs.gov/documents/227/ECO_Earthdata_Search_Quick_Guide.pdf"
+            "href": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ascat/preview/L2/docs/ASCAT_calval_250.pdf"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/browse#",
             "hreflang": "en-US",
-            "href": "https://e4ftl01.cr.usgs.gov//WORKING/BRWS/Browse.001/2020.10.29/ECOSTRESS_L2_LSTE_13110_011_20201028T103433_0601_01.1.jpg"
+            "href": "https://podaac.jpl.nasa.gov/Podaac/thumbnails/ASCATB-L2-25km.jpg"
           },
           {
-            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
             "hreflang": "en-US",
-            "href": "https://lpdaacsvc.cr.usgs.gov/appeears/"
+            "href": "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ascat/preview/L2/metop_b/25km/README.datagap"
           },
           {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://www.eumetsat.int/our-satellites/metop-series"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://scatterometer.knmi.nl/training_material/"
+          },
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/documentation#",
+            "hreflang": "en-US",
+            "href": "https://podaac.jpl.nasa.gov/CitingPODAAC"
+          },
+          {
+            "length": "0.0MB",
             "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
             "hreflang": "en-US",
-            "href": "https://earthexplorer.usgs.gov/"
+            "href": "https://cmr.earthdata.nasa.gov/virtual-directory/collections/C2075141559-POCLOUD"
+          },
+          {
+            "length": "0.0MB",
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://search.earthdata.nasa.gov/search/granules?p=C2075141559-POCLOUD"
           },
           {
             "rel": "http://esipfed.org/ns/fedsearch/1.1/service#",
             "hreflang": "en-US",
-            "href": "https://opendap.cr.usgs.gov/opendap/hyrax/ECOB/ECOSTRESS/ECO2LSTE.001/contents.html"
+            "href": "https://podaac.jpl.nasa.gov/OPeNDAP-in-the-Cloud"
           }
         ]
       },
       {
+        "cloud_hosted": true,
         "tags": {
           "edsc.extra.serverless.collection_capabilities": {
             "data": {
@@ -1483,37 +2085,128 @@
               "day_night_flag": false,
               "granule_online_access_flag": true,
               "orbit_calculated_spatial_domains": true,
-              "updated_at": "2021-05-27T12:13:52.181Z"
+              "updated_at": "2022-10-06T12:43:41.769Z"
             }
           }
         },
-        "boxes": [
-          "-90 -180 90 180"
-        ],
-        "time_start": "2016-04-25T00:00:00.000Z",
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2014-04-03T00:00:00.000Z",
         "version_id": "1",
-        "updated": "2021-05-24T19:11:42.000Z",
-        "dataset_id": "SENTINEL-1B_METADATA_SLC",
+        "updated": "2021-07-15T19:15:58.000Z",
+        "dataset_id": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
         "has_spatial_subsetting": false,
         "has_transforms": false,
         "has_variables": false,
         "data_center": "ASF",
-        "short_name": "SENTINEL-1B_META_SLC",
-        "organizations": [
-          "ASF"
-        ],
-        "title": "SENTINEL-1B_METADATA_SLC",
+        "short_name": "SENTINEL-1A_DP_GRD_MEDIUM",
+        "organizations": ["ASF", "ESA/CS1CGS"],
+        "title": "SENTINEL-1A_DUAL_POL_GRD_MEDIUM_RES",
         "coordinate_system": "CARTESIAN",
-        "summary": "Metadata for Sentinel-1B slant-range product",
+        "summary": "Sentinel-1A Dual-pol ground projected medium resolution images",
         "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
         "orbit_parameters": {},
-        "id": "C1327985617-ASF",
+        "id": "C1214471521-ASF",
         "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
         "original_format": "ECHO10",
-        "granule_count": 693114,
+        "granule_count": 186953,
         "archive_center": "ASF",
         "has_temporal_subsetting": false,
         "browse_flag": false,
+        "platforms": ["Sentinel-1A"],
+        "online_access_flag": true,
+        "links": [
+          {
+            "rel": "http://esipfed.org/ns/fedsearch/1.1/data#",
+            "hreflang": "en-US",
+            "href": "https://vertex.daac.asf.alaska.edu/"
+          }
+        ]
+      },
+      {
+        "cloud_hosted": true,
+        "tags": {
+          "edsc.extra.serverless.collection_capabilities": {
+            "data": {
+              "cloud_cover": false,
+              "day_night_flag": false,
+              "granule_online_access_flag": true,
+              "orbit_calculated_spatial_domains": true,
+              "updated_at": "2022-10-06T12:43:44.839Z"
+            }
+          }
+        },
+        "boxes": ["-90 -180 90 180"],
+        "time_start": "2016-04-25T00:00:00.000Z",
+        "version_id": "1",
+        "updated": "2021-07-15T19:17:05.000Z",
+        "dataset_id": "SENTINEL-1B_OCN",
+        "has_spatial_subsetting": false,
+        "has_transforms": false,
+        "has_variables": false,
+        "data_center": "ASF",
+        "short_name": "SENTINEL-1B_OCN",
+        "organizations": ["ASF", "ESA/CS1CGS"],
+        "title": "SENTINEL-1B_OCN",
+        "coordinate_system": "CARTESIAN",
+        "summary": "Sentinel-1B Level 2 Ocean wind, wave and current data",
+        "has_granules": true,
+        "service_features": {
+          "opendap": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "esi": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          },
+          "harmony": {
+            "has_formats": false,
+            "has_variables": false,
+            "has_transforms": false,
+            "has_spatial_subsetting": false,
+            "has_temporal_subsetting": false
+          }
+        },
+        "orbit_parameters": {},
+        "id": "C1327985579-ASF",
+        "has_formats": false,
+        "consortiums": ["GEOSS", "EOSDIS"],
+        "original_format": "ECHO10",
+        "granule_count": 374262,
+        "archive_center": "ASF",
+        "has_temporal_subsetting": false,
+        "browse_flag": false,
+        "platforms": ["Sentinel-1B"],
         "online_access_flag": true,
         "links": [
           {
@@ -1536,22 +2229,12 @@
           "has_children": true,
           "children": [
             {
-              "title": "Aerosols",
-              "type": "filter",
-              "applied": false,
-              "count": 1,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Aerosols&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": true
-            },
-            {
               "title": "Agriculture",
               "type": "filter",
               "applied": false,
-              "count": 147,
+              "count": 150,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Agriculture&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Agriculture"
               },
               "has_children": true
             },
@@ -1559,9 +2242,9 @@
               "title": "Atmosphere",
               "type": "filter",
               "applied": false,
-              "count": 3277,
+              "count": 3978,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Atmosphere&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Atmosphere"
               },
               "has_children": true
             },
@@ -1571,7 +2254,7 @@
               "applied": false,
               "count": 17,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Biological+Classification&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Biological+Classification"
               },
               "has_children": true
             },
@@ -1579,9 +2262,9 @@
               "title": "Biosphere",
               "type": "filter",
               "applied": false,
-              "count": 1124,
+              "count": 1223,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Biosphere&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Biosphere"
               },
               "has_children": true
             },
@@ -1589,9 +2272,19 @@
               "title": "Climate Indicators",
               "type": "filter",
               "applied": false,
-              "count": 69,
+              "count": 99,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Climate+Indicators&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Climate+Indicators"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Clouds",
+              "type": "filter",
+              "applied": false,
+              "count": 1,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Clouds"
               },
               "has_children": true
             },
@@ -1599,19 +2292,9 @@
               "title": "Cryosphere",
               "type": "filter",
               "applied": false,
-              "count": 354,
+              "count": 350,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Cryosphere&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": true
-            },
-            {
-              "title": "Environmental Advisories",
-              "type": "filter",
-              "applied": false,
-              "count": 8,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Environmental+Advisories&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Cryosphere"
               },
               "has_children": true
             },
@@ -1619,9 +2302,9 @@
               "title": "Human Dimensions",
               "type": "filter",
               "applied": false,
-              "count": 291,
+              "count": 346,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Human+Dimensions&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Human+Dimensions"
               },
               "has_children": true
             },
@@ -1629,9 +2312,19 @@
               "title": "Land Surface",
               "type": "filter",
               "applied": false,
-              "count": 1765,
+              "count": 1877,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Land+Surface&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Land+Surface"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Models",
+              "type": "filter",
+              "applied": false,
+              "count": 8,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Models"
               },
               "has_children": true
             },
@@ -1639,9 +2332,9 @@
               "title": "Oceans",
               "type": "filter",
               "applied": false,
-              "count": 1433,
+              "count": 1774,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Oceans&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Oceans"
               },
               "has_children": true
             },
@@ -1649,9 +2342,9 @@
               "title": "Solid Earth",
               "type": "filter",
               "applied": false,
-              "count": 249,
+              "count": 269,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Solid+Earth&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Solid+Earth"
               },
               "has_children": true
             },
@@ -1659,9 +2352,9 @@
               "title": "Spectral/Engineering",
               "type": "filter",
               "applied": false,
-              "count": 1182,
+              "count": 1337,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Spectral%2FEngineering&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Spectral%2FEngineering"
               },
               "has_children": true
             },
@@ -1669,9 +2362,9 @@
               "title": "Sun-Earth Interactions",
               "type": "filter",
               "applied": false,
-              "count": 44,
+              "count": 47,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Sun-Earth+Interactions&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Sun-Earth+Interactions"
               },
               "has_children": true
             },
@@ -1679,9 +2372,67 @@
               "title": "Terrestrial Hydrosphere",
               "type": "filter",
               "applied": false,
-              "count": 344,
+              "count": 392,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Terrestrial+Hydrosphere&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Terrestrial+Hydrosphere"
+              },
+              "has_children": true
+            }
+          ]
+        },
+        {
+          "title": "Platforms",
+          "type": "group",
+          "applied": false,
+          "has_children": true,
+          "children": [
+            {
+              "title": "Space-based Platforms",
+              "type": "filter",
+              "applied": false,
+              "count": 4746,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platforms_h%5B0%5D%5Bbasis%5D=Space-based+Platforms"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Other",
+              "type": "filter",
+              "applied": false,
+              "count": 1928,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platforms_h%5B0%5D%5Bbasis%5D=Other"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Air-based Platforms",
+              "type": "filter",
+              "applied": false,
+              "count": 959,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platforms_h%5B0%5D%5Bbasis%5D=Air-based+Platforms"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Land-based Platforms",
+              "type": "filter",
+              "applied": false,
+              "count": 995,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platforms_h%5B0%5D%5Bbasis%5D=Land-based+Platforms"
+              },
+              "has_children": true
+            },
+            {
+              "title": "Water-based Platforms",
+              "type": "filter",
+              "applied": false,
+              "count": 151,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platforms_h%5B0%5D%5Bbasis%5D=Water-based+Platforms"
               },
               "has_children": true
             }
@@ -1697,9 +2448,9 @@
               "title": "AIRS",
               "type": "filter",
               "applied": false,
-              "count": 120,
+              "count": 128,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AIRS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AIRS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1707,9 +2458,9 @@
               "title": "ALT (TOPEX)",
               "type": "filter",
               "applied": false,
-              "count": 79,
+              "count": 99,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ALT+%28TOPEX%29&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ALT+%28TOPEX%29&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1717,9 +2468,9 @@
               "title": "AltiKa Altimeter",
               "type": "filter",
               "applied": false,
-              "count": 74,
+              "count": 87,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AltiKa+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AltiKa+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1727,19 +2478,9 @@
               "title": "AMI",
               "type": "filter",
               "applied": false,
-              "count": 74,
+              "count": 82,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AMI&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "AMSR-E",
-              "type": "filter",
-              "applied": false,
-              "count": 80,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AMSR-E&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AMI&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1747,9 +2488,9 @@
               "title": "Aquarius_Radiometer",
               "type": "filter",
               "applied": false,
-              "count": 215,
+              "count": 226,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Aquarius_Radiometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Aquarius_Radiometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1757,9 +2498,9 @@
               "title": "Aquarius_Scatterometer",
               "type": "filter",
               "applied": false,
-              "count": 234,
+              "count": 249,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Aquarius_Scatterometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Aquarius_Scatterometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1767,9 +2508,9 @@
               "title": "ASTER",
               "type": "filter",
               "applied": false,
-              "count": 52,
+              "count": 40,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ASTER&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ASTER&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1777,9 +2518,9 @@
               "title": "ATSR",
               "type": "filter",
               "applied": false,
-              "count": 91,
+              "count": 87,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ATSR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ATSR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1787,9 +2528,9 @@
               "title": "ATSR-2",
               "type": "filter",
               "applied": false,
-              "count": 74,
+              "count": 86,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ATSR-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ATSR-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1797,9 +2538,9 @@
               "title": "AVHRR",
               "type": "filter",
               "applied": false,
-              "count": 227,
+              "count": 185,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AVHRR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AVHRR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1807,9 +2548,9 @@
               "title": "AVHRR-2",
               "type": "filter",
               "applied": false,
-              "count": 111,
+              "count": 126,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AVHRR-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AVHRR-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1817,9 +2558,9 @@
               "title": "AVHRR-3",
               "type": "filter",
               "applied": false,
-              "count": 155,
+              "count": 179,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=AVHRR-3&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=AVHRR-3&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1827,9 +2568,9 @@
               "title": "BALANCE",
               "type": "filter",
               "applied": false,
-              "count": 160,
+              "count": 162,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=BALANCE&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=BALANCE&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1837,9 +2578,9 @@
               "title": "Computer",
               "type": "filter",
               "applied": false,
-              "count": 453,
+              "count": 599,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Computer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Computer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1847,9 +2588,19 @@
               "title": "Coring Devices",
               "type": "filter",
               "applied": false,
-              "count": 80,
+              "count": 77,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Coring+Devices&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Coring+Devices&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "CrIS",
+              "type": "filter",
+              "applied": false,
+              "count": 77,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=CrIS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1857,9 +2608,9 @@
               "title": "CTD",
               "type": "filter",
               "applied": false,
-              "count": 102,
+              "count": 124,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=CTD&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=CTD&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1867,9 +2618,9 @@
               "title": "ERS-1 ALTIMETER",
               "type": "filter",
               "applied": false,
-              "count": 76,
+              "count": 88,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ERS-1+ALTIMETER&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ERS-1+ALTIMETER&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1877,9 +2628,9 @@
               "title": "ERS-2 Altimeter",
               "type": "filter",
               "applied": false,
-              "count": 77,
+              "count": 88,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ERS-2+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ERS-2+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1887,9 +2638,9 @@
               "title": "ETM+",
               "type": "filter",
               "applied": false,
-              "count": 89,
+              "count": 81,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=ETM%2B&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=ETM%2B&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1897,9 +2648,9 @@
               "title": "GPS Receivers",
               "type": "filter",
               "applied": false,
-              "count": 100,
+              "count": 130,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=GPS+Receivers&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=GPS+Receivers&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1907,9 +2658,9 @@
               "title": "GRACE ACC",
               "type": "filter",
               "applied": false,
-              "count": 104,
+              "count": 113,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=GRACE+ACC&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=GRACE+ACC&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1917,9 +2668,9 @@
               "title": "GRACE SCA",
               "type": "filter",
               "applied": false,
-              "count": 108,
+              "count": 123,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=GRACE+SCA&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=GRACE+SCA&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1927,9 +2678,9 @@
               "title": "GRACE-FO ACC",
               "type": "filter",
               "applied": false,
-              "count": 99,
+              "count": 125,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=GRACE-FO+ACC&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=GRACE-FO+ACC&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1937,9 +2688,9 @@
               "title": "GRACE-FO SCA",
               "type": "filter",
               "applied": false,
-              "count": 95,
+              "count": 113,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=GRACE-FO+SCA&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=GRACE-FO+SCA&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1947,9 +2698,9 @@
               "title": "Hygrometer",
               "type": "filter",
               "applied": false,
-              "count": 83,
+              "count": 96,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Hygrometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Hygrometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1957,9 +2708,19 @@
               "title": "JASON-1 Microwave Radiometer",
               "type": "filter",
               "applied": false,
-              "count": 89,
+              "count": 111,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=JASON-1+Microwave+Radiometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=JASON-1+Microwave+Radiometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "KBR",
+              "type": "filter",
+              "applied": false,
+              "count": 87,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=KBR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1967,9 +2728,9 @@
               "title": "MISR",
               "type": "filter",
               "applied": false,
-              "count": 187,
+              "count": 176,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=MISR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=MISR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1979,7 +2740,7 @@
               "applied": false,
               "count": 176,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=MLS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=MLS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -1987,29 +2748,9 @@
               "title": "MODIS",
               "type": "filter",
               "applied": false,
-              "count": 922,
+              "count": 951,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=MODIS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "MWR",
-              "type": "filter",
-              "applied": false,
-              "count": 70,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=MWR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NEXRAD",
-              "type": "filter",
-              "applied": false,
-              "count": 83,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=NEXRAD&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=MODIS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2017,9 +2758,9 @@
               "title": "POSEIDON-2",
               "type": "filter",
               "applied": false,
-              "count": 89,
+              "count": 115,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=POSEIDON-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=POSEIDON-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2027,9 +2768,9 @@
               "title": "POSEIDON-3",
               "type": "filter",
               "applied": false,
-              "count": 88,
+              "count": 112,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=POSEIDON-3&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=POSEIDON-3&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2037,9 +2778,9 @@
               "title": "POSEIDON-3B",
               "type": "filter",
               "applied": false,
-              "count": 80,
+              "count": 96,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=POSEIDON-3B&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=POSEIDON-3B&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2047,9 +2788,9 @@
               "title": "Pyranometer",
               "type": "filter",
               "applied": false,
-              "count": 122,
+              "count": 125,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Pyranometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Pyranometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2057,9 +2798,9 @@
               "title": "RA-2",
               "type": "filter",
               "applied": false,
-              "count": 73,
+              "count": 96,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=RA-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=RA-2&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2067,9 +2808,9 @@
               "title": "Radar Altimeter",
               "type": "filter",
               "applied": false,
-              "count": 83,
+              "count": 100,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Radar+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Radar+Altimeter&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2077,9 +2818,9 @@
               "title": "RAIN GAUGES",
               "type": "filter",
               "applied": false,
-              "count": 154,
+              "count": 157,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=RAIN+GAUGES&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=RAIN+GAUGES&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2087,9 +2828,19 @@
               "title": "SAR",
               "type": "filter",
               "applied": false,
-              "count": 148,
+              "count": 159,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=SAR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=SAR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "SIRAL",
+              "type": "filter",
+              "applied": false,
+              "count": 83,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=SIRAL&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2097,9 +2848,9 @@
               "title": "SSALT",
               "type": "filter",
               "applied": false,
-              "count": 82,
+              "count": 102,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=SSALT&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=SSALT&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2107,9 +2858,9 @@
               "title": "SSM/I",
               "type": "filter",
               "applied": false,
-              "count": 208,
+              "count": 255,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=SSM%2FI&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=SSM%2FI&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2117,9 +2868,9 @@
               "title": "SSMIS",
               "type": "filter",
               "applied": false,
-              "count": 128,
+              "count": 172,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=SSMIS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=SSMIS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2127,9 +2878,9 @@
               "title": "Steel Measuring Tape",
               "type": "filter",
               "applied": false,
-              "count": 118,
+              "count": 117,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Steel+Measuring+Tape&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Steel+Measuring+Tape&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2137,9 +2888,9 @@
               "title": "TES",
               "type": "filter",
               "applied": false,
-              "count": 142,
+              "count": 143,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=TES&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=TES&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2147,9 +2898,9 @@
               "title": "Thermometer",
               "type": "filter",
               "applied": false,
-              "count": 94,
+              "count": 102,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Thermometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Thermometer&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2157,9 +2908,9 @@
               "title": "TM",
               "type": "filter",
               "applied": false,
-              "count": 113,
+              "count": 108,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=TM&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=TM&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2167,9 +2918,9 @@
               "title": "TMR",
               "type": "filter",
               "applied": false,
-              "count": 80,
+              "count": 102,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=TMR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=TMR&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2177,9 +2928,9 @@
               "title": "VIIRS",
               "type": "filter",
               "applied": false,
-              "count": 317,
+              "count": 364,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=VIIRS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=VIIRS&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2187,9 +2938,9 @@
               "title": "Visual Observations",
               "type": "filter",
               "applied": false,
-              "count": 177,
+              "count": 182,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&instrument_h%5B%5D=Visual+Observations&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&instrument_h%5B%5D=Visual+Observations&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -2202,22 +2953,32 @@
           "has_children": true,
           "children": [
             {
-              "title": "ArcGIS",
+              "title": "ASCII",
               "type": "filter",
               "applied": false,
-              "count": 5,
+              "count": 508,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ArcGIS&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "ASCII",
+              "title": "ASCII - Binary",
               "type": "filter",
               "applied": false,
-              "count": 414,
+              "count": 6,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII+-+Binary&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "ASCII - netCDF-3",
+              "type": "filter",
+              "applied": false,
+              "count": 4,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII+-+netCDF-3&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2227,37 +2988,17 @@
               "applied": false,
               "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII+-+netCDF-4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII+-+netCDF-4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "ASCII-ict",
+              "title": "ASCII - XML",
               "type": "filter",
               "applied": false,
-              "count": 4,
+              "count": 6,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII-ict&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ASCII; ASCII-IWG1",
-              "type": "filter",
-              "applied": false,
-              "count": 3,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII%3B+ASCII-IWG1&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ASCII; Binary",
-              "type": "filter",
-              "applied": false,
-              "count": 4,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII%3B+Binary&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ASCII+-+XML&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2265,9 +3006,9 @@
               "title": "BIL",
               "type": "filter",
               "applied": false,
-              "count": 12,
+              "count": 5,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=BIL&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=BIL&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2275,9 +3016,9 @@
               "title": "Binary",
               "type": "filter",
               "applied": false,
-              "count": 219,
+              "count": 336,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Binary&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Binary&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2287,17 +3028,7 @@
               "applied": false,
               "count": 4,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Binary+-+netCDF-4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Binary - Universal Format (UF)",
-              "type": "filter",
-              "applied": false,
-              "count": 5,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Binary+-+Universal+Format+%28UF%29&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Binary+-+netCDF-4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2305,9 +3036,9 @@
               "title": "CSV",
               "type": "filter",
               "applied": false,
-              "count": 98,
+              "count": 220,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=CSV&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=CSV&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2317,7 +3048,7 @@
               "applied": false,
               "count": 15,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=DBF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=DBF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2325,9 +3056,9 @@
               "title": "Excel",
               "type": "filter",
               "applied": false,
-              "count": 68,
+              "count": 78,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Excel&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Excel&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2335,9 +3066,9 @@
               "title": "Geodatabase",
               "type": "filter",
               "applied": false,
-              "count": 3,
+              "count": 6,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Geodatabase&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Geodatabase&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2345,9 +3076,9 @@
               "title": "GeoTIFF",
               "type": "filter",
               "applied": false,
-              "count": 209,
+              "count": 309,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GeoTIFF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GeoTIFF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2355,9 +3086,9 @@
               "title": "GIF",
               "type": "filter",
               "applied": false,
-              "count": 16,
+              "count": 8,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GIF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GIF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2365,9 +3096,9 @@
               "title": "GRIB",
               "type": "filter",
               "applied": false,
-              "count": 16,
+              "count": 17,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GRIB&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GRIB&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2375,19 +3106,9 @@
               "title": "Grid",
               "type": "filter",
               "applied": false,
-              "count": 40,
+              "count": 46,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Grid&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "GRID",
-              "type": "filter",
-              "applied": false,
-              "count": 4,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=GRID&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Grid&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2395,29 +3116,29 @@
               "title": "HDF",
               "type": "filter",
               "applied": false,
-              "count": 2423,
+              "count": 2660,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "HDF-4 - netCDF-4",
+              "title": "HDF4 - netCDF-4",
               "type": "filter",
               "applied": false,
-              "count": 8,
+              "count": 15,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF-4+-+netCDF-4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF4+-+netCDF-4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "HDF-4 - netCDF-4/CF",
+              "title": "HDF5, ICARTT",
               "type": "filter",
               "applied": false,
-              "count": 7,
+              "count": 18,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF-4+-+netCDF-4%2FCF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HDF5%2C+ICARTT&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2427,7 +3148,7 @@
               "applied": false,
               "count": 3,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HGT&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=HGT&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2435,19 +3156,19 @@
               "title": "ICARTT",
               "type": "filter",
               "applied": false,
-              "count": 126,
+              "count": 259,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ICARTT&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ICARTT&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "ICARTT, NetCDF",
+              "title": "ICARTT, Other (.zip)",
               "type": "filter",
               "applied": false,
-              "count": 9,
+              "count": 6,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ICARTT%2C+NetCDF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ICARTT%2C+Other+%28.zip%29&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2457,7 +3178,7 @@
               "applied": false,
               "count": 3,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Image&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Image&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2465,19 +3186,9 @@
               "title": "JPEG",
               "type": "filter",
               "applied": false,
-              "count": 50,
+              "count": 88,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=JPEG&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "JPS",
-              "type": "filter",
-              "applied": false,
-              "count": 3,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=JPS&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=JPEG&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2485,9 +3196,29 @@
               "title": "KML",
               "type": "filter",
               "applied": false,
-              "count": 19,
+              "count": 18,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=KML&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=KML&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "LAZ",
+              "type": "filter",
+              "applied": false,
+              "count": 9,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=LAZ&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "MAT",
+              "type": "filter",
+              "applied": false,
+              "count": 4,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=MAT&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2497,7 +3228,7 @@
               "applied": false,
               "count": 4,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=McIDAS&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=McIDAS&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2505,29 +3236,9 @@
               "title": "NetCDF",
               "type": "filter",
               "applied": false,
-              "count": 1466,
+              "count": 1929,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NetCDF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "netcdf4",
-              "type": "filter",
-              "applied": false,
-              "count": 75,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netcdf4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NETCDF4",
-              "type": "filter",
-              "applied": false,
-              "count": 6,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NETCDF4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NetCDF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2537,7 +3248,17 @@
               "applied": false,
               "count": 6,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NETCDF+4.7.4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NETCDF+4.7.4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "NetCDF-3, ICARTT",
+              "type": "filter",
+              "applied": false,
+              "count": 6,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NetCDF-3%2C+ICARTT&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2545,49 +3266,69 @@
               "title": "NETCDF-4",
               "type": "filter",
               "applied": false,
-              "count": 4,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NETCDF-4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "netCDF-4/CF - HDF-4",
-              "type": "filter",
-              "applied": false,
               "count": 3,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netCDF-4%2FCF+-+HDF-4&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NETCDF-4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "NIDS (binary)",
+              "title": "netCDF-4 - ASCII",
               "type": "filter",
               "applied": false,
               "count": 4,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NIDS+%28binary%29&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netCDF-4+-+ASCII&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "Other (kmz)",
+              "title": "netCDF-4 - HDF4",
               "type": "filter",
               "applied": false,
               "count": 3,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Other+%28kmz%29&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netCDF-4+-+HDF4&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "Other (pdf)",
+              "title": "netCDF-4 - HDF-EOS5",
               "type": "filter",
               "applied": false,
-              "count": 9,
+              "count": 3,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Other+%28pdf%29&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netCDF-4+-+HDF-EOS5&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "netCDF-4 - netCDF-3",
+              "type": "filter",
+              "applied": false,
+              "count": 3,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=netCDF-4+-+netCDF-3&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "NIDS",
+              "type": "filter",
+              "applied": false,
+              "count": 4,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=NIDS&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "Other (.zip)",
+              "type": "filter",
+              "applied": false,
+              "count": 8,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Other+%28.zip%29&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2597,7 +3338,7 @@
               "applied": false,
               "count": 11,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Other+%28zip%29&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Other+%28zip%29&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2605,9 +3346,9 @@
               "title": "PDF",
               "type": "filter",
               "applied": false,
-              "count": 147,
+              "count": 162,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=PDF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=PDF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2615,9 +3356,9 @@
               "title": "PNG",
               "type": "filter",
               "applied": false,
-              "count": 172,
+              "count": 188,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=PNG&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=PNG&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2625,9 +3366,9 @@
               "title": "RAW",
               "type": "filter",
               "applied": false,
-              "count": 28,
+              "count": 8,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=RAW&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=RAW&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2635,19 +3376,19 @@
               "title": "SHP",
               "type": "filter",
               "applied": false,
-              "count": 57,
+              "count": 72,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=SHP&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=SHP&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "Text",
+              "title": "Text File",
               "type": "filter",
               "applied": false,
-              "count": 4,
+              "count": 8,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Text&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=Text+File&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2655,9 +3396,9 @@
               "title": "TIFF",
               "type": "filter",
               "applied": false,
-              "count": 9,
+              "count": 23,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=TIFF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=TIFF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2667,7 +3408,17 @@
               "applied": false,
               "count": 10,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=UF&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=UF&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "UF - Binary",
+              "type": "filter",
+              "applied": false,
+              "count": 3,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=UF+-+Binary&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2675,9 +3426,9 @@
               "title": "WMS",
               "type": "filter",
               "applied": false,
-              "count": 110,
+              "count": 116,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=WMS&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=WMS&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2687,7 +3438,7 @@
               "applied": false,
               "count": 34,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=XML&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=XML&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2697,7 +3448,7 @@
               "applied": false,
               "count": 10,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ZIP&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&granule_data_format_h%5B%5D=ZIP&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -2715,7 +3466,7 @@
               "applied": false,
               "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Agriculture+and+Agri-Food+Canada+%28AAFC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Agriculture+and+Agri-Food+Canada+%28AAFC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2723,9 +3474,9 @@
               "title": "Alaska Satellite Facility",
               "type": "filter",
               "applied": false,
-              "count": 128,
+              "count": 129,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Alaska+Satellite+Facility&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Alaska+Satellite+Facility&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2733,9 +3484,9 @@
               "title": "AMSR-E Science Investigator-Led Processing System (AMSR-E SIPS)",
               "type": "filter",
               "applied": false,
-              "count": 22,
+              "count": 24,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=AMSR-E+Science+Investigator-Led+Processing+System+%28AMSR-E+SIPS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=AMSR-E+Science+Investigator-Led+Processing+System+%28AMSR-E+SIPS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2745,7 +3496,7 @@
               "applied": false,
               "count": 23,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Aquarius+Project+NASA%2FOBPG%2C+Reynolds+%26+Smith+NOAA%2FNCDC&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Aquarius+Project+NASA%2FOBPG%2C+Reynolds+%26+Smith+NOAA%2FNCDC&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2753,9 +3504,9 @@
               "title": "Atmospheric Science Data Center (ASDC)",
               "type": "filter",
               "applied": false,
-              "count": 1161,
+              "count": 1343,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Atmospheric+Science+Data+Center+%28ASDC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Atmospheric+Science+Data+Center+%28ASDC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2763,9 +3514,9 @@
               "title": "BSU",
               "type": "filter",
               "applied": false,
-              "count": 11,
+              "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=BSU&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=BSU&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2773,9 +3524,9 @@
               "title": "Comision Nacional de Actividades Espaciales (CONAE)",
               "type": "filter",
               "applied": false,
-              "count": 160,
+              "count": 158,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Comision+Nacional+de+Actividades+Espaciales+%28CONAE%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Comision+Nacional+de+Actividades+Espaciales+%28CONAE%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2783,19 +3534,19 @@
               "title": "DOC/NOAA/NESDIS/STAR",
               "type": "filter",
               "applied": false,
-              "count": 10,
+              "count": 26,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=DOC%2FNOAA%2FNESDIS%2FSTAR&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=DOC%2FNOAA%2FNESDIS%2FSTAR&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "Earth Resources Observation and Science Center (EROS)",
+              "title": "DOD/USNAVY/NAVOCEANO",
               "type": "filter",
               "applied": false,
-              "count": 33,
+              "count": 12,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Earth+Resources+Observation+and+Science+Center+%28EROS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=DOD%2FUSNAVY%2FNAVOCEANO&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2803,9 +3554,19 @@
               "title": "ESA/CS1CGS",
               "type": "filter",
               "applied": false,
-              "count": 15,
+              "count": 16,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=ESA%2FCS1CGS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=ESA%2FCS1CGS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "EUMETSAT Ocean and Sea Ice Satellite Application Facility (OSI SAF)",
+              "type": "filter",
+              "applied": false,
+              "count": 17,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=EUMETSAT+Ocean+and+Sea+Ice+Satellite+Application+Facility+%28OSI+SAF%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2815,7 +3576,7 @@
               "applied": false,
               "count": 12,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=European+Organisation+for+the+Exploitation+of+Meteorological+Satellites+%28EUMETSAT%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=European+Organisation+for+the+Exploitation+of+Meteorological+Satellites+%28EUMETSAT%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2823,9 +3584,9 @@
               "title": "Global Hydrology Resource Center (GHRC)",
               "type": "filter",
               "applied": false,
-              "count": 569,
+              "count": 585,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Global+Hydrology+Resource+Center+%28GHRC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Global+Hydrology+Resource+Center+%28GHRC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2833,9 +3594,9 @@
               "title": "Goddard Earth Sciences Data and Information Services Center (GES DISC)",
               "type": "filter",
               "applied": false,
-              "count": 1520,
+              "count": 1808,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Goddard+Earth+Sciences+Data+and+Information+Services+Center+%28GES+DISC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Goddard+Earth+Sciences+Data+and+Information+Services+Center+%28GES+DISC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2843,9 +3604,9 @@
               "title": "Jet Propulsion Laboratory (JPL)",
               "type": "filter",
               "applied": false,
-              "count": 16,
+              "count": 25,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Jet+Propulsion+Laboratory+%28JPL%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Jet+Propulsion+Laboratory+%28JPL%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2853,9 +3614,9 @@
               "title": "Laboratory for Atmospheric and Space Physics (LASP)",
               "type": "filter",
               "applied": false,
-              "count": 18,
+              "count": 19,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Laboratory+for+Atmospheric+and+Space+Physics+%28LASP%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Laboratory+for+Atmospheric+and+Space+Physics+%28LASP%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2863,9 +3624,9 @@
               "title": "Land Process Distributed Active Archive Center (LPDAAC)",
               "type": "filter",
               "applied": false,
-              "count": 548,
+              "count": 568,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Land+Process+Distributed+Active+Archive+Center+%28LPDAAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Land+Process+Distributed+Active+Archive+Center+%28LPDAAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2875,7 +3636,7 @@
               "applied": false,
               "count": 125,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Land+Science+Investigator-Led+Processing+System+%28LandSIPS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Land+Science+Investigator-Led+Processing+System+%28LandSIPS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2883,9 +3644,9 @@
               "title": "Level-1 and Atmosphere Archive & Distribution System (LAADS)",
               "type": "filter",
               "applied": false,
-              "count": 99,
+              "count": 116,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Level-1+and+Atmosphere+Archive+%26+Distribution+System+%28LAADS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Level-1+and+Atmosphere+Archive+%26+Distribution+System+%28LAADS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2893,9 +3654,9 @@
               "title": "MODIS Adaptive Processing System (MODAPS)",
               "type": "filter",
               "applied": false,
-              "count": 105,
+              "count": 106,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=MODIS+Adaptive+Processing+System+%28MODAPS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=MODIS+Adaptive+Processing+System+%28MODAPS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2903,9 +3664,9 @@
               "title": "NASA Earth Sciences Division (ESD)",
               "type": "filter",
               "applied": false,
-              "count": 24,
+              "count": 34,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA+Earth+Sciences+Division+%28ESD%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA+Earth+Sciences+Division+%28ESD%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2913,9 +3674,9 @@
               "title": "NASA/ESSP/UMICH/CYGNSS",
               "type": "filter",
               "applied": false,
-              "count": 17,
+              "count": 34,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FESSP%2FUMICH%2FCYGNSS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FESSP%2FUMICH%2FCYGNSS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2923,9 +3684,9 @@
               "title": "NASA/GSFC/EOS/EO",
               "type": "filter",
               "applied": false,
-              "count": 20,
+              "count": 40,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FEO&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FEO&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2933,9 +3694,9 @@
               "title": "NASA/GSFC/EOS/ESDIS",
               "type": "filter",
               "applied": false,
-              "count": 27,
+              "count": 44,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FESDIS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FESDIS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2943,9 +3704,9 @@
               "title": "NASA/GSFC/EOS/ESDIS/LANCE MODIS",
               "type": "filter",
               "applied": false,
-              "count": 22,
+              "count": 56,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FESDIS%2FLANCE+MODIS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FEOS%2FESDIS%2FLANCE+MODIS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2953,9 +3714,9 @@
               "title": "NASA/GSFC/SED/ESD/BSL/VCST",
               "type": "filter",
               "applied": false,
-              "count": 27,
+              "count": 35,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FBSL%2FVCST&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FBSL%2FVCST&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2963,9 +3724,19 @@
               "title": "NASA/GSFC/SED/ESD/GGL/CDDIS",
               "type": "filter",
               "applied": false,
-              "count": 128,
+              "count": 130,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FGGL%2FCDDIS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FGGL%2FCDDIS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "NASA/GSFC/SED/ESD/GMAO",
+              "type": "filter",
+              "applied": false,
+              "count": 19,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FGMAO&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2973,9 +3744,9 @@
               "title": "NASA/GSFC/SED/ESD/HBSL/BSB/MCST",
               "type": "filter",
               "applied": false,
-              "count": 10,
+              "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FHBSL%2FBSB%2FMCST&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FHBSL%2FBSB%2FMCST&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2983,9 +3754,9 @@
               "title": "NASA/GSFC/SED/ESD/LRSL",
               "type": "filter",
               "applied": false,
-              "count": 23,
+              "count": 21,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FLRSL&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FLRSL&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -2993,9 +3764,9 @@
               "title": "NASA/GSFC/SED/ESD/TISL/MODAPS",
               "type": "filter",
               "applied": false,
-              "count": 341,
+              "count": 352,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FTISL%2FMODAPS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FGSFC%2FSED%2FESD%2FTISL%2FMODAPS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3003,9 +3774,9 @@
               "title": "NASA/JPL/ECOSTRESS",
               "type": "filter",
               "applied": false,
-              "count": 12,
+              "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FECOSTRESS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FECOSTRESS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3013,9 +3784,9 @@
               "title": "NASA/JPL/ESSD",
               "type": "filter",
               "applied": false,
-              "count": 19,
+              "count": 20,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FESSD&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FESSD&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3023,9 +3794,9 @@
               "title": "NASA/JPL/GRACE-TELLUS-0001",
               "type": "filter",
               "applied": false,
-              "count": 16,
+              "count": 28,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FGRACE-TELLUS-0001&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FJPL%2FGRACE-TELLUS-0001&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3035,7 +3806,7 @@
               "applied": false,
               "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FWallops+Observational+Sciences+Branch+%28OSB%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=NASA%2FWallops+Observational+Sciences+Branch+%28OSB%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3045,7 +3816,7 @@
               "applied": false,
               "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=National+Snow+and+Ice+Data+Center+%28NSIDC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=National+Snow+and+Ice+Data+Center+%28NSIDC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3053,19 +3824,9 @@
               "title": "National Snow and Ice Data Center Distributed Active Archive Center (NSIDC DAAC)",
               "type": "filter",
               "applied": false,
-              "count": 452,
+              "count": 517,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=National+Snow+and+Ice+Data+Center+Distributed+Active+Archive+Center+%28NSIDC+DAAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Naval Oceanographic Office (NAVOCEANO)",
-              "type": "filter",
-              "applied": false,
-              "count": 13,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Naval+Oceanographic+Office+%28NAVOCEANO%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=National+Snow+and+Ice+Data+Center+Distributed+Active+Archive+Center+%28NSIDC+DAAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3073,9 +3834,9 @@
               "title": "Oak Ridge National Laboratory Distributed Active Archive Center (ORNL DAAC)",
               "type": "filter",
               "applied": false,
-              "count": 1528,
+              "count": 1723,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Oak+Ridge+National+Laboratory+Distributed+Active+Archive+Center+%28ORNL+DAAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Oak+Ridge+National+Laboratory+Distributed+Active+Archive+Center+%28ORNL+DAAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3083,9 +3844,9 @@
               "title": "Ocean Biology Distributed Active Archive Center (OB.DAAC)",
               "type": "filter",
               "applied": false,
-              "count": 556,
+              "count": 743,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Ocean+Biology+Distributed+Active+Archive+Center+%28OB.DAAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Ocean+Biology+Distributed+Active+Archive+Center+%28OB.DAAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3093,9 +3854,9 @@
               "title": "Ocean Biology Processing Group (OBPG)",
               "type": "filter",
               "applied": false,
-              "count": 99,
+              "count": 410,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Ocean+Biology+Processing+Group+%28OBPG%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Ocean+Biology+Processing+Group+%28OBPG%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3103,9 +3864,9 @@
               "title": "Physical Oceanography Distributed Active Archive Center (PO.DAAC)",
               "type": "filter",
               "applied": false,
-              "count": 639,
+              "count": 754,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Physical+Oceanography+Distributed+Active+Archive+Center+%28PO.DAAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Physical+Oceanography+Distributed+Active+Archive+Center+%28PO.DAAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3113,9 +3874,9 @@
               "title": "Remote Sensing Systems (RSS)",
               "type": "filter",
               "applied": false,
-              "count": 15,
+              "count": 22,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Remote+Sensing+Systems+%28RSS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Remote+Sensing+Systems+%28RSS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3125,17 +3886,7 @@
               "applied": false,
               "count": 38,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Salinity+Processes+in+the+Upper+Ocean+Regional+Study+%28SPURS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Scatterometer Climate Record Pathfinder (SCP)",
-              "type": "filter",
-              "applied": false,
-              "count": 23,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Scatterometer+Climate+Record+Pathfinder+%28SCP%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Salinity+Processes+in+the+Upper+Ocean+Regional+Study+%28SPURS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3145,7 +3896,7 @@
               "applied": false,
               "count": 20,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Shuttle+Radar+Topography+Mission+%28SRTM%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Shuttle+Radar+Topography+Mission+%28SRTM%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3153,9 +3904,9 @@
               "title": "Socioeconomic Data and Applications Center (SEDAC)",
               "type": "filter",
               "applied": false,
-              "count": 227,
+              "count": 274,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Socioeconomic+Data+and+Applications+Center+%28SEDAC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Socioeconomic+Data+and+Applications+Center+%28SEDAC%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3163,9 +3914,19 @@
               "title": "Soil Moisture Active Passive (SMAP)",
               "type": "filter",
               "applied": false,
-              "count": 68,
+              "count": 77,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Soil+Moisture+Active+Passive+%28SMAP%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Soil+Moisture+Active+Passive+%28SMAP%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "Tropospheric Emission Spectrometer SIPS (TES SIPS)",
+              "type": "filter",
+              "applied": false,
+              "count": 20,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Tropospheric+Emission+Spectrometer+SIPS+%28TES+SIPS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3173,9 +3934,9 @@
               "title": "University of California Irvine Earth System Science (ESS)",
               "type": "filter",
               "applied": false,
-              "count": 11,
+              "count": 13,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=University+of+California+Irvine+Earth+System+Science+%28ESS%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=University+of+California+Irvine+Earth+System+Science+%28ESS%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3185,7 +3946,7 @@
               "applied": false,
               "count": 17,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=University+of+Texas+Institute+for+Geophysics+%28UTIG%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=University+of+Texas+Institute+for+Geophysics+%28UTIG%29&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3193,19 +3954,9 @@
               "title": "UWI-MAD/SSEC",
               "type": "filter",
               "applied": false,
-              "count": 13,
+              "count": 18,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=UWI-MAD%2FSSEC&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Western Geographic Science Center (WGSC)",
-              "type": "filter",
-              "applied": false,
-              "count": 12,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=Western+Geographic+Science+Center+%28WGSC%29&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&data_center_h%5B%5D=UWI-MAD%2FSSEC&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -3221,19 +3972,9 @@
               "title": "ABoVE",
               "type": "filter",
               "applied": false,
-              "count": 175,
+              "count": 211,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ABoVE&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Aklavik Highway",
-              "type": "filter",
-              "applied": false,
-              "count": 18,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Aklavik+Highway&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ABoVE&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3241,9 +3982,9 @@
               "title": "AQUARIUS SAC-D",
               "type": "filter",
               "applied": false,
-              "count": 187,
+              "count": 188,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=AQUARIUS+SAC-D&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=AQUARIUS+SAC-D&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3253,7 +3994,7 @@
               "applied": false,
               "count": 26,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ATDD&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ATDD&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3261,9 +4002,9 @@
               "title": "ATom",
               "type": "filter",
               "applied": false,
-              "count": 31,
+              "count": 53,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ATom&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ATom&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3273,7 +4014,7 @@
               "applied": false,
               "count": 303,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=BOREAS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=BOREAS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3283,17 +4024,7 @@
               "applied": false,
               "count": 62,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CAMEX&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "CARVE",
-              "type": "filter",
-              "applied": false,
-              "count": 19,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CARVE&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CAMEX&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3303,17 +4034,7 @@
               "applied": false,
               "count": 25,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CATS-ISS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Central Valley, CA",
-              "type": "filter",
-              "applied": false,
-              "count": 18,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Central+Valley%2C+CA&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CATS-ISS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3321,9 +4042,9 @@
               "title": "CERES",
               "type": "filter",
               "applied": false,
-              "count": 146,
+              "count": 147,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CERES&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CERES&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3331,9 +4052,9 @@
               "title": "CMS",
               "type": "filter",
               "applied": false,
-              "count": 108,
+              "count": 135,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CMS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CMS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3341,9 +4062,29 @@
               "title": "CWIC",
               "type": "filter",
               "applied": false,
-              "count": 62,
+              "count": 38,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CWIC&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CWIC&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "CYGNSS",
+              "type": "filter",
+              "applied": false,
+              "count": 41,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=CYGNSS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "Delta-X",
+              "type": "filter",
+              "applied": false,
+              "count": 32,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Delta-X&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3353,7 +4094,17 @@
               "applied": false,
               "count": 30,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=DISCOVER&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=DISCOVER&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "DISCOVER-AQ",
+              "type": "filter",
+              "applied": false,
+              "count": 77,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=DISCOVER-AQ&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3361,9 +4112,9 @@
               "title": "ECCO",
               "type": "filter",
               "applied": false,
-              "count": 77,
+              "count": 90,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ECCO&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ECCO&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3371,9 +4122,9 @@
               "title": "EOS",
               "type": "filter",
               "applied": false,
-              "count": 50,
+              "count": 51,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=EOS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=EOS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3383,7 +4134,7 @@
               "applied": false,
               "count": 115,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=FIFE&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=FIFE&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3393,7 +4144,7 @@
               "applied": false,
               "count": 131,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=FIRE&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=FIRE&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3403,7 +4154,7 @@
               "applied": false,
               "count": 40,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GCPEx&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GCPEx&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3411,9 +4162,9 @@
               "title": "GHRSST",
               "type": "filter",
               "applied": false,
-              "count": 89,
+              "count": 108,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GHRSST&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GHRSST&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3423,7 +4174,7 @@
               "applied": false,
               "count": 21,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GLDAS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=GLDAS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3431,9 +4182,9 @@
               "title": "IceBridge",
               "type": "filter",
               "applied": false,
-              "count": 76,
+              "count": 78,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IceBridge&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IceBridge&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3443,7 +4194,7 @@
               "applied": false,
               "count": 26,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IFloodS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IFloodS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3453,7 +4204,7 @@
               "applied": false,
               "count": 94,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IGS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IGS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3461,9 +4212,9 @@
               "title": "IMPACTS",
               "type": "filter",
               "applied": false,
-              "count": 59,
+              "count": 65,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IMPACTS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IMPACTS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3473,7 +4224,7 @@
               "applied": false,
               "count": 42,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IPHEx&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=IPHEx&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3483,7 +4234,7 @@
               "applied": false,
               "count": 43,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ISLSCP+II&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=ISLSCP+II&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3491,9 +4242,9 @@
               "title": "LANCE",
               "type": "filter",
               "applied": false,
-              "count": 68,
+              "count": 41,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LANCE&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LANCE&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3503,7 +4254,7 @@
               "applied": false,
               "count": 264,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LBA&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LBA&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3513,7 +4264,17 @@
               "applied": false,
               "count": 20,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LPVEx&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=LPVEx&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "MASTER",
+              "type": "filter",
+              "applied": false,
+              "count": 80,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MASTER&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3523,7 +4284,7 @@
               "applied": false,
               "count": 26,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MC3E&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MC3E&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3531,9 +4292,9 @@
               "title": "MEaSUREs",
               "type": "filter",
               "applied": false,
-              "count": 146,
+              "count": 195,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MEaSUREs&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MEaSUREs&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3543,7 +4304,7 @@
               "applied": false,
               "count": 144,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MERRA+TIME-MEAN+OBSERVATION+DATA&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=MERRA+TIME-MEAN+OBSERVATION+DATA&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3551,9 +4312,9 @@
               "title": "NACP",
               "type": "filter",
               "applied": false,
-              "count": 70,
+              "count": 78,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NACP&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NACP&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3561,9 +4322,9 @@
               "title": "NARSTO",
               "type": "filter",
               "applied": false,
-              "count": 51,
+              "count": 57,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NARSTO&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NARSTO&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3571,9 +4332,19 @@
               "title": "Nimbus",
               "type": "filter",
               "applied": false,
-              "count": 47,
+              "count": 49,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Nimbus&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Nimbus&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "NLDAS",
+              "type": "filter",
+              "applied": false,
+              "count": 22,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NLDAS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3581,9 +4352,9 @@
               "title": "NPP-JPSS",
               "type": "filter",
               "applied": false,
-              "count": 144,
+              "count": 147,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NPP-JPSS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=NPP-JPSS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3591,9 +4362,9 @@
               "title": "OCO-2",
               "type": "filter",
               "applied": false,
-              "count": 22,
+              "count": 46,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=OCO-2&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=OCO-2&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3603,7 +4374,7 @@
               "applied": false,
               "count": 25,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=OLYMPEX&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=OLYMPEX&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3613,17 +4384,7 @@
               "applied": false,
               "count": 110,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SAFARI&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "SCP",
-              "type": "filter",
-              "applied": false,
-              "count": 20,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SCP&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SAFARI&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3631,9 +4392,9 @@
               "title": "Sentinel-5P",
               "type": "filter",
               "applied": false,
-              "count": 42,
+              "count": 65,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Sentinel-5P&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Sentinel-5P&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3641,9 +4402,9 @@
               "title": "SMAPVEX",
               "type": "filter",
               "applied": false,
-              "count": 31,
+              "count": 34,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SMAPVEX&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SMAPVEX&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3653,17 +4414,7 @@
               "applied": false,
               "count": 32,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SNF&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Soil",
-              "type": "filter",
-              "applied": false,
-              "count": 20,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Soil&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SNF&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3673,7 +4424,7 @@
               "applied": false,
               "count": 31,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SPURS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SPURS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -3681,507 +4432,9 @@
               "title": "SRB",
               "type": "filter",
               "applied": false,
-              "count": 43,
+              "count": 22,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SRB&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "TOVS Pathfinder",
-              "type": "filter",
-              "applied": false,
-              "count": 18,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=TOVS+Pathfinder&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "TROPESS",
-              "type": "filter",
-              "applied": false,
-              "count": 24,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=TROPESS&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Vegetation",
-              "type": "filter",
-              "applied": false,
-              "count": 72,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Vegetation&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            }
-          ]
-        },
-        {
-          "title": "Platforms",
-          "type": "group",
-          "applied": false,
-          "has_children": true,
-          "children": [
-            {
-              "title": "AIRCRAFT",
-              "type": "filter",
-              "applied": false,
-              "count": 108,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=AIRCRAFT&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Aqua",
-              "type": "filter",
-              "applied": false,
-              "count": 769,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Aqua&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Aquarius_SAC-D",
-              "type": "filter",
-              "applied": false,
-              "count": 234,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Aquarius_SAC-D&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Aura",
-              "type": "filter",
-              "applied": false,
-              "count": 399,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Aura&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "CRYOSAT-2",
-              "type": "filter",
-              "applied": false,
-              "count": 90,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=CRYOSAT-2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DC-8",
-              "type": "filter",
-              "applied": false,
-              "count": 184,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DC-8&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-2/F10",
-              "type": "filter",
-              "applied": false,
-              "count": 93,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-2%2FF10&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-2/F11",
-              "type": "filter",
-              "applied": false,
-              "count": 108,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-2%2FF11&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-2/F13",
-              "type": "filter",
-              "applied": false,
-              "count": 112,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-2%2FF13&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-2/F14",
-              "type": "filter",
-              "applied": false,
-              "count": 100,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-2%2FF14&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-3/F17",
-              "type": "filter",
-              "applied": false,
-              "count": 118,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-3%2FF17&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "DMSP 5D-3/F18",
-              "type": "filter",
-              "applied": false,
-              "count": 108,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=DMSP+5D-3%2FF18&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ENVISAT",
-              "type": "filter",
-              "applied": false,
-              "count": 119,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=ENVISAT&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ER-2",
-              "type": "filter",
-              "applied": false,
-              "count": 144,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=ER-2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ERS-1",
-              "type": "filter",
-              "applied": false,
-              "count": 109,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=ERS-1&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "ERS-2",
-              "type": "filter",
-              "applied": false,
-              "count": 106,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=ERS-2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Field Investigation",
-              "type": "filter",
-              "applied": false,
-              "count": 494,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Field+Investigation&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Field Survey",
-              "type": "filter",
-              "applied": false,
-              "count": 149,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Field+Survey&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "GLONASS",
-              "type": "filter",
-              "applied": false,
-              "count": 85,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=GLONASS&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "GRACE",
-              "type": "filter",
-              "applied": false,
-              "count": 109,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=GRACE&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "GRACE-FO",
-              "type": "filter",
-              "applied": false,
-              "count": 95,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=GRACE-FO&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Ground Station",
-              "type": "filter",
-              "applied": false,
-              "count": 474,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Ground+Station&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Ground-based Observation",
-              "type": "filter",
-              "applied": false,
-              "count": 94,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Ground-based+Observation&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "In Situ Ocean-based Platforms",
-              "type": "filter",
-              "applied": false,
-              "count": 287,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=In+Situ+Ocean-based+Platforms&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "International Space Station",
-              "type": "filter",
-              "applied": false,
-              "count": 93,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=International+Space+Station&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "JASON-1",
-              "type": "filter",
-              "applied": false,
-              "count": 107,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=JASON-1&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "JASON-3",
-              "type": "filter",
-              "applied": false,
-              "count": 90,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=JASON-3&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Laboratory",
-              "type": "filter",
-              "applied": false,
-              "count": 149,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Laboratory&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Landsat-5",
-              "type": "filter",
-              "applied": false,
-              "count": 104,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Landsat-5&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "MERRA",
-              "type": "filter",
-              "applied": false,
-              "count": 215,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=MERRA&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "MERRA-2",
-              "type": "filter",
-              "applied": false,
-              "count": 100,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=MERRA-2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Meteorological Station",
-              "type": "filter",
-              "applied": false,
-              "count": 122,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Meteorological+Station&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "MetOp-A",
-              "type": "filter",
-              "applied": false,
-              "count": 127,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=MetOp-A&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "MetOp-B",
-              "type": "filter",
-              "applied": false,
-              "count": 104,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=MetOp-B&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "Model",
-              "type": "filter",
-              "applied": false,
-              "count": 492,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Model&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA POES",
-              "type": "filter",
-              "applied": false,
-              "count": 90,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA+POES&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-7",
-              "type": "filter",
-              "applied": false,
-              "count": 106,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-7&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-9",
-              "type": "filter",
-              "applied": false,
-              "count": 174,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-9&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-10",
-              "type": "filter",
-              "applied": false,
-              "count": 114,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-10&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-11",
-              "type": "filter",
-              "applied": false,
-              "count": 147,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-11&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-12",
-              "type": "filter",
-              "applied": false,
-              "count": 86,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-12&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-14",
-              "type": "filter",
-              "applied": false,
-              "count": 123,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-14&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-19",
-              "type": "filter",
-              "applied": false,
-              "count": 160,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-19&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "NOAA-20 (JPSS-1)",
-              "type": "filter",
-              "applied": false,
-              "count": 167,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=NOAA-20+%28JPSS-1%29&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "OSTM/JASON-2",
-              "type": "filter",
-              "applied": false,
-              "count": 101,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=OSTM%2FJASON-2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "P-3",
-              "type": "filter",
-              "applied": false,
-              "count": 89,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=P-3&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=SRB&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4189,39 +4442,29 @@
               "title": "Suomi-NPP",
               "type": "filter",
               "applied": false,
-              "count": 327,
+              "count": 24,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Suomi-NPP&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Suomi-NPP&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "Terra",
+              "title": "TROPESS",
               "type": "filter",
               "applied": false,
-              "count": 866,
+              "count": 35,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=Terra&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=TROPESS&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "TOPEX/POSEIDON",
+              "title": "Vegetation",
               "type": "filter",
               "applied": false,
-              "count": 97,
+              "count": 71,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=TOPEX%2FPOSEIDON&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "TRMM",
-              "type": "filter",
-              "applied": false,
-              "count": 91,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&platform_h%5B%5D=TRMM&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&project_h%5B%5D=Vegetation&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -4237,9 +4480,9 @@
               "title": "0 - Raw Data",
               "type": "filter",
               "applied": false,
-              "count": 50,
+              "count": 53,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=0+-+Raw+Data&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=0+-+Raw+Data&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4247,9 +4490,9 @@
               "title": "1 - Radiance",
               "type": "filter",
               "applied": false,
-              "count": 266,
+              "count": 322,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1+-+Radiance&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1+-+Radiance&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4257,9 +4500,9 @@
               "title": "1A - Radiance",
               "type": "filter",
               "applied": false,
-              "count": 172,
+              "count": 188,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1A+-+Radiance&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1A+-+Radiance&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4267,9 +4510,9 @@
               "title": "1B - Radiance, Sensor Coordinates",
               "type": "filter",
               "applied": false,
-              "count": 504,
+              "count": 593,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1B+-+Radiance%2C+Sensor+Coordinates&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=1B+-+Radiance%2C+Sensor+Coordinates&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4277,9 +4520,9 @@
               "title": "2 - Geophys. Variables, Sensor Coordinates",
               "type": "filter",
               "applied": false,
-              "count": 2208,
+              "count": 2692,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=2+-+Geophys.+Variables%2C+Sensor+Coordinates&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=2+-+Geophys.+Variables%2C+Sensor+Coordinates&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4287,9 +4530,9 @@
               "title": "3 - Gridded Observations",
               "type": "filter",
               "applied": false,
-              "count": 3435,
+              "count": 3767,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=3+-+Gridded+Observations&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=3+-+Gridded+Observations&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
@@ -4297,19 +4540,9 @@
               "title": "4 - Gridded Model Output",
               "type": "filter",
               "applied": false,
-              "count": 916,
+              "count": 1043,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=4+-+Gridded+Model+Output&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
-              },
-              "has_children": false
-            },
-            {
-              "title": "product-level-id smusrlbl not found",
-              "type": "filter",
-              "applied": false,
-              "count": 5,
-              "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=product-level-id+smusrlbl+not+found&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&processing_level_id_h%5B%5D=4+-+Gridded+Model+Output&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -4325,9 +4558,19 @@
               "title": "CALIPSO",
               "type": "filter",
               "applied": false,
-              "count": 69,
+              "count": 75,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=CALIPSO&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=CALIPSO&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "Military Grid Reference System",
+              "type": "filter",
+              "applied": false,
+              "count": 2,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=Military+Grid+Reference+System&include_facets=v2"
               },
               "has_children": false
             },
@@ -4335,9 +4578,9 @@
               "title": "MISR",
               "type": "filter",
               "applied": false,
-              "count": 81,
+              "count": 83,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MISR&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MISR&include_facets=v2"
               },
               "has_children": false
             },
@@ -4345,9 +4588,9 @@
               "title": "MODIS Tile EASE",
               "type": "filter",
               "applied": false,
-              "count": 12,
+              "count": 8,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MODIS+Tile+EASE&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MODIS+Tile+EASE&include_facets=v2"
               },
               "has_children": false
             },
@@ -4355,29 +4598,47 @@
               "title": "MODIS Tile SIN",
               "type": "filter",
               "applied": false,
-              "count": 171,
+              "count": 172,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MODIS+Tile+SIN&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=MODIS+Tile+SIN&include_facets=v2"
               },
               "has_children": false
-            },
+            }
+          ]
+        },
+        {
+          "title": "Latency",
+          "type": "group",
+          "applied": false,
+          "has_children": true,
+          "children": [
             {
-              "title": "WRS-1",
+              "title": "1 to 3 hours",
               "type": "filter",
               "applied": false,
-              "count": 2,
+              "count": 294,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=WRS-1&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&latency%5B%5D=1+to+3+hours&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             },
             {
-              "title": "WRS-2",
+              "title": "1 to 4 days",
               "type": "filter",
               "applied": false,
               "count": 10,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&two_d_coordinate_system_name%5B%5D=WRS-2&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&latency%5B%5D=1+to+4+days&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
+              },
+              "has_children": false
+            },
+            {
+              "title": "3 to 24 hours",
+              "type": "filter",
+              "applied": false,
+              "count": 14,
+              "links": {
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&latency%5B%5D=3+to+24+hours&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&include_facets=v2"
               },
               "has_children": false
             }
@@ -4393,9 +4654,9 @@
               "title": "0 to 1 meter",
               "type": "filter",
               "applied": false,
-              "count": 42,
+              "count": 76,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=0+to+1+meter&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=0+to+1+meter&include_facets=v2"
               },
               "has_children": false
             },
@@ -4403,9 +4664,9 @@
               "title": "1 to 30 meters",
               "type": "filter",
               "applied": false,
-              "count": 95,
+              "count": 141,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1+to+30+meters&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1+to+30+meters&include_facets=v2"
               },
               "has_children": false
             },
@@ -4413,9 +4674,9 @@
               "title": "30 to 100 meters",
               "type": "filter",
               "applied": false,
-              "count": 68,
+              "count": 132,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=30+to+100+meters&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=30+to+100+meters&include_facets=v2"
               },
               "has_children": false
             },
@@ -4423,9 +4684,9 @@
               "title": "100 to 250 meters",
               "type": "filter",
               "applied": false,
-              "count": 27,
+              "count": 56,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=100+to+250+meters&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=100+to+250+meters&include_facets=v2"
               },
               "has_children": false
             },
@@ -4433,9 +4694,9 @@
               "title": "250 to 500 meters",
               "type": "filter",
               "applied": false,
-              "count": 111,
+              "count": 171,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=250+to+500+meters&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=250+to+500+meters&include_facets=v2"
               },
               "has_children": false
             },
@@ -4443,9 +4704,9 @@
               "title": "500 to 1000 meters",
               "type": "filter",
               "applied": false,
-              "count": 431,
+              "count": 508,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=500+to+1000+meters&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=500+to+1000+meters&include_facets=v2"
               },
               "has_children": false
             },
@@ -4453,9 +4714,9 @@
               "title": "1 to 10 km",
               "type": "filter",
               "applied": false,
-              "count": 580,
+              "count": 706,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1+to+10+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1+to+10+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4463,9 +4724,9 @@
               "title": "10 to 50 km",
               "type": "filter",
               "applied": false,
-              "count": 127,
+              "count": 208,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=10+to+50+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=10+to+50+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4473,9 +4734,9 @@
               "title": "50 to 100 km",
               "type": "filter",
               "applied": false,
-              "count": 99,
+              "count": 69,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=50+to+100+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=50+to+100+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4483,9 +4744,9 @@
               "title": "100 to 250 km",
               "type": "filter",
               "applied": false,
-              "count": 343,
+              "count": 315,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=100+to+250+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=100+to+250+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4493,9 +4754,9 @@
               "title": "250 to 500 km",
               "type": "filter",
               "applied": false,
-              "count": 59,
+              "count": 30,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=250+to+500+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=250+to+500+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4503,9 +4764,9 @@
               "title": "500 to 1000 km",
               "type": "filter",
               "applied": false,
-              "count": 20,
+              "count": 24,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=500+to+1000+km&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=500+to+1000+km&include_facets=v2"
               },
               "has_children": false
             },
@@ -4513,9 +4774,9 @@
               "title": "1000 km & beyond",
               "type": "filter",
               "applied": false,
-              "count": 11,
+              "count": 14,
               "links": {
-                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&options%5Bscience_keywords_h%5D%5Bor%5D=true&options%5Btemporal%5D%5Blimit_to_granules%5D=true&has_granules_or_cwic=true&options%5Bspatial%5D%5Bor%5D=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.extra.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1000+km+%26+beyond&include_facets=v2&tag_key%5B%5D=gov.nasa.eosdis"
+                "apply": "https://cmr.earthdata.nasa.gov:443/search/collections.json?page_num=1&include_granule_counts=true&consortium%5B%5D=EOSDIS&has_granules_or_cwic=true&sort_key%5B%5D=has_granules_or_cwic&sort_key%5B%5D=-usage_score&include_tags=edsc.*%2Copensearch.granule.osdd&page_size=20&include_has_granules=true&horizontal_data_resolution_range%5B%5D=1000+km+%26+beyond&include_facets=v2"
               },
               "has_children": false
             }

--- a/cypress/integration/paths/search/granules/collection_details/collection_details_spec.js
+++ b/cypress/integration/paths/search/granules/collection_details/collection_details_spec.js
@@ -170,6 +170,7 @@ describe('Path /search/granules/collection-details', () => {
       },
       (req) => {
         expect(JSON.parse(req.body).params).to.eql({
+          consortium: [],
           include_facets: 'v2',
           include_granule_counts: true,
           include_has_granules: true,

--- a/cypress/integration/paths/search/granules/granules_spec.js
+++ b/cypress/integration/paths/search/granules/granules_spec.js
@@ -1227,6 +1227,7 @@ describe('Path /search/granules', () => {
       },
       (req) => {
         expect(JSON.parse(req.body).params).to.eql({
+          consortium: [],
           has_granules_or_cwic: true,
           include_facets: 'v2',
           include_granule_counts: true,

--- a/cypress/integration/paths/search/search_spec.js
+++ b/cypress/integration/paths/search/search_spec.js
@@ -1075,7 +1075,7 @@ describe('Path /search', () => {
           url: '**/search/collections.json'
         },
         (req) => {
-          expect(req.body).to.eq('has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.*,opensearch.granule.osdd&page_num=1&page_size=20&sort_key[]=has_granules_or_cwic&sort_key[]=-usage_score&tag_key[]=gov.nasa.eosdis')
+          expect(req.body).to.eq('has_granules_or_cwic=true&include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.*,opensearch.granule.osdd&page_num=1&page_size=20&consortium[]=EOSDIS&sort_key[]=has_granules_or_cwic&sort_key[]=-usage_score')
 
           req.reply({
             body: nonEosdisBody,
@@ -1086,7 +1086,7 @@ describe('Path /search', () => {
           })
         })
 
-        cy.visit('/search?tag_key=gov.nasa.eosdis')
+        cy.visit('/search?oe=t')
 
         // Ensure the correct number of results were loaded
         testResultsSize(cmrHits)

--- a/static.config.json
+++ b/static.config.json
@@ -18,7 +18,6 @@
       "width": 85
     },
     "orderStatusRefreshTime": 60000,
-    "eosdisTagKey": "gov.nasa.eosdis",
     "defaultCmrPageSize": 20,
     "maxCmrPageSize": 2000,
     "granuleLinksPageSize": "500",

--- a/static.webpack.config.dev.js
+++ b/static.webpack.config.dev.js
@@ -16,7 +16,7 @@ const Config = mergeWithRules({
   }
 })(StaticCommonConfig, {
   mode: 'development',
-  devtool: 'inline-cheap-module-source-map',
+  devtool: 'eval-source-map',
   resolve: {
     extensions: ['.js', '.jsx']
   },

--- a/static/src/js/containers/SubscriptionsBodyContainer/__tests__/SubscriptionsBodyContainer.test.js
+++ b/static/src/js/containers/SubscriptionsBodyContainer/__tests__/SubscriptionsBodyContainer.test.js
@@ -110,6 +110,7 @@ describe('mapStateToProps', () => {
 
     const expectedState = {
       collectionQueryObj: {
+        consortium: [],
         serviceType: [],
         tagKey: []
       },

--- a/static/src/js/containers/UrlQueryContainer/UrlQueryContainer.js
+++ b/static/src/js/containers/UrlQueryContainer/UrlQueryContainer.js
@@ -40,6 +40,7 @@ export const mapStateToProps = (state) => ({
   location: state.router.location,
   map: state.map,
   mapPreferences: getMapPreferences(state),
+  onlyEosdisCollections: state.query.collection.onlyEosdisCollections,
   organizationFacets: state.facetsParams.cmr.data_center_h,
   overrideTemporalSearch: state.query.collection.overrideTemporal,
   pathname: state.router.location.pathname,

--- a/static/src/js/routes/Search/Search.js
+++ b/static/src/js/routes/Search/Search.js
@@ -40,7 +40,6 @@ import SidebarFiltersList from '../../components/Sidebar/SidebarFiltersList'
 import actions from '../../actions'
 import { metricsCollectionSortChange } from '../../middleware/metrics/actions'
 import advancedSearchFields from '../../data/advancedSearchFields'
-import { getApplicationConfig } from '../../../../../sharedUtils/config'
 
 const mapDispatchToProps = (dispatch) => ({
   onUpdateAdvancedSearch:
@@ -74,11 +73,13 @@ export const Search = ({
   const { path } = match
   const [granuleFiltersNeedsReset, setGranuleFiltersNeedReset] = useState(false)
 
-  const { hasGranulesOrCwic = false, tagKey } = collectionQuery
+  const {
+    hasGranulesOrCwic = false,
+    onlyEosdisCollections
+  } = collectionQuery
   const isHasNoGranulesChecked = !hasGranulesOrCwic
 
-  const { eosdisTagKey } = getApplicationConfig()
-  const isEosdisChecked = tagKey === eosdisTagKey
+  const isEosdisChecked = onlyEosdisCollections || false
 
   const handleCheckboxCheck = (event) => {
     const { target } = event
@@ -86,8 +87,8 @@ export const Search = ({
 
     const collection = {}
     if (id === 'input__non-eosdis') {
-      if (!checked) collection.tagKey = undefined
-      if (checked) collection.tagKey = getApplicationConfig().eosdisTagKey
+      if (!checked) collection.onlyEosdisCollections = undefined
+      if (checked) collection.onlyEosdisCollections = true
     }
 
     if (id === 'input__only-granules') {
@@ -212,7 +213,7 @@ export const Search = ({
 Search.propTypes = {
   collectionQuery: PropTypes.shape({
     hasGranulesOrCwic: PropTypes.bool,
-    tagKey: PropTypes.string
+    onlyEosdisCollections: PropTypes.bool
   }).isRequired,
   match: PropTypes.shape({
     path: PropTypes.string

--- a/static/src/js/routes/Search/__tests__/Search.test.js
+++ b/static/src/js/routes/Search/__tests__/Search.test.js
@@ -113,7 +113,7 @@ describe('Search component', () => {
       expect(props.onChangeQuery).toHaveBeenCalledTimes(1)
       expect(props.onChangeQuery).toHaveBeenCalledWith({
         collection: {
-          tagKey: 'gov.nasa.eosdis'
+          onlyEosdisCollections: true
         }
       })
     })

--- a/static/src/js/util/__tests__/humanizedQueryValueFormattingMap.test.js
+++ b/static/src/js/util/__tests__/humanizedQueryValueFormattingMap.test.js
@@ -108,6 +108,14 @@ describe('humanizedQueryValueFormattingMap', () => {
     })
   })
 
+  describe('when formatting onlyEosdisCollections', () => {
+    test('calls the correct formatter with the correct arguments', () => {
+      humanizedQueryValueFormattingMap.onlyEosdisCollections(true)
+      expect(formatBooleanMock).toHaveBeenCalledTimes(1)
+      expect(formatBooleanMock).toHaveBeenCalledWith(true)
+    })
+  })
+
   describe('when formatting platformsH', () => {
     test('calls the correct formatter with the correct arguments', () => {
       humanizedQueryValueFormattingMap.platformsH([{

--- a/static/src/js/util/__tests__/queryToHumanizedList.test.js
+++ b/static/src/js/util/__tests__/queryToHumanizedList.test.js
@@ -16,10 +16,10 @@ describe('queryToHumanizedList', () => {
     }])
   })
 
-  test('returns a humanized param for EOSDIS collections tag', () => {
+  test('returns a humanized param for EOSDIS consortium', () => {
     const query = {
       hasGranulesOrCwic: true,
-      tagKey: ['gov.nasa.eosdis']
+      consortium: ['EOSDIS']
     }
 
     const subscriptionType = 'collection'
@@ -27,23 +27,7 @@ describe('queryToHumanizedList', () => {
     const result = queryToHumanizedList(query, subscriptionType)
 
     expect(result).toEqual([{
-      key: 'tagKey-gov.nasa.eosdis',
-      humanizedKey: 'Include only EOSDIS datasets'
-    }])
-  })
-
-  test('returns a humanized param for EOSDIS collections tag when tagKey is not an array', () => {
-    const query = {
-      hasGranulesOrCwic: true,
-      tagKey: 'gov.nasa.eosdis'
-    }
-
-    const subscriptionType = 'collection'
-
-    const result = queryToHumanizedList(query, subscriptionType)
-
-    expect(result).toEqual([{
-      key: 'tagKey-gov.nasa.eosdis',
+      key: 'consortium-EOSDIS',
       humanizedKey: 'Include only EOSDIS datasets'
     }])
   })

--- a/static/src/js/util/__tests__/subscriptions.test.js
+++ b/static/src/js/util/__tests__/subscriptions.test.js
@@ -70,11 +70,27 @@ describe('removeDisabledFieldsFromQuery', () => {
     expect(result).toEqual({ keyword: 'modis' })
   })
 
+  test('removes disabled consortium field from query', () => {
+    const query = {
+      keyword: 'modis',
+      consortium: ['mockConsortium']
+    }
+
+    const disabledFields = {
+      'consortium-mockConsortium': true
+    }
+
+    const result = removeDisabledFieldsFromQuery(query, disabledFields)
+
+    expect(result).toEqual({ keyword: 'modis' })
+  })
+
   test('does not remove a disabled field from the query if it is false in the disabledFields', () => {
     // This can happen when the user disables and field, and reenables it
     const query = {
       keyword: 'modis',
-      tagKey: ['mocktag']
+      tagKey: ['mocktag'],
+      consortium: ['mockConsortium']
     }
 
     const disabledFields = {
@@ -83,7 +99,7 @@ describe('removeDisabledFieldsFromQuery', () => {
 
     const result = removeDisabledFieldsFromQuery(query, disabledFields)
 
-    expect(result).toEqual({ keyword: 'modis', tagKey: ['mocktag'] })
+    expect(result).toEqual({ keyword: 'modis', tagKey: ['mocktag'], consortium: ['mockConsortium'] })
   })
 
   test('removes any remaining fields that are empty arrays', () => {

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -28,6 +28,7 @@ export const prepareCollectionParams = (state) => {
   const {
     hasGranulesOrCwic,
     keyword,
+    onlyEosdisCollections,
     overrideTemporal = {},
     pageNum,
     sortKey = [],
@@ -78,7 +79,13 @@ export const prepareCollectionParams = (state) => {
   let cloudHosted
   if (featureFacets.availableFromAwsCloud) cloudHosted = true
 
+  let consortium = []
+  if (onlyEosdisCollections) {
+    consortium = ['EOSDIS']
+  }
+
   const { query: portalQuery = {} } = portal
+  const { consortium: portalConsortium = [] } = portalQuery
 
   const collectionParams = {
     authToken,
@@ -99,7 +106,11 @@ export const prepareCollectionParams = (state) => {
     temporalString,
     viewAllFacetsCategory,
     viewAllFacets,
-    ...portalQuery
+    ...portalQuery,
+    consortium: [
+      ...consortium,
+      ...portalConsortium
+    ]
   }
 
   // Add the autocomplete selected parameters if the type is not a CMR Facet

--- a/static/src/js/util/humanizedQueryValueFormattingMap.js
+++ b/static/src/js/util/humanizedQueryValueFormattingMap.js
@@ -38,6 +38,7 @@ export const humanizedQueryValueFormattingMap = {
   latency: (value) => formatFacetHierarchy(value),
   line: (value) => formatPoints(value),
   onlineOnly: (value) => formatBoolean(value),
+  onlyEosdisCollections: (value) => formatBoolean(value),
   platformsH: (value) => formatFacetHierarchy(value, platformsHierarchy),
   point: (value) => formatPoints(value),
   polygon: (value) => formatPoints(value),

--- a/static/src/js/util/queryToHumanizedList.js
+++ b/static/src/js/util/queryToHumanizedList.js
@@ -22,12 +22,11 @@ export const queryToHumanizedList = (subscriptionsQuery, subscriptionQueryType) 
     }
 
     // If only displaying EOSDIS collections, add a key of "EOSDIS collections"
-    if (subscriptionsQuery.tagKey && subscriptionsQuery.tagKey.includes('gov.nasa.eosdis')) {
+    if (subscriptionsQuery.consortium && ['EOSDIS'].every((type) => subscriptionsQuery.consortium.includes(type))) {
       values.push({
-        key: 'tagKey-gov.nasa.eosdis',
+        key: 'consortium-EOSDIS',
         humanizedKey: 'Include only EOSDIS datasets'
       })
-      subscriptionsQueryTemp.tagKey = castArray(subscriptionsQueryTemp.tagKey).filter((tagKey) => tagKey !== 'gov.nasa.eosdis')
     }
 
     // If only displaying collections with Map Imagery, add a key of "Map Imagery"
@@ -53,7 +52,8 @@ export const queryToHumanizedList = (subscriptionsQuery, subscriptionQueryType) 
     // hasGranulesOrCwic is the default, so it should not be displayed
     'hasGranulesOrCwic',
     // options are derrived from a users query and should not be displayed
-    'options'
+    'options',
+    'consortium'
   ]
 
   Object.keys(subscriptionsQueryTemp)

--- a/static/src/js/util/subscriptions.js
+++ b/static/src/js/util/subscriptions.js
@@ -47,7 +47,7 @@ export const removeDisabledFieldsFromQuery = (query, disabledFields) => {
       return
     }
 
-    // If the key starts with `tagKey`, remove the correct tag from the tags array
+    // If the key starts with `consortium`, remove the correct tag from the tags array
     if (key.startsWith('consortium')) {
       const [, cosortiumValue] = key.split('-')
 

--- a/static/src/js/util/subscriptions.js
+++ b/static/src/js/util/subscriptions.js
@@ -33,6 +33,7 @@ export const prepareSubscriptionQuery = (params) => {
 export const removeDisabledFieldsFromQuery = (query, disabledFields) => {
   const newQuery = { ...query }
   let tags = query.tagKey
+  let consortiums = query.consortium
 
   Object.keys(disabledFields).forEach((key) => {
     // If the disabledField is false, the user has re-enabled the field, don't remove it
@@ -46,11 +47,19 @@ export const removeDisabledFieldsFromQuery = (query, disabledFields) => {
       return
     }
 
+    // If the key starts with `tagKey`, remove the correct tag from the tags array
+    if (key.startsWith('consortium')) {
+      const [, cosortiumValue] = key.split('-')
+
+      consortiums = consortiums.filter((value) => value !== cosortiumValue)
+      return
+    }
+
     // Remove the field from the newQuery
     delete newQuery[key]
   })
 
-  // If some tags still exist, set the new tagKey to the updates tags array
+  // If some tags still exist, set the new tagKey to the updated tags array
   if (tags && tags.length > 0) {
     newQuery.tagKey = tags
   }
@@ -58,6 +67,16 @@ export const removeDisabledFieldsFromQuery = (query, disabledFields) => {
   // If no tags remain, delete the tagKey from the newQuery
   if (tags && tags.length === 0) {
     delete newQuery.tagKey
+  }
+
+  // If some consortiums still exist, set the new consortium to the updated consortiums array
+  if (consortiums && consortiums.length > 0) {
+    newQuery.consortium = consortiums
+  }
+
+  // If no consortiums remain, delete the consortium from the newQuery
+  if (consortiums && consortiums.length === 0) {
+    delete newQuery.consortium
   }
 
   // Remove any existing query fields that are empty

--- a/static/src/js/util/url/__tests__/onlyEosdisCollections.test.js
+++ b/static/src/js/util/url/__tests__/onlyEosdisCollections.test.js
@@ -1,0 +1,37 @@
+import { decodeUrlParams, encodeUrlQuery } from '../url'
+
+import { emptyDecodedResult } from './url.mocks'
+
+import * as deployedEnvironment from '../../../../../../sharedUtils/deployedEnvironment'
+
+beforeEach(() => {
+  jest.spyOn(deployedEnvironment, 'deployedEnvironment').mockImplementation(() => 'prod')
+})
+
+describe('url#decodeUrlParams', () => {
+  test('decodes onlyEosdisCollections correctly', () => {
+    const expectedResult = {
+      ...emptyDecodedResult,
+      query: {
+        ...emptyDecodedResult.query,
+        collection: {
+          ...emptyDecodedResult.query.collection,
+          onlyEosdisCollections: true
+        }
+      }
+    }
+    expect(decodeUrlParams('?oe=t')).toEqual(expectedResult)
+  })
+})
+
+describe('url#encodeUrlQuery', () => {
+  test('encodes onlyEosdisCollections correctly', () => {
+    const props = {
+      hasGranulesOrCwic: true,
+      pathname: '/path/here',
+      onlyEosdisCollections: true
+    }
+
+    expect(encodeUrlQuery(props)).toEqual('/path/here?oe=t')
+  })
+})

--- a/static/src/js/util/url/__tests__/url.mocks.js
+++ b/static/src/js/util/url/__tests__/url.mocks.js
@@ -29,6 +29,7 @@ export const emptyDecodedResult = {
       byId: {},
       pageNum: 1,
       keyword: undefined,
+      onlyEosdisCollections: undefined,
       overrideTemporal: {},
       spatial: {
         boundingBox: undefined,

--- a/static/src/js/util/url/booleanEncoders.js
+++ b/static/src/js/util/url/booleanEncoders.js
@@ -1,0 +1,23 @@
+/**
+ * Decodes an boolean parameter
+ * @param {Boolean} boolean
+ */
+export const decodeBoolean = (boolean) => {
+  if (boolean === 't') {
+    return true
+  }
+
+  return undefined
+}
+
+/**
+ * Encodes an boolean parameter
+ * @param {Boolean} boolean
+ */
+export const encodeBoolean = (boolean) => {
+  if (boolean === true) {
+    return 't'
+  }
+
+  return undefined
+}

--- a/static/src/js/util/url/url.js
+++ b/static/src/js/util/url/url.js
@@ -15,6 +15,7 @@ import { encodeAdvancedSearch, decodeAdvancedSearch } from './advancedSearchEnco
 import { encodeArray, decodeArray } from './arrayEncoders'
 import { encodeAutocomplete, decodeAutocomplete } from './autocompleteEncoders'
 import { encodeEarthdataEnvironment, decodeEarthdataEnvironment } from './environmentEncoders'
+import { decodeBoolean, encodeBoolean } from './booleanEncoders'
 
 import { isPath } from '../isPath'
 import { deprecatedURLParameters } from '../../constants/deprecatedURLParameters'
@@ -65,7 +66,8 @@ const urlDefs = {
   selectedFeatures: { shortKey: 'sfs', encode: encodeArray, decode: decodeArray },
   tagKey: { shortKey: 'tag_key', encode: encodeString, decode: decodeString },
   hasGranulesOrCwic: { shortKey: 'ac', encode: encodeHasGranulesOrCwic, decode: decodeHasGranulesOrCwic },
-  autocompleteSelected: { shortKey: 'as', encode: encodeAutocomplete, decode: decodeAutocomplete }
+  autocompleteSelected: { shortKey: 'as', encode: encodeAutocomplete, decode: decodeAutocomplete },
+  onlyEosdisCollections: { shortKey: 'oe', encode: encodeBoolean, decode: decodeBoolean }
 }
 
 /**
@@ -119,12 +121,13 @@ export const decodeUrlParams = (paramString) => {
     ...collection,
     pageNum: 1
   }
-  collectionQuery.spatial = spatial
-  collectionQuery.keyword = decodeHelp(params, 'keywordSearch')
-  collectionQuery.temporal = decodeHelp(params, 'temporalSearch')
-  collectionQuery.overrideTemporal = decodeHelp(params, 'overrideTemporalSearch')
-  collectionQuery.tagKey = decodeHelp(params, 'tagKey')
   collectionQuery.hasGranulesOrCwic = decodeHelp(params, 'hasGranulesOrCwic')
+  collectionQuery.keyword = decodeHelp(params, 'keywordSearch')
+  collectionQuery.onlyEosdisCollections = decodeHelp(params, 'onlyEosdisCollections')
+  collectionQuery.overrideTemporal = decodeHelp(params, 'overrideTemporalSearch')
+  collectionQuery.spatial = spatial
+  collectionQuery.tagKey = decodeHelp(params, 'tagKey')
+  collectionQuery.temporal = decodeHelp(params, 'temporalSearch')
 
   // Initialize the collection granule query
   const granuleQuery = {


### PR DESCRIPTION
# Overview

### What is the feature?

This PR changes the behavior of the `Include only EOSDIS collections` checkbox to use the consortium parameter instead of the current behavior of tags

### What areas of the application does this impact?

Collection Search

# Testing

Check the `Include only EOSDIS collections` checkbox, verify the consortium parameter is sent with the collection request and not the tagKey

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
