### PR TITLE
EDSC-3652: Adds admin ability to requeue orders

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -454,6 +454,20 @@
             resultTtlInSeconds: 0
 
 
+  requeueOrder:
+    handler: serverless/src/requeueOrder/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT, '30'}
+    events:
+      - http:
+          method: post
+          cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
+          path: requeue_order
+          authorizer:
+            name: edlAuthorizer
+            type: request
+            resultTtlInSeconds: 0
+
+
   getRetrieval:
     handler: serverless/src/getRetrieval/handler.default
     timeout: ${env:LAMBDA_TIMEOUT, '30'}

--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -454,20 +454,6 @@
             resultTtlInSeconds: 0
 
 
-  requeueOrder:
-    handler: serverless/src/requeueOrder/handler.default
-    timeout: ${env:LAMBDA_TIMEOUT, '30'}
-    events:
-      - http:
-          method: post
-          cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-          path: requeue_order
-          authorizer:
-            name: edlAuthorizer
-            type: request
-            resultTtlInSeconds: 0
-
-
   getRetrieval:
     handler: serverless/src/getRetrieval/handler.default
     timeout: ${env:LAMBDA_TIMEOUT, '30'}
@@ -725,6 +711,19 @@
           method: get
           cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
           path: admin/projects/{id}
+          authorizer:
+            name: edlAdminAuthorizer
+            type: request
+            resultTtlInSeconds: 0
+
+  requeueOrder:
+    handler: serverless/src/requeueOrder/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT, '30'}
+    events:
+      - http:
+          method: post
+          cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
+          path: requeue_order
           authorizer:
             name: edlAdminAuthorizer
             type: request

--- a/serverless/src/requeueOrder/__tests__/handler.test.js
+++ b/serverless/src/requeueOrder/__tests__/handler.test.js
@@ -1,0 +1,178 @@
+import knex from 'knex'
+import mockKnex from 'mock-knex'
+import AWS from 'aws-sdk'
+import * as getDbConnection from '../../util/database/getDbConnection'
+import requeueOrder from '../handler'
+
+let dbConnectionToMock
+let dbTracker
+
+const OLD_ENV = process.env
+
+const sqsSendMessagePromise = jest.fn().mockReturnValue({
+  promise: jest.fn().mockResolvedValue()
+})
+
+AWS.SQS = jest.fn()
+  .mockImplementationOnce(() => ({
+    sendMessageBatch: sqsSendMessagePromise
+  }))
+
+export const orderPayload = {
+  body: JSON.stringify({
+    params: {
+      orderId: 1234
+    }
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  jest.spyOn(getDbConnection, 'getDbConnection').mockImplementationOnce(() => {
+    dbConnectionToMock = knex({
+      client: 'pg',
+      debug: false
+    })
+
+    // Mock the db connection
+    mockKnex.mock(dbConnectionToMock)
+
+    return dbConnectionToMock
+  })
+
+  dbTracker = mockKnex.getTracker()
+  dbTracker.install()
+
+  // Manage resetting ENV variables
+  // TODO: This is causing problems with mocking knex but is noted as important for managing process.env
+  // jest.resetModules()
+  process.env = { ...OLD_ENV }
+  delete process.env.NODE_ENV
+})
+
+afterEach(() => {
+  dbTracker.uninstall()
+
+  // Restore any ENV variables overwritten in tests
+  process.env = OLD_ENV
+})
+
+describe('requeueOrder', () => {
+  test('correctly requeues an ESI order', async () => {
+    process.env.catalogRestQueueUrl = 'http://example.com/echoQueue'
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          retrieval_collection_id: 1,
+          token: 'mock-token',
+          type: 'ESI'
+        }])
+      } else {
+        query.response([])
+      }
+    })
+
+    const orderResponse = await requeueOrder(orderPayload, {})
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toContain('select')
+
+    expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
+      QueueUrl: 'http://example.com/echoQueue',
+      Entries: [{
+        Id: '1',
+        MessageBody: JSON.stringify({
+          accessToken: 'mock-token',
+          id: 1234
+        })
+      }]
+    }])
+
+    const { body } = orderResponse
+
+    expect(JSON.parse(body)).toEqual({
+      orderId: 1234
+    })
+  })
+
+  test('correctly requeues an ECHO ORDERS order', async () => {
+    process.env.legacyServicesQueueUrl = 'http://example.com/echoQueue'
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          retrieval_collection_id: 1,
+          token: 'mock-token',
+          type: 'ECHO ORDERS'
+        }])
+      } else {
+        query.response([])
+      }
+    })
+
+    const orderResponse = await requeueOrder(orderPayload, {})
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toContain('select')
+
+    expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
+      QueueUrl: 'http://example.com/echoQueue',
+      Entries: [{
+        Id: '1',
+        MessageBody: JSON.stringify({
+          accessToken: 'mock-token',
+          id: 1234
+        })
+      }]
+    }])
+
+    const { body } = orderResponse
+
+    expect(JSON.parse(body)).toEqual({
+      orderId: 1234
+    })
+  })
+
+  test('correctly requeues a Harmony order', async () => {
+    process.env.harmonyQueueUrl = 'http://example.com/echoQueue'
+
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        query.response([{
+          retrieval_collection_id: 1,
+          token: 'mock-token',
+          type: 'Harmony'
+        }])
+      } else {
+        query.response([])
+      }
+    })
+
+    const orderResponse = await requeueOrder(orderPayload, {})
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].method).toContain('select')
+
+    expect(sqsSendMessagePromise.mock.calls[0]).toEqual([{
+      QueueUrl: 'http://example.com/echoQueue',
+      Entries: [{
+        Id: '1',
+        MessageBody: JSON.stringify({
+          accessToken: 'mock-token',
+          id: 1234
+        })
+      }]
+    }])
+
+    const { body } = orderResponse
+
+    expect(JSON.parse(body)).toEqual({
+      orderId: 1234
+    })
+  })
+})

