### PR TITLE
EDSC-3314: Display explore button with diabled state and tooltip

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsActions.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsActions.js
@@ -170,14 +170,14 @@ const GranuleResultsActions = ({
             </AuthRequiredContainer>
           </PortalFeatureContainer>
           <Dropdown
-            rop="up"
+            drop="up"
             className="granule-results-actions__action granule-results-actions__action--explore"
           >
             <OverlayTrigger
               placement="bottom"
               delay={{ show: 250, hide: 400 }}
               overlay={renderTooltip}
-              show={!!handoffLinks.length}
+              show={!handoffLinks.length}
             >
               <Dropdown.Toggle
                 as={Button}
@@ -188,7 +188,7 @@ const GranuleResultsActions = ({
                 dataTestId="granule-results-actions__explore-button"
                 label="Explore"
                 title="Explore"
-                disabled={!!handoffLinks.length}
+                disabled={!handoffLinks.length}
               >
                 Explore
               </Dropdown.Toggle>

--- a/static/src/js/components/GranuleResults/GranuleResultsActions.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsActions.js
@@ -8,7 +8,7 @@ import {
   FaFolderMinus
 } from 'react-icons/fa'
 import { IoShare } from 'react-icons/io5'
-import { Dropdown } from 'react-bootstrap'
+import { Dropdown, OverlayTrigger, Tooltip } from 'react-bootstrap'
 
 import { commafy } from '../../util/commafy'
 import { locationPropType } from '../../util/propTypes/location'
@@ -105,7 +105,7 @@ const GranuleResultsActions = ({
             <EDSCIcon icon={FaFolder} className="granule-results-actions__project-pill-icon" />
           )
         }
-        { commafy(granuleCount) }
+        {commafy(granuleCount)}
       </>
     )
 
@@ -139,6 +139,12 @@ const GranuleResultsActions = ({
     }
   ])
 
+  const renderTooltip = () => (
+    <Tooltip id="button-tooltip">
+      Invalid parameters
+    </Tooltip>
+  )
+
   return (
     <div ref={granuleResultsActionsContainer} className="granule-results-actions">
       <div className="granule-results-actions__secondary-actions">
@@ -163,44 +169,48 @@ const GranuleResultsActions = ({
               </PortalLinkContainer>
             </AuthRequiredContainer>
           </PortalFeatureContainer>
-          {
-            handoffLinks.length > 0 && (
-              <Dropdown
-                drop="up"
-                className="granule-results-actions__action granule-results-actions__action--explore"
+          <Dropdown
+            rop="up"
+            className="granule-results-actions__action granule-results-actions__action--explore"
+          >
+            <OverlayTrigger
+              placement="bottom"
+              delay={{ show: 250, hide: 400 }}
+              overlay={renderTooltip}
+              show={!!handoffLinks.length}
+            >
+              <Dropdown.Toggle
+                as={Button}
+                type="button"
+                naked
+                icon={IoShare}
+                className="granule-results-actions__explore-button"
+                dataTestId="granule-results-actions__explore-button"
+                label="Explore"
+                title="Explore"
+                disabled={!!handoffLinks.length}
               >
-                <Dropdown.Toggle
-                  as={Button}
-                  type="button"
-                  naked
-                  icon={IoShare}
-                  className="granule-results-actions__explore-button"
-                  dataTestId="granule-results-actions__explore-button"
-                  label="Explore"
-                  title="Explore"
-                >
-                  Explore
-                </Dropdown.Toggle>
-                <Dropdown.Menu
-                  className={dropdownMenuClasses}
-                >
-                  <Dropdown.Header>Open search in:</Dropdown.Header>
-                  {
-                    handoffLinks.map((link) => (
-                      <Dropdown.Item
-                        key={link.title}
-                        className="link link--external more-actions-dropdown__item more-actions-dropdown__vis analytics__smart-handoff-link"
-                        href={link.href}
-                        target="_blank"
-                      >
-                        {link.title}
-                      </Dropdown.Item>
-                    ))
-                  }
-                </Dropdown.Menu>
-              </Dropdown>
-            )
-          }
+                Explore
+              </Dropdown.Toggle>
+            </OverlayTrigger>
+            <Dropdown.Menu
+              className={dropdownMenuClasses}
+            >
+              <Dropdown.Header>Open search in:</Dropdown.Header>
+              {
+                handoffLinks.map((link) => (
+                  <Dropdown.Item
+                    key={link.title}
+                    className="link link--external more-actions-dropdown__item more-actions-dropdown__vis analytics__smart-handoff-link"
+                    href={link.href}
+                    target="_blank"
+                  >
+                    {link.title}
+                  </Dropdown.Item>
+                ))
+              }
+            </Dropdown.Menu>
+          </Dropdown>
         </div>
         <PortalFeatureContainer authentication>
           <>

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsActions.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsActions.test.js
@@ -32,6 +32,7 @@ function setup(overrideProps) {
     onSetActivePanelSection: jest.fn(),
     onChangePath: jest.fn(),
     subscriptions: [],
+    handoffLinks: [],
     ...overrideProps
   }
 
@@ -187,5 +188,21 @@ describe('GranuleResultsActions component', () => {
 
       expect(subscriptionButton.props().className).toContain('granule-results-actions__action--is-active')
     })
+  })
+})
+
+describe('when invalid parameters', () => {
+  test('explore button is disabled', () => {
+    const { enzymeWrapper } = setup()
+
+    const exploreButton = enzymeWrapper.find('.granule-results-actions__explore-button')
+
+    expect(exploreButton.getDOMNode().hasAttribute('disabled')).toBe(true)
+  })
+
+  test('ToolTip is Visible', () => {
+    const { enzymeWrapper } = setup()
+
+    expect(enzymeWrapper.exists('#button-tooltip')).to.equal(true)
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?
This pr will help  the explore button to be disabled along with a tooltip when parameters are invalid.
solves https://github.com/nasa/earthdata-search/issues/1544

### What is the Solution?
I have used react bootstrap's overlaytrigger component that will show tooltip only when the conditions are met. Similarly the dropdown toggle will be disabled.

### What areas of the application does this impact?
Explore button 

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
