### PR TITLE
EDSC-3565: Downcase keys in authorizer lambdas to ensure Authorization header is read successfully

### DIFF
--- a/serverless/src/edlAdminAuthorizer/__tests__/handler.test.js
+++ b/serverless/src/edlAdminAuthorizer/__tests__/handler.test.js
@@ -48,7 +48,7 @@ describe('edlAdminAuthorizer', () => {
       const { jwtToken } = getEnvironmentConfig('test')
 
       const event = {
-        authorizationToken: `Bearer ${jwtToken}`
+        Authorization: `Bearer ${jwtToken}`
       }
 
       await expect(
@@ -68,7 +68,7 @@ describe('edlAdminAuthorizer', () => {
       const { jwtToken } = getEnvironmentConfig('test')
 
       const event = {
-        authorizationToken: `Bearer ${jwtToken}`
+        Authorization: `Bearer ${jwtToken}`
       }
 
       await expect(

--- a/serverless/src/edlAdminAuthorizer/handler.js
+++ b/serverless/src/edlAdminAuthorizer/handler.js
@@ -22,7 +22,7 @@ const edlAdminAuthorizer = async (event, context) => {
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
   // const { Authorization: authorizationToken = '' } = headers
-  const { authorization: authorizationToken } = downcaseKeys(headers)
+  const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')

--- a/serverless/src/edlAdminAuthorizer/handler.js
+++ b/serverless/src/edlAdminAuthorizer/handler.js
@@ -21,7 +21,6 @@ const edlAdminAuthorizer = async (event, context) => {
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  // const { Authorization: authorizationToken = '' } = headers
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token

--- a/serverless/src/edlAdminAuthorizer/handler.js
+++ b/serverless/src/edlAdminAuthorizer/handler.js
@@ -2,6 +2,7 @@ import { determineEarthdataEnvironment } from '../util/determineEarthdataEnviron
 import { generatePolicy } from '../util/authorizer/generatePolicy'
 import { getAdminUsers } from '../util/getAdminUsers'
 import { validateToken } from '../util/authorizer/validateToken'
+import { downcaseKeys } from '../util/downcaseKeys'
 
 /**
  * Custom authorizer for API Gateway authentication for the admin routes
@@ -20,7 +21,8 @@ const edlAdminAuthorizer = async (event, context) => {
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  const { Authorization: authorizationToken = '' } = headers
+  // const { Authorization: authorizationToken = '' } = headers
+  const { authorization: authorizationToken } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -18,7 +18,7 @@ const edlAuthorizer = async (event) => {
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
   // const { Authorization: authorizationToken = '' } = headers
-  const { authorization: authorizationToken } = downcaseKeys(headers)
+  const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -13,11 +13,9 @@ const edlAuthorizer = async (event) => {
     headers = {},
     methodArn
   } = event
-  console.log('🚀 ~ file: handler.js ~ line 19 ~ edlAuthorizer ~ headers', headers)
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  // const { Authorization: authorizationToken = '' } = headers
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
@@ -25,7 +23,6 @@ const edlAuthorizer = async (event) => {
   const jwtToken = tokenParts[1]
 
   const username = await validateToken(jwtToken, earthdataEnvironment)
-  console.log('🚀 ~ file: handler.js ~ line 25 ~ edlAuthorizer ~ username', username)
 
   if (username) {
     return generatePolicy(username, jwtToken, 'Allow', methodArn)

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -1,6 +1,7 @@
 import { determineEarthdataEnvironment } from '../util/determineEarthdataEnvironment'
 import { generatePolicy } from '../util/authorizer/generatePolicy'
 import { validateToken } from '../util/authorizer/validateToken'
+import { downcaseKeys } from '../util/downcaseKeys'
 
 /**
  * Custom authorizer for API Gateway authentication
@@ -16,7 +17,8 @@ const edlAuthorizer = async (event) => {
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  const { Authorization: authorizationToken = '' } = headers
+  // const { Authorization: authorizationToken = '' } = headers
+  const { authorization: authorizationToken } = downcaseKeys(headers)
 
   // authorizationToken comes in as `Bearer asdf.qwer.hjkl` but we only need the actual token
   const tokenParts = authorizationToken.split(' ')

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -12,6 +12,7 @@ const edlAuthorizer = async (event) => {
     headers = {},
     methodArn
   } = event
+  console.log('🚀 ~ file: handler.js ~ line 19 ~ edlAuthorizer ~ headers', headers)
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
@@ -22,6 +23,7 @@ const edlAuthorizer = async (event) => {
   const jwtToken = tokenParts[1]
 
   const username = await validateToken(jwtToken, earthdataEnvironment)
+  console.log('🚀 ~ file: handler.js ~ line 25 ~ edlAuthorizer ~ username', username)
 
   if (username) {
     return generatePolicy(username, jwtToken, 'Allow', methodArn)

--- a/serverless/src/edlOptionalAuthorizer/handler.js
+++ b/serverless/src/edlOptionalAuthorizer/handler.js
@@ -18,7 +18,7 @@ const edlOptionalAuthorizer = async (event) => {
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
   // const { Authorization: authorizationToken = '' } = headers
-  const { authorization: authorizationToken } = downcaseKeys(headers)
+  const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // resourcePath contains the path assigned to the lambda being requested
   const { resourcePath } = requestContext

--- a/serverless/src/edlOptionalAuthorizer/handler.js
+++ b/serverless/src/edlOptionalAuthorizer/handler.js
@@ -1,6 +1,7 @@
 import { determineEarthdataEnvironment } from '../util/determineEarthdataEnvironment'
 import { generatePolicy } from '../util/authorizer/generatePolicy'
 import { validateToken } from '../util/authorizer/validateToken'
+import { downcaseKeys } from '../util/downcaseKeys'
 
 /**
  * Custom authorizer for API Gateway authentication
@@ -16,7 +17,8 @@ const edlOptionalAuthorizer = async (event) => {
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  const { Authorization: authorizationToken = '' } = headers
+  // const { Authorization: authorizationToken = '' } = headers
+  const { authorization: authorizationToken } = downcaseKeys(headers)
 
   // resourcePath contains the path assigned to the lambda being requested
   const { resourcePath } = requestContext

--- a/serverless/src/edlOptionalAuthorizer/handler.js
+++ b/serverless/src/edlOptionalAuthorizer/handler.js
@@ -17,7 +17,6 @@ const edlOptionalAuthorizer = async (event) => {
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
 
-  // const { Authorization: authorizationToken = '' } = headers
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 
   // resourcePath contains the path assigned to the lambda being requested

--- a/serverless/src/util/__tests__/downcaseKeys.test.js
+++ b/serverless/src/util/__tests__/downcaseKeys.test.js
@@ -1,0 +1,39 @@
+import { downcaseKeys } from '../downcaseKeys'
+
+describe('downcaseKeys', () => {
+  test('returns an empty object when undefined is provided', () => {
+    const returnObject = downcaseKeys(undefined)
+
+    expect(returnObject).toMatchObject({})
+  })
+
+  test('downcases keys', () => {
+    const returnObject = downcaseKeys({
+      KEY: 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      key: 'value'
+    })
+  })
+
+  test('downcases camel cased keys', () => {
+    const returnObject = downcaseKeys({
+      hyphenatedKey: 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      hyphenatedkey: 'value'
+    })
+  })
+
+  test('downcases hyphenated keys', () => {
+    const returnObject = downcaseKeys({
+      'Hyphenated-Key': 'value'
+    })
+
+    expect(returnObject).toMatchObject({
+      'hyphenated-key': 'value'
+    })
+  })
+})

--- a/serverless/src/util/downcaseKeys.js
+++ b/serverless/src/util/downcaseKeys.js
@@ -1,0 +1,12 @@
+/**
+ * Downcase all keys of an object
+ * @param {*} obj Object to transform
+ * @returns Object with all keys downcased
+ */
+export const downcaseKeys = (obj = {}) => {
+  const entries = Object.entries(obj)
+
+  return Object.fromEntries(
+    entries.map(([key, value]) => [key.toLowerCase(), value])
+  )
+}


### PR DESCRIPTION
# Overview

### What is the Solution?

Our code was expecting an `Authorization` header, but we started receiving an `authorization` header. To fix that issue we downcase the keys in the header object before destructing `authorization` out of the headers. This ensures the casing is always what we expect

### What areas of the application does this impact?

All logged in actions

# Testing

### Reproduction steps

Log in to EDSC, ensure collection results are returned.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