--- a/serverless/src/requeueOrder/handler.js
+++ b/serverless/src/requeueOrder/handler.js
@@ -1,0 +1,92 @@
+import AWS from 'aws-sdk'
+
+import { getApplicationConfig } from '../../../sharedUtils/config'
+import { getSqsConfig } from '../util/aws/getSqsConfig'
+import { getDbConnection } from '../util/database/getDbConnection'
+
+// AWS SQS adapter
+let sqs
+
+/**
+ * Requeues an order onto an SQS queue for processing
+ * @param {Object} event Details about the HTTP request that it received
+ * @param {Object} context Methods and properties that provide information about the invocation, function, and execution environment
+ */
+const requeueOrder = async (event, context) => {
+  // https://stackoverflow.com/questions/49347210/why-aws-lambda-keeps-timing-out-when-using-knex-js
+  // eslint-disable-next-line no-param-reassign
+  context.callbackWaitsForEmptyEventLoop = false
+
+  const { defaultResponseHeaders } = getApplicationConfig()
+
+  const { body } = event
+  const { params = {} } = JSON.parse(body)
+
+  const { orderId } = params
+
+  if (sqs == null) {
+    sqs = new AWS.SQS(getSqsConfig())
+  }
+
+  // Fetch order from database to find the type of order
+
+  // Retrieve a connection to the database
+  const dbConnection = await getDbConnection()
+
+  const [retrievalOrder] = await dbConnection('retrieval_orders')
+    .select(
+      'retrieval_orders.retrieval_collection_id',
+      'retrieval_orders.type',
+      'retrievals.token'
+    )
+    .join('retrieval_collections', { 'retrieval_orders.retrieval_collection_id': 'retrieval_collections.id' })
+    .join('retrievals', { 'retrieval_collections.retrieval_id': 'retrievals.id' })
+    .where({ 'retrieval_orders.id': orderId })
+
+  // Add the order to the correct sqs queue based on order type
+  const {
+    retrieval_collection_id: retrievalCollectionId,
+    token: accessToken,
+    type
+  } = retrievalOrder
+
+  if (['ESI', 'ECHO ORDERS', 'Harmony'].includes(type)) {
+    let queueUrl
+
+    if (type === 'ESI') {
+      // Submits to Catalog Rest and is often referred to as a
+      // service order -- this is presenting in EDSC as the 'Customize' access method
+      queueUrl = process.env.catalogRestQueueUrl
+    } else if (type === 'ECHO ORDERS') {
+      // Submits to Legacy Services (CMR) and is often referred to as an
+      // echo order -- this is presenting in EDSC as the 'Stage For Delivery' access method
+      queueUrl = process.env.legacyServicesQueueUrl
+    } else if (type === 'Harmony') {
+      // Submits to Harmony
+      queueUrl = process.env.harmonyQueueUrl
+    }
+
+    if (!process.env.IS_OFFLINE) {
+      // Send all of the order messages to sqs as a single batch
+      await sqs.sendMessageBatch({
+        QueueUrl: queueUrl,
+        Entries: [{
+          Id: `${retrievalCollectionId}`,
+          MessageBody: JSON.stringify({
+            accessToken,
+            id: orderId
+          })
+        }]
+      }).promise()
+    }
+  }
+
+  return {
+    isBase64Encoded: false,
+    statusCode: 200,
+    headers: defaultResponseHeaders,
+    body: JSON.stringify({ orderId })
+  }
+}
+
+export default requeueOrder

