### PR TITLE
EDSC-3484: Fix /contact_info url

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -615,7 +615,7 @@
       - http:
           method: get
           cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-          path: contact_info
+          path: contact-info
           authorizer:
             name: edlAuthorizer
             type: request
@@ -629,7 +629,7 @@
       - http:
           method: post
           cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
-          path: contact_info
+          path: contact-info
           authorizer:
             name: edlAuthorizer
             type: request

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -111,7 +111,7 @@ class App extends Component {
                       )}
                     />
                     <Route
-                      path={this.portalPaths('/contact_info')}
+                      path={this.portalPaths('/contact-info')}
                       render={() => (
                         <AuthRequiredContainer>
                           <ContactInfo />

--- a/static/src/js/actions/__tests__/contactInfo.test.js
+++ b/static/src/js/actions/__tests__/contactInfo.test.js
@@ -59,7 +59,7 @@ describe('setContactInfoFromJwt', () => {
 describe('fetchContactInfo', () => {
   test('should update the contact info with data from lambda', async () => {
     nock(/localhost/)
-      .get(/contact_info/)
+      .get(/contact-info/)
       .reply(200, {
         echo_preferences: { mock: 'echo' },
         urs_profile: { mock: 'urs' }
@@ -89,7 +89,7 @@ describe('updateNotificationLevel', () => {
     const addToastMock = jest.spyOn(addToast, 'addToast')
 
     nock(/localhost/)
-      .post(/contact_info/)
+      .post(/contact-info/)
       .reply(201, {
         preferences: { mock: 'echo' }
       })
@@ -117,7 +117,7 @@ describe('updateNotificationLevel', () => {
 
   test('does not call updateContactInfo on error', async () => {
     nock(/localhost/)
-      .post(/contact_info/)
+      .post(/contact-info/)
       .reply(500, {
         errors: ['An error occured.']
       })

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
@@ -252,7 +252,7 @@ class SecondaryToolbar extends Component {
             </Dropdown.Item>
           </LinkContainer>
           <LinkContainer
-            to={`${portalPath(portal)}/contact_info`}
+            to={`${portalPath(portal)}/contact-info`}
           >
             <Dropdown.Item
               className="secondary-toolbar__contact-info"

--- a/static/src/js/routes/ContactInfo/ContactInfo.js
+++ b/static/src/js/routes/ContactInfo/ContactInfo.js
@@ -15,7 +15,7 @@ export const ContactInfo = () => (
       <title>Contact Information</title>
       <meta name="title" content="Contact Information" />
       <meta name="robots" content="noindex, nofollow" />
-      <link rel="canonical" href={`${edscHost}/contact_info`} />
+      <link rel="canonical" href={`${edscHost}/contact-info`} />
     </Helmet>
     <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
       <div className="route-wrapper__content">

--- a/static/src/js/util/request/__tests__/contactInfoRequest.test.js
+++ b/static/src/js/util/request/__tests__/contactInfoRequest.test.js
@@ -27,7 +27,7 @@ describe('ContactInfoRequest#fetch', () => {
     request.fetch()
 
     expect(getMock).toBeCalledTimes(1)
-    expect(getMock).toBeCalledWith('contact_info')
+    expect(getMock).toBeCalledWith('contact-info')
   })
 })
 
@@ -42,6 +42,6 @@ describe('ContactInfoRequest#updateNotificationLevel', () => {
     request.updateNotificationLevel(data)
 
     expect(postMock).toBeCalledTimes(1)
-    expect(postMock).toBeCalledWith('contact_info', data)
+    expect(postMock).toBeCalledWith('contact-info', data)
   })
 })

--- a/static/src/js/util/request/contactInfoRequest.js
+++ b/static/src/js/util/request/contactInfoRequest.js
@@ -10,10 +10,10 @@ export default class ContactInfoRequest extends Request {
   }
 
   fetch() {
-    return this.get('contact_info')
+    return this.get('contact-info')
   }
 
   updateNotificationLevel(data) {
-    return this.post('contact_info', data)
+    return this.post('contact-info', data)
   }
 }

--- a/static/src/js/util/url/url.js
+++ b/static/src/js/util/url/url.js
@@ -257,7 +257,7 @@ export const encodeUrlQuery = (props) => {
  * because it shares the base url with the projects page.
  */
 export const urlPathsWithoutUrlParams = [
-  /^\/contact_info/,
+  /^\/contact-info/,
   /^\/auth_callback/,
   /^\/admin/
 ]

--- a/static/src/public/robots.txt
+++ b/static/src/public/robots.txt
@@ -5,4 +5,4 @@ User-Agent: *
 Disallow: /downloads
 Disallow: /projects
 Disallow: /search/granules
-Disallow: /contact_info
+Disallow: /contact-info


### PR DESCRIPTION
# Overview

### What is the feature?

The Contact Information route should use a hypen instead of an underscore to match our the other routes. Fix #1541


### What is the Solution?

Routes have been renamed


### What areas of the application does this impact?

URL to access contact information




# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
