### PR TITLE
EDSC-2514: Display spinner for granule search time before values start loading

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsBody.js
+++ b/static/src/js/components/GranuleResults/GranuleResultsBody.js
@@ -64,7 +64,7 @@ const GranuleResultsBody = ({
 
   const {
     hits: granuleHits,
-    loadTime,
+    loadTime = 0,
     isLoaded,
     isLoading,
     allIds
@@ -236,7 +236,7 @@ const GranuleResultsBody = ({
           Search Time:
           {' '}
           {
-            isLoading && !isLoaded
+            (isLoading && !isLoaded) || loadTime === 0
               ? (
                 <span className="granule-results-body__search-time-value">
                   <Spinner

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsBody.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsBody.test.js
@@ -254,10 +254,32 @@ describe('GranuleResultsBody component', () => {
       .toEqual(props.onMetricsDataAccess)
   })
 
-  test('renders the correct search time', () => {
-    const { enzymeWrapper } = setup()
+  describe('search time', () => {
+    test('renders the correct search time', () => {
+      const { enzymeWrapper } = setup()
 
-    expect(enzymeWrapper.find('.granule-results-body__search-time-value').text()).toEqual('1.1s')
+      expect(enzymeWrapper.find('.granule-results-body__search-time-value').text()).toEqual('1.1s')
+    })
+
+    test('renders a spinner when the page is loading', () => {
+      const { enzymeWrapper } = setup({}, {
+        granuleSearchResults: {
+          loadTime: undefined,
+          isLoading: true,
+          isLoaded: false
+        }
+      })
+
+      expect(enzymeWrapper.find('.granule-results-body__search-time-value').text()).toEqual('<Spinner />')
+    })
+
+    test('renders a spinner before the page has started loading', () => {
+      const { enzymeWrapper } = setup({}, {
+        granuleSearchResults: {}
+      })
+
+      expect(enzymeWrapper.find('.granule-results-body__search-time-value').text()).toEqual('<Spinner />')
+    })
   })
 
   describe('isItemLoaded', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

When loading a granule results page directly from the URL (or refreshing the page while viewing granule results), the Search Time value is displaying `NaNs`

### What is the Solution?

Default the load time to 0. If loadTime is 0, display the spinner, as the values have not been loaded yet

### What areas of the application does this impact?

Granule search results

# Testing

### Reproduction steps

View granule results for any collection. Refresh the page. As soon as the page loads ensure that the search time spinner is visible and not `NaN`

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