--- a/static/src/js/actions/admin/__tests__/retrievals.test.js
+++ b/static/src/js/actions/admin/__tests__/retrievals.test.js
@@ -2,6 +2,7 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import nock from 'nock'
 
+import * as addToast from '../../../util/addToast'
 import actions from '../../index'
 import {
   setAdminRetrieval,
@@ -15,7 +16,8 @@ import {
   fetchAdminRetrievals,
   adminViewRetrieval,
   updateAdminRetrievalsSortKey,
-  updateAdminRetrievalsPageNum
+  updateAdminRetrievalsPageNum,
+  requeueOrder
 } from '../retrievals'
 import {
   SET_ADMIN_RETRIEVAL,
@@ -167,6 +169,44 @@ describe('fetchAdminRetrieval', () => {
       })
     })
   })
+
+  test('calls handleError when there is an error', async () => {
+    const handleErrorMock = jest.spyOn(actions, 'handleError')
+    const consoleMock = jest.spyOn(console, 'error').mockImplementationOnce(() => jest.fn())
+
+    const id = 123
+
+    nock(/localhost/)
+      .get(/admin\/retrieval/)
+      .reply(500)
+
+    nock(/localhost/)
+      .post(/error_logger/)
+      .reply(200)
+
+    const store = mockStore({
+      authToken: 'mockToken',
+      admin: {
+        isAuthorized: true
+      }
+    })
+
+    await store.dispatch(fetchAdminRetrieval(id))
+
+    const storeActions = store.getActions()
+    expect(storeActions[0]).toEqual({
+      type: SET_ADMIN_RETRIEVAL_LOADING,
+      payload: id
+    })
+
+    expect(handleErrorMock).toHaveBeenCalledTimes(1)
+    expect(handleErrorMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'fetchAdminRetrieval',
+      resource: 'admin retrieval'
+    }))
+
+    expect(consoleMock).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('fetchAdminRetrievals', () => {
@@ -216,6 +256,48 @@ describe('fetchAdminRetrievals', () => {
         payload: data.results
       })
     })
