### PR TITLE
EDSC-3234: Fix OPeNDAP orders only return a maximum of 10 files for d…

### DIFF
--- a/serverless/src/ousGranuleSearch/handler.js
+++ b/serverless/src/ousGranuleSearch/handler.js
@@ -17,7 +17,8 @@ const ousGranuleSearch = async (event) => {
     'granules',
     'format',
     'temporal',
-    'variables'
+    'variables',
+    'page_size'
   ]
 
   const nonIndexedKeys = [

--- a/serverless/src/ousGranuleSearch/handler.js
+++ b/serverless/src/ousGranuleSearch/handler.js
@@ -16,6 +16,7 @@ const ousGranuleSearch = async (event) => {
     'exclude_granules',
     'granules',
     'format',
+    'page_num',
     'page_size',
     'temporal',
     'variables'

--- a/serverless/src/ousGranuleSearch/handler.js
+++ b/serverless/src/ousGranuleSearch/handler.js
@@ -16,9 +16,9 @@ const ousGranuleSearch = async (event) => {
     'exclude_granules',
     'granules',
     'format',
+    'page_size',
     'temporal',
-    'variables',
-    'page_size'
+    'variables'
   ]
 
   const nonIndexedKeys = [

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1548,6 +1548,12 @@ describe('fetchOpendapLinks', () => {
   })
 
   test('calls lambda to get links from opendap', async () => {
+    const granuleLinksPageSize = '1'
+
+    jest.spyOn(applicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+      granuleLinksPageSize: '1'
+    }))
+
     nock(/localhost/)
       .post(/ous/, (body) => {
         const { params } = body
@@ -1559,7 +1565,8 @@ describe('fetchOpendapLinks', () => {
           bounding_box: '23.607421875,5.381262277997806,27.7965087890625,14.973184553280502',
           echo_collection_id: 'C10000005-EDSC',
           format: 'nc4',
-          variables: ['V1000004-EDSC']
+          variables: ['V1000004-EDSC'],
+          page_size: granuleLinksPageSize
         })
       })
       .reply(200, {
@@ -1588,7 +1595,8 @@ describe('fetchOpendapLinks', () => {
         echo_collection_id: 'C10000005-EDSC',
         bounding_box: ['23.607421875,5.381262277997806,27.7965087890625,14.973184553280502']
       },
-      granule_count: 3
+      granule_count: 3,
+      page_size: granuleLinksPageSize
     }
 
     await store.dispatch(fetchOpendapLinks(params))
@@ -1609,6 +1617,12 @@ describe('fetchOpendapLinks', () => {
   })
 
   test('calls lambda to get links from opendap with excluded granules', async () => {
+    const granuleLinksPageSize = '1'
+
+    jest.spyOn(applicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+      granuleLinksPageSize: '1'
+    }))
+
     nock(/localhost/)
       .post(/ous/, (body) => {
         const { params } = body
@@ -1622,7 +1636,8 @@ describe('fetchOpendapLinks', () => {
           exclude_granules: true,
           granules: ['G10000404-EDSC'],
           format: 'nc4',
-          variables: ['V1000004-EDSC']
+          variables: ['V1000004-EDSC'],
+          page_size: granuleLinksPageSize
         })
       })
       .reply(200, {
@@ -1654,7 +1669,8 @@ describe('fetchOpendapLinks', () => {
           concept_id: ['G10000404-EDSC']
         }
       },
-      granule_count: 3
+      granule_count: 3,
+      page_size: granuleLinksPageSize
     }
 
     await store.dispatch(fetchOpendapLinks(params))
@@ -1675,6 +1691,12 @@ describe('fetchOpendapLinks', () => {
   })
 
   test('calls lambda to get links from opendap when using additive model', async () => {
+    const granuleLinksPageSize = '1'
+
+    jest.spyOn(applicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+      granuleLinksPageSize: '1'
+    }))
+
     nock(/localhost/)
       .post(/ous/, (body) => {
         const { params } = body
@@ -1687,7 +1709,8 @@ describe('fetchOpendapLinks', () => {
           echo_collection_id: 'C10000005-EDSC',
           granules: ['G10000003-EDSC'],
           format: 'nc4',
-          variables: ['V1000004-EDSC']
+          variables: ['V1000004-EDSC'],
+          page_size: granuleLinksPageSize
         })
       })
       .reply(200, {
@@ -1715,7 +1738,8 @@ describe('fetchOpendapLinks', () => {
         echo_collection_id: 'C10000005-EDSC',
         bounding_box: ['23.607421875,5.381262277997806,27.7965087890625,14.973184553280502']
       },
-      granule_count: 1
+      granule_count: 1,
+      page_size: granuleLinksPageSize
     }
 
     await store.dispatch(fetchOpendapLinks(params))
@@ -1734,6 +1758,12 @@ describe('fetchOpendapLinks', () => {
   })
 
   test('calls lambda to get links from opendap without spatial params added', async () => {
+    const granuleLinksPageSize = '1'
+
+    jest.spyOn(applicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+      granuleLinksPageSize: '1'
+    }))
+
     nock(/localhost/)
       .post(/ous/, (body) => {
         const { params } = body
@@ -1744,7 +1774,8 @@ describe('fetchOpendapLinks', () => {
         return JSON.stringify(params) === JSON.stringify({
           echo_collection_id: 'C10000005-EDSC',
           format: 'nc4',
-          variables: ['V1000004-EDSC']
+          variables: ['V1000004-EDSC'],
+          page_size: granuleLinksPageSize
         })
       })
       .reply(200, {
@@ -1772,7 +1803,8 @@ describe('fetchOpendapLinks', () => {
       granule_params: {
         echo_collection_id: 'C10000005-EDSC'
       },
-      granule_count: 3
+      granule_count: 3,
+      page_size: granuleLinksPageSize
     }
 
     await store.dispatch(fetchOpendapLinks(params))

--- a/static/src/js/actions/__tests__/granules.test.js
+++ b/static/src/js/actions/__tests__/granules.test.js
@@ -1565,8 +1565,8 @@ describe('fetchOpendapLinks', () => {
           bounding_box: '23.607421875,5.381262277997806,27.7965087890625,14.973184553280502',
           echo_collection_id: 'C10000005-EDSC',
           format: 'nc4',
-          variables: ['V1000004-EDSC'],
-          page_size: granuleLinksPageSize
+          page_size: granuleLinksPageSize,
+          variables: ['V1000004-EDSC']
         })
       })
       .reply(200, {
@@ -1636,8 +1636,8 @@ describe('fetchOpendapLinks', () => {
           exclude_granules: true,
           granules: ['G10000404-EDSC'],
           format: 'nc4',
-          variables: ['V1000004-EDSC'],
-          page_size: granuleLinksPageSize
+          page_size: granuleLinksPageSize,
+          variables: ['V1000004-EDSC']
         })
       })
       .reply(200, {
@@ -1709,8 +1709,8 @@ describe('fetchOpendapLinks', () => {
           echo_collection_id: 'C10000005-EDSC',
           granules: ['G10000003-EDSC'],
           format: 'nc4',
-          variables: ['V1000004-EDSC'],
-          page_size: granuleLinksPageSize
+          page_size: granuleLinksPageSize,
+          variables: ['V1000004-EDSC']
         })
       })
       .reply(200, {
@@ -1774,8 +1774,8 @@ describe('fetchOpendapLinks', () => {
         return JSON.stringify(params) === JSON.stringify({
           echo_collection_id: 'C10000005-EDSC',
           format: 'nc4',
-          variables: ['V1000004-EDSC'],
-          page_size: granuleLinksPageSize
+          page_size: granuleLinksPageSize,
+          variables: ['V1000004-EDSC']
         })
       })
       .reply(200, {

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -391,6 +391,9 @@ export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getStat
 
   const requestObject = new OusGranuleRequest(authToken, earthdataEnvironment)
 
+  // The number of granules to request per page from CMR
+  const { granuleLinksPageSize } = getApplicationConfig()
+
   const {
     id,
     access_method: accessMethod,
@@ -416,7 +419,8 @@ export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getStat
   const ousPayload = {
     format,
     variables,
-    echo_collection_id: collectionId
+    echo_collection_id: collectionId,
+    page_size: granuleLinksPageSize
   }
 
   // If conceptId is truthy, send those granules explictly.

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -381,7 +381,7 @@ export const fetchBrowseLinks = (retrievalCollectionData) => async (dispatch, ge
  * Fetch all relevant links from CMR Service Bridge (OPeNDAP) to the granules that are part of the provided collection
  * @param {Object} retrievalCollectionData Retreival Collection response from the database
  */
-export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getState) => {
+export const fetchOpendapLinks = (retrievalCollectionData) => async (dispatch, getState) => {
   const state = getState()
 
   // Retrieve data from Redux using selectors
@@ -390,9 +390,6 @@ export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getStat
   const { authToken } = state
 
   const requestObject = new OusGranuleRequest(authToken, earthdataEnvironment)
-
-  // The number of granules to request per page from CMR
-  const { granuleLinksPageSize } = getApplicationConfig()
 
   const {
     id,
@@ -459,10 +456,24 @@ export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getStat
     ousPayload.granules = excludedGranuleIds
   }
 
-  const response = requestObject.search(ousPayload)
-    .then((response) => {
+  let response
+  let finished = false
+  let currentPage = 1
+
+  try {
+    while (!finished) {
+      // When using POST on this endpoint, CMR requires the paging parameters to be strings
+      ousPayload.page_num = `${currentPage}`
+
+      // eslint-disable-next-line no-await-in-loop
+      response = await requestObject.search(ousPayload)
       const { data } = response
       const { items = [] } = data
+
+      if (items.length === 0) {
+        finished = true
+        break
+      }
 
       dispatch(updateGranuleLinks({
         id,
@@ -470,15 +481,17 @@ export const fetchOpendapLinks = (retrievalCollectionData) => (dispatch, getStat
           download: items
         }
       }))
-    })
-    .catch((error) => {
-      dispatch(actions.handleError({
-        error,
-        action: 'fetchOpendapLinks',
-        resource: 'OPeNDAP links',
-        requestObject
-      }))
-    })
+
+      currentPage += 1
+    }
+  } catch (error) {
+    dispatch(actions.handleError({
+      error,
+      action: 'fetchOpendapLinks',
+      resource: 'OPeNDAP links',
+      requestObject
+    }))
+  }
 
   return response
 }

--- a/static/src/js/util/request/__tests__/ousGranuleRequest.test.js
+++ b/static/src/js/util/request/__tests__/ousGranuleRequest.test.js
@@ -1,0 +1,36 @@
+import OusGranuleRequest from '../ousGranuleRequest'
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
+
+describe('OusGranuleRequest#constructor', () => {
+  test('sets the default values when authenticated', () => {
+    const token = '123'
+    const request = new OusGranuleRequest(token)
+
+    expect(request.authenticated).toBeTruthy()
+    expect(request.authToken).toEqual(token)
+    expect(request.baseUrl).toEqual('http://localhost:3000')
+    expect(request.searchPath).toEqual('granules/ous')
+  })
+})
+
+describe('OusGranuleRequest#permittedCmrKeys', () => {
+  test('returns an array of collection CMR keys', () => {
+    const request = new OusGranuleRequest(undefined, 'prod')
+
+    expect(request.permittedCmrKeys()).toEqual([
+      'bounding_box',
+      'echo_collection_id',
+      'exclude_granules',
+      'granules',
+      'format',
+      'page_num',
+      'page_size',
+      'temporal',
+      'variables'
+    ])
+  })
+})

--- a/static/src/js/util/request/ousGranuleRequest.js
+++ b/static/src/js/util/request/ousGranuleRequest.js
@@ -22,9 +22,9 @@ export default class OusGranuleRequest extends CmrRequest {
       'exclude_granules',
       'granules',
       'format',
+      'page_size',
       'temporal',
-      'variables',
-      'page_size'
+      'variables'
     ]
   }
 }

--- a/static/src/js/util/request/ousGranuleRequest.js
+++ b/static/src/js/util/request/ousGranuleRequest.js
@@ -22,6 +22,7 @@ export default class OusGranuleRequest extends CmrRequest {
       'exclude_granules',
       'granules',
       'format',
+      'page_num',
       'page_size',
       'temporal',
       'variables'

--- a/static/src/js/util/request/ousGranuleRequest.js
+++ b/static/src/js/util/request/ousGranuleRequest.js
@@ -23,7 +23,8 @@ export default class OusGranuleRequest extends CmrRequest {
       'granules',
       'format',
       'temporal',
-      'variables'
+      'variables',
+      'page_size'
     ]
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

When loading OPeNDAP orders for direct download, display granule links equivalent to the number of granules retrieved.

### What is the Solution?

Set the page size param in the event body. Page size config value defined as  granuleLinksPageSize.  GranuleLinksPageSize has value of '500'. Set the 'page_num' param, loops through all pages of granule results.

### What areas of the application does this impact?

OPeNDAP granule collection download.

# Testing

### Reproduction steps

1. Load: https://search.earthdata.nasa.gov/projects?p=C1453188197-GES_DISC!C1453188197-GES_DISC&pg[1][v]=t&pg[1][gsk]=-start_date&pg[1][m]=opendap&pg[1][uv]=V1634371552-GES_DISC&ee=prod&g=G1453711508-GES_DISC&q=C1453188197-GES_DISC&qt=2011-07-30T07%3A26%3A32.686Z%2C2011-08-20T22%3A45%3A30.307Z&tl=1379329944!4!!

2. Check that there are 22 granule links displayed in preview box.

### Attachments
Before:  
![image](https://user-images.githubusercontent.com/45947800/202777594-158de261-8105-426d-a197-e8686dea3055.png)

After: 
![image](https://user-images.githubusercontent.com/45947800/202778393-4133d254-d122-4f58-97f1-d10d5ae7ded8.png)

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
