### PR TITLE
EDSC-2960: updated download script to support data served with 200 and 301 HTTP codes

### DIFF
--- a/static/src/js/util/files/generateDownloadScript.js
+++ b/static/src/js/util/files/generateDownloadScript.js
@@ -64,7 +64,7 @@ exit_with_error() {
 prompt_credentials
   detect_app_approval() {
     approved=\`curl -s -b "$cookiejar" -c "$cookiejar" -L --max-redirs 5 --netrc-file "$netrc" ${firstGranuleLink} -w %{http_code} | tail  -1\`
-    if [ "$approved" -ne "302" ]; then
+    if [ "$approved" -ne "200" ] && [ "$approved" -ne "301" ] && [ "$approved" -ne "302" ]; then
         # User didn't approve the app. Direct users to approve the app in URS
         exit_with_error "Please ensure that you have authorized the remote application by visiting the link below "
     fi


### PR DESCRIPTION
# Overview
Sometimes data providers will host their granules for direct download on static hosting solutions (sometimes cloud-based) that return a `200` or `301` fetches the status code of the first granule URL.  Previously the download script only supported 302 (`Found`).

### What is the feature?
Pass the app approval check if fetching the first granule returns a `200` or `301`.

### What is the Solution?

added some additional conditions to the if statement checking the status code after curl makes the first request for a granule

### What areas of the application does this impact?

This updates the direct download script and will enable users to download granules without error from more data providers.

# Testing

### Reproduction steps

summary: generate and run a download script for a granule that wasn't previously working 

steps
1. got the main page
2. search for C1996881752-POCLOUD
3. click on the one search result
4. add the first granule to your project
5. go to the project
6. click download data
7. on the download page, click the Download Script tab
8. click save and save the download script to your computer
9. run the download script via bash (e.g. `bash 4517239960-download.sh`)
10. fill out your username and password when prompted
11. check your folder to see if the download worked


### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