+  })
+
+  test('calls handleError when there is an error', async () => {
+    const handleErrorMock = jest.spyOn(actions, 'handleError')
+    const consoleMock = jest.spyOn(console, 'error').mockImplementationOnce(() => jest.fn())
+
+    nock(/localhost/)
+      .get(/admin\/retrieval/)
+      .reply(500)
+
+    nock(/localhost/)
+      .post(/error_logger/)
+      .reply(200)
+
+    const store = mockStore({
+      authToken: 'mockToken',
+      admin: {
+        isAuthorized: true,
+        retrievals: {
+          sortKey: '-created_at',
+          pagination: {
+            pageNum: 1,
+            pageSize: 20
+          }
+        }
+      }
+    })
+
+    await store.dispatch(fetchAdminRetrievals())
+
+    const storeActions = store.getActions()
+    expect(storeActions[0]).toEqual({
+      type: SET_ADMIN_RETRIEVALS_LOADING
+    })
+
+    expect(handleErrorMock).toHaveBeenCalledTimes(1)
+    expect(handleErrorMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'fetchAdminRetrievals',
+      resource: 'admin retrievals'
+    }))
+
+    expect(consoleMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -303,5 +385,62 @@ describe('updateAdminRetrievalsPageNum', () => {
     })
 
     expect(fetchAdminRetrievalsMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('requeueOrder', () => {
+  test('sends request to requeue order', async () => {
+    const addToastMock = jest.spyOn(addToast, 'addToast')
+
+    const orderId = 1234
+
+    nock(/localhost/)
+      .post(/requeue/)
+      .reply(200)
+
+    const store = mockStore({
+      authToken: 'mockToken'
+    })
+
+    await store.dispatch(requeueOrder(orderId))
+
+    expect(addToastMock).toHaveBeenCalledTimes(1)
+    expect(addToastMock).toHaveBeenCalledWith(
+      'Order Requeued for processing',
+      {
+        appearance: 'success',
+        autoDismiss: true
+      }
+    )
+  })
+
+  test('calls handleError when there is an error', async () => {
+    const handleErrorMock = jest.spyOn(actions, 'handleError')
+    const consoleMock = jest.spyOn(console, 'error').mockImplementationOnce(() => jest.fn())
+
+    const orderId = 1234
+
+    nock(/localhost/)
+      .post(/requeue/)
+      .reply(500)
+
+    nock(/localhost/)
+      .post(/error_logger/)
+      .reply(200)
+
+    const store = mockStore({
+      authToken: 'mockToken'
+    })
+
+    await store.dispatch(requeueOrder(orderId))
+
+    expect(handleErrorMock).toHaveBeenCalledTimes(1)
+    expect(handleErrorMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'requeueOrder',
+      notificationType: 'toast',
+      resource: 'admin retrievals'
+    }))
+
+    expect(consoleMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/static/src/js/actions/admin/retrievals.js
+++ b/static/src/js/actions/admin/retrievals.js
@@ -170,27 +170,23 @@ export const requeueOrder = (orderId) => (dispatch, getState) => {
 
   const { authToken } = state
 
-  try {
-    const requestObject = new RetrievalRequest(authToken, earthdataEnvironment)
-    const response = requestObject.requeueOrder({ orderId })
-      .then(() => {
-        addToast('Order Requeued for processing', {
-          appearance: 'success',
-          autoDismiss: true
-        })
+  const requestObject = new RetrievalRequest(authToken, earthdataEnvironment)
+  const response = requestObject.requeueOrder({ orderId })
+    .then(() => {
+      addToast('Order Requeued for processing', {
+        appearance: 'success',
+        autoDismiss: true
       })
-      .catch((error) => {
-        dispatch(actions.handleError({
-          error,
-          action: 'requeueOrder',
-          resource: 'admin retrievals',
-          requestObject,
-          notificationType: displayNotificationType.toast
-        }))
-      })
+    })
+    .catch((error) => {
+      dispatch(actions.handleError({
+        error,
+        action: 'requeueOrder',
+        resource: 'admin retrievals',
+        requestObject,
+        notificationType: displayNotificationType.toast
+      }))
+    })
 
-    return response
-  } catch (e) {
-    return null
-  }
+  return response
 }

--- a/static/src/js/actions/index.js
+++ b/static/src/js/actions/index.js
@@ -4,6 +4,7 @@ import {
   adminViewRetrieval,
   fetchAdminRetrievals,
   fetchAdminRetrieval,
+  requeueOrder,
   updateAdminRetrievalsSortKey,
   updateAdminRetrievalsPageNum
 } from './admin/retrievals'
@@ -279,6 +280,7 @@ const actions = {
   removeSpatialFilter,
   removeSubscriptionDisabledFields,
   removeTemporalFilter,
+  requeueOrder,
   restoreProject,
   saveShapefile,
   selectAccessMethod,

--- a/static/src/js/components/AdminRetrieval/AdminRetrieval.js
+++ b/static/src/js/components/AdminRetrieval/AdminRetrieval.js
@@ -5,7 +5,8 @@ import { AdminRetrievalDetails } from '../AdminRetrievalDetails/AdminRetrievalDe
 import { AdminPage } from '../AdminPage/AdminPage'
 
 export const AdminRetrieval = ({
-  retrieval
+  retrieval,
+  onRequeueOrder
 }) => (
   <AdminPage
     pageTitle="Retrieval Details"
@@ -26,6 +27,7 @@ export const AdminRetrieval = ({
   >
     <AdminRetrievalDetails
       retrieval={retrieval}
+      onRequeueOrder={onRequeueOrder}
     />
   </AdminPage>
 )
@@ -35,7 +37,8 @@ AdminRetrieval.defaultProps = {
 }
 
 AdminRetrieval.propTypes = {
-  retrieval: PropTypes.shape({})
+  retrieval: PropTypes.shape({}),
+  onRequeueOrder: PropTypes.func.isRequired
 }
 
 export default AdminRetrieval

--- a/static/src/js/components/AdminRetrieval/__tests__/AdminRetrieval.test.js
+++ b/static/src/js/components/AdminRetrieval/__tests__/AdminRetrieval.test.js
@@ -12,7 +12,8 @@ function setup() {
   const props = {
     retrieval: {
       id: 1
-    }
+    },
+    onRequeueOrder: jest.fn()
   }
 
   const enzymeWrapper = shallow(<AdminRetrieval {...props} />)

--- a/static/src/js/components/AdminRetrievalDetails/AdminRetrievalDetails.js
+++ b/static/src/js/components/AdminRetrievalDetails/AdminRetrievalDetails.js
@@ -5,7 +5,8 @@ import { withRouter } from 'react-router-dom'
 import {
   Table,
   Row,
-  Col
+  Col,
+  Alert
 } from 'react-bootstrap'
 
 import { commafy } from '../../util/commafy'
@@ -100,6 +101,11 @@ export const AdminRetrievalDetails = ({
                             </div>
                           </div>
                         </header>
+
+                        <Alert variant="warning">
+                          Clicking Requeue could generate duplicate orders, sending duplicated data to the user. Use with Caution
+                        </Alert>
+
                         {
                           orders.length > 0 && (
                             <Table className="admin-retrieval-details__orders-table" striped variant="light">

--- a/static/src/js/components/AdminRetrievalDetails/AdminRetrievalDetails.js
+++ b/static/src/js/components/AdminRetrievalDetails/AdminRetrievalDetails.js
@@ -7,12 +7,16 @@ import {
   Row,
   Col
 } from 'react-bootstrap'
+
 import { commafy } from '../../util/commafy'
+
+import Button from '../Button/Button'
 
 import './AdminRetrievalDetails.scss'
 
 export const AdminRetrievalDetails = ({
-  retrieval
+  retrieval,
+  onRequeueOrder
 }) => {
   const {
     collections = [],
@@ -101,11 +105,12 @@ export const AdminRetrievalDetails = ({
                             <Table className="admin-retrieval-details__orders-table" striped variant="light">
                               <thead>
                                 <tr>
+                                  <th width="10%">Actions</th>
                                   <th width="7%">ID</th>
-                                  <th width="23%">Order Number</th>
+                                  <th width="20%">Order Number</th>
                                   <th width="20%">Type</th>
                                   <th width="10%">State</th>
-                                  <th width="50%">Details</th>
+                                  <th width="33%">Details</th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -121,6 +126,20 @@ export const AdminRetrievalDetails = ({
 
                                     return (
                                       <tr className="admin-retrieval-details__order-row" key={`${collectionId}-${orderId}`}>
+                                        <td>
+                                          <Button
+                                            dataTestId="admin-retrieval-details__requeue-order"
+                                            type="button"
+                                            bootstrapVariant="secondary"
+                                            label="Requeue Order for Processing"
+                                            bootstrapSize="sm"
+                                            onClick={() => {
+                                              onRequeueOrder(orderId)
+                                            }}
+                                          >
+                                            Requeue
+                                          </Button>
+                                        </td>
                                         <td>{orderId}</td>
                                         <td>{orderNumber}</td>
                                         <td>{type}</td>
@@ -161,7 +180,8 @@ AdminRetrievalDetails.propTypes = {
     jsondata: PropTypes.shape({}),
     obfuscated_id: PropTypes.string,
     username: PropTypes.string
-  })
+  }),
+  onRequeueOrder: PropTypes.func.isRequired
 }
 
 export default withRouter(

--- a/static/src/js/components/AdminRetrievalDetails/__tests__/AdminRetrievalDetails.test.js
+++ b/static/src/js/components/AdminRetrievalDetails/__tests__/AdminRetrievalDetails.test.js
@@ -12,6 +12,7 @@ function setup(overrideProps) {
       username: 'edsc-test',
       obfuscated_id: '06347346'
     },
+    onRequeueOrder: jest.fn(),
     ...overrideProps
   }
   const enzymeWrapper = shallow(<AdminRetrievalDetails {...props} />)
@@ -107,10 +108,40 @@ describe('AdminRetrievalDetails component', () => {
 
       expect(enzymeWrapper.find('.admin-retrieval-details__orders-table').length).toEqual(1)
       expect(enzymeWrapper.find('.admin-retrieval-details__order-row').length).toEqual(2)
-      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(0).text()).toEqual('5')
-      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(1).text()).toEqual('40058')
-      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(2).text()).toEqual('ECHO ORDERS')
-      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(3).text()).toEqual('creating')
+      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(1).text()).toEqual('5')
+      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(2).text()).toEqual('40058')
+      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(3).text()).toEqual('ECHO ORDERS')
+      expect(enzymeWrapper.find('.admin-retrieval-details__order-row td').at(4).text()).toEqual('creating')
+    })
+
+    test('clicking on the Requeue button calls onRequeueOrder', () => {
+      const { enzymeWrapper, props } = setup({
+        retrieval: {
+          username: 'edsc-test',
+          jsondata: {
+            source: '?mock-source'
+          },
+          obfuscated_id: '06347346',
+          collections: [{
+            id: 1,
+            collection_id: 'C10000005',
+            data_center: 'EDSC',
+            granule_count: 35,
+            orders: [{
+              id: 5,
+              order_information: {},
+              order_number: '40058',
+              state: 'creating',
+              type: 'ECHO ORDERS'
+            }]
+          }]
+        }
+      })
+
+      enzymeWrapper.find('.admin-retrieval-details__order-row td').at(0).children(0).simulate('click')
+
+      expect(props.onRequeueOrder).toHaveBeenCalledTimes(1)
+      expect(props.onRequeueOrder).toHaveBeenCalledWith(5)
     })
   })
 })

--- a/static/src/js/containers/AdminRetrievalContainer/AdminRetrievalContainer.js
+++ b/static/src/js/containers/AdminRetrievalContainer/AdminRetrievalContainer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
@@ -11,39 +11,36 @@ export const mapStateToProps = (state) => ({
 })
 
 export const mapDispatchToProps = (dispatch) => ({
-  onFetchAdminRetrieval: (id) => dispatch(actions.fetchAdminRetrieval(id))
+  onFetchAdminRetrieval: (id) => dispatch(actions.fetchAdminRetrieval(id)),
+  onRequeueOrder: (orderId) => dispatch(actions.requeueOrder(orderId))
 })
 
-export class AdminRetrievalContainer extends Component {
-  componentDidMount() {
-    const {
-      match,
-      onFetchAdminRetrieval
-    } = this.props
-
+export const AdminRetrievalContainer = ({
+  match,
+  retrievals,
+  onFetchAdminRetrieval,
+  onRequeueOrder
+}) => {
+  // On mount call onFetchAdminRetrieval
+  useEffect(() => {
     const { params } = match
     const { id } = params
+    console.log('🚀 ~ file: AdminRetrievalContainer.js:28 ~ useEffect ~ id', id)
 
     onFetchAdminRetrieval(id)
-  }
+  }, [])
 
-  render() {
-    const {
-      match,
-      retrievals
-    } = this.props
+  const { params } = match
+  const { id } = params
 
-    const { params } = match
-    const { id } = params
+  const { [id]: selectedRetrieval } = retrievals
 
-    const { [id]: selectedRetrieval } = retrievals
-
-    return (
-      <AdminRetrieval
-        retrieval={selectedRetrieval}
-      />
-    )
-  }
+  return ((
+    <AdminRetrieval
+      retrieval={selectedRetrieval}
+      onRequeueOrder={onRequeueOrder}
+    />
+  ))
 }
 
 AdminRetrievalContainer.defaultProps = {
@@ -57,7 +54,8 @@ AdminRetrievalContainer.propTypes = {
     })
   }).isRequired,
   onFetchAdminRetrieval: PropTypes.func.isRequired,
-  retrievals: PropTypes.shape({})
+  retrievals: PropTypes.shape({}),
+  onRequeueOrder: PropTypes.func.isRequired
 }
 
 export default withRouter(

--- a/static/src/js/containers/AdminRetrievalContainer/AdminRetrievalContainer.js
+++ b/static/src/js/containers/AdminRetrievalContainer/AdminRetrievalContainer.js
@@ -25,7 +25,6 @@ export const AdminRetrievalContainer = ({
   useEffect(() => {
     const { params } = match
     const { id } = params
-    console.log('🚀 ~ file: AdminRetrievalContainer.js:28 ~ useEffect ~ id', id)
 
     onFetchAdminRetrieval(id)
   }, [])

--- a/static/src/js/containers/AdminRetrievalContainer/__tests__/AdminRetrievalContainer.test.js
+++ b/static/src/js/containers/AdminRetrievalContainer/__tests__/AdminRetrievalContainer.test.js
@@ -1,31 +1,15 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import { render } from '@testing-library/react'
+
+jest.mock('../../../components/AdminRetrieval/AdminRetrieval', () => jest.fn(({ children }) => (
+  <mock-AdminRetrieval data-testid="AdminRetrieval">
+    {children}
+  </mock-AdminRetrieval>
+)))
 
 import actions from '../../../actions'
 import AdminRetrieval from '../../../components/AdminRetrieval/AdminRetrieval'
 import { AdminRetrievalContainer, mapDispatchToProps, mapStateToProps } from '../AdminRetrievalContainer'
-
-Enzyme.configure({ adapter: new Adapter() })
-
-function setup() {
-  const props = {
-    match: {
-      params: {
-        id: '1'
-      }
-    },
-    onFetchAdminRetrieval: jest.fn(),
-    retrieval: {}
-  }
-
-  const enzymeWrapper = shallow(<AdminRetrievalContainer {...props} />)
-
-  return {
-    enzymeWrapper,
-    props
-  }
-}
 
 describe('mapDispatchToProps', () => {
   test('onFetchAdminRetrieval calls actions.fetchAdminRetrieval', () => {
@@ -33,6 +17,16 @@ describe('mapDispatchToProps', () => {
     const spy = jest.spyOn(actions, 'fetchAdminRetrieval')
 
     mapDispatchToProps(dispatch).onFetchAdminRetrieval('id')
+
+    expect(spy).toBeCalledTimes(1)
+    expect(spy).toBeCalledWith('id')
+  })
+
+  test('onRequeueOrder calls actions.requeueOrder', () => {
+    const dispatch = jest.fn()
+    const spy = jest.spyOn(actions, 'requeueOrder')
+
+    mapDispatchToProps(dispatch).onRequeueOrder('id')
 
     expect(spy).toBeCalledTimes(1)
     expect(spy).toBeCalledWith('id')
@@ -59,8 +53,34 @@ describe('mapStateToProps', () => {
 
 describe('AdminRetrievalContainer component', () => {
   test('render AdminRetrieval with the correct props', () => {
-    const { enzymeWrapper } = setup()
+    const onFetchAdminRetrievalMock = jest.fn()
+    const onRequeueOrderMock = jest.fn()
+    const props = {
+      match: {
+        params: {
+          id: '1'
+        }
+      },
+      onFetchAdminRetrieval: onFetchAdminRetrievalMock,
+      onRequeueOrder: onRequeueOrderMock,
+      retrieval: {}
+    }
 
-    expect(enzymeWrapper.find(AdminRetrieval).length).toBe(1)
+    const { rerender } = render((<AdminRetrievalContainer {...props} />))
+
+    expect(onFetchAdminRetrievalMock).toHaveBeenCalledTimes(1)
+    expect(onFetchAdminRetrievalMock).toHaveBeenCalledWith('1')
+
+    rerender((<AdminRetrievalContainer {...props} retrievals={{ 1: 'mock-retrieval' }} />))
+
+    expect(AdminRetrieval).toHaveBeenCalledTimes(2)
+    expect(AdminRetrieval).toHaveBeenCalledWith({
+      retrieval: undefined,
+      onRequeueOrder: onRequeueOrderMock
+    }, {})
+    expect(AdminRetrieval).toHaveBeenCalledWith({
+      retrieval: 'mock-retrieval',
+      onRequeueOrder: onRequeueOrderMock
+    }, {})
   })
 })

--- a/static/src/js/util/request/admin/__tests__/retrievalRequest.test.js
+++ b/static/src/js/util/request/admin/__tests__/retrievalRequest.test.js
@@ -1,0 +1,92 @@
+import RetrievalRequest from '../retrievalRequest'
+import Request from '../../request'
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  jest.clearAllMocks()
+})
+
+describe('RetrievalRequest#constructor', () => {
+  test('sets the default values when authenticated', () => {
+    const token = '123'
+    const request = new RetrievalRequest(token)
+
+    expect(request.authenticated).toBeTruthy()
+    expect(request.authToken).toEqual(token)
+    expect(request.baseUrl).toEqual('http://localhost:3000')
+  })
+})
+
+describe('RetrievalRequest#transformResponse', () => {
+  beforeEach(() => {
+    jest.spyOn(RetrievalRequest.prototype, 'handleUnauthorized').mockImplementation()
+  })
+
+  test('returns data if response is not successful', () => {
+    const request = new RetrievalRequest()
+
+    const data = {
+      statusCode: 404
+    }
+
+    const result = request.transformResponse(data)
+
+    expect(result).toEqual(data)
+  })
+})
+
+describe('RetrievalRequest#all', () => {
+  test('calls Request#get', () => {
+    const token = '123'
+    const request = new RetrievalRequest(token)
+
+    const getMock = jest.spyOn(Request.prototype, 'get').mockImplementation()
+
+    request.all({ mock: 'params' })
+
+    expect(getMock).toBeCalledTimes(1)
+    expect(getMock).toBeCalledWith('admin/retrievals', { mock: 'params' })
+  })
+})
+
+describe('RetrievalRequest#fetch', () => {
+  test('calls Request#get', () => {
+    const request = new RetrievalRequest()
+
+    const getMock = jest.spyOn(Request.prototype, 'get').mockImplementation()
+
+    const id = '12345'
+    request.fetch(id)
+
+    expect(getMock).toBeCalledTimes(1)
+    expect(getMock).toBeCalledWith('admin/retrievals/12345')
+  })
+})
+
+describe('RetrievalRequest#isAuthorized', () => {
+  test('calls Request#get', () => {
+    const token = '123'
+    const request = new RetrievalRequest(token)
+
+    const getMock = jest.spyOn(Request.prototype, 'get').mockImplementation()
+
+    request.isAuthorized()
+
+    expect(getMock).toBeCalledTimes(1)
+    expect(getMock).toBeCalledWith('admin/is_authorized')
+  })
+})
+
+describe('RetrievalRequest#requeueOrder', () => {
+  test('calls Request#post', () => {
+    const request = new RetrievalRequest()
+
+    const postMock = jest.spyOn(Request.prototype, 'post').mockImplementation()
+
+    const params = { orderId: 1234 }
+    request.requeueOrder(params)
+
+    expect(postMock).toBeCalledTimes(1)
+    expect(postMock).toBeCalledWith('requeue_order', params)
+  })
+})

--- a/static/src/js/util/request/admin/retrievalRequest.js
+++ b/static/src/js/util/request/admin/retrievalRequest.js
@@ -18,6 +18,10 @@ export default class RetrievalRequest extends Request {
   }
 
   isAuthorized() {
-    return this.get('/admin/is_authorized')
+    return this.get('admin/is_authorized')
+  }
+
+  requeueOrder(params) {
+    return this.post('requeue_order', params)
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

When submitting large orders it is possible that one or more of the sub-orders that EDSC creates will fail to be submitted. If this happens currently it is up to the user to figure out which granules from their large order they are missing, or try to submit the entire order again.

### What is the Solution?

This PR adds a button to the admin retrieval page to requeue a single sub-order for processing.

### What areas of the application does this impact?

Ordering

# Testing

### Reproduction steps

As an admin user, visit the /admin/retrievals page, and find a retrieval you created. Click on that retrieval to visit the retrieval page.
Click the "Requeue" button next to one of the sub-orders, you should receive emails as the order processes and completes.
This should work for ESI, ECHO Orders, and Harmony orders

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
