### PR TITLE
EDSC-3660: Updates selected_features column in shapefiles table

### DIFF
--- a/migrations/1676323693507_update-selected-features-column.js
+++ b/migrations/1676323693507_update-selected-features-column.js
@@ -1,0 +1,53 @@
+exports.shorthands = undefined
+
+// The migrations can't alter the selected_features column to change the type from `text [] `
+// to `jsonb`. This migration will query all the rows that have data in selected_features, drop and add the column, then update the rows with their previous data
+exports.up = async (pgm) => {
+  // Query the shapefiles table for selected_features
+  const { rows } = await pgm.db.query('SELECT id, selected_features FROM shapefiles WHERE selected_features IS NOT NULL;')
+
+  // Generate update statements for each row
+  const updateRowsSql = rows.map((row) => {
+    const { id, selected_features: selectedFeatures } = row
+
+    return `UPDATE shapefiles SET selected_features = '${JSON.stringify(selectedFeatures)}' WHERE id = ${id}`
+  })
+
+  // Drop the selected_features column, then re-add it with the correct type
+  pgm.dropColumns('shapefiles', ['selected_features'])
+  pgm.addColumns('shapefiles', {
+    selected_features: {
+      type: 'jsonb'
+    }
+  })
+
+  // Execute the update statements to put the data back in to the table
+  updateRowsSql.forEach((updateSql) => {
+    pgm.sql(updateSql)
+  })
+}
+
+exports.down = async (pgm) => {
+  // Query the shapefiles table for selected_features
+  const { rows } = await pgm.db.query('SELECT id, selected_features FROM shapefiles WHERE selected_features IS NOT NULL;')
+
+  // Generate update statements for each row
+  const updateRowsSql = rows.map((row) => {
+    const { id, selected_features: selectedFeatures } = row
+
+    return `UPDATE shapefiles SET selected_features = '{${selectedFeatures}}' WHERE id = ${id}`
+  })
+
+  // Drop the selected_features column, then re-add it with the correct type
+  pgm.dropColumns('shapefiles', ['selected_features'])
+  pgm.addColumns('shapefiles', {
+    selected_features: {
+      type: 'text []'
+    }
+  })
+
+  // Execute the update statements to put the data back in to the table
+  updateRowsSql.forEach((updateSql) => {
+    pgm.sql(updateSql)
+  })
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Previously the selected_features column was stored as a `text []` type. The updated version of knex from EDSC-3615 is unable to handle that field correctly, so this PR changes that column to a `jsonb` type.

### What is the Solution?

Write a migration to change selected_features from `text []` to `jsonb`

### What areas of the application does this impact?

Customize ordering with a shapefile

# Testing

### Reproduction steps

Upload any shapefile. 
Order a collection with ESI that allows you to spatial subset with a shapefile
Ensure the ESI request is submitted successfully.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
