### PR TITLE
EDSC-3484: Fix /contact_info url

### DIFF
--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -111,7 +111,7 @@ class App extends Component {
                       )}
                     />
                     <Route
-                      path={this.portalPaths('/contact_info')}
+                      path={this.portalPaths('/contact-info')}
                       render={() => (
                         <AuthRequiredContainer>
                           <ContactInfo />

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.js
@@ -252,7 +252,7 @@ class SecondaryToolbar extends Component {
             </Dropdown.Item>
           </LinkContainer>
           <LinkContainer
-            to={`${portalPath(portal)}/contact_info`}
+            to={`${portalPath(portal)}/contact-info`}
           >
             <Dropdown.Item
               className="secondary-toolbar__contact-info"

--- a/static/src/js/routes/ContactInfo/ContactInfo.js
+++ b/static/src/js/routes/ContactInfo/ContactInfo.js
@@ -15,7 +15,7 @@ export const ContactInfo = () => (
       <title>Contact Information</title>
       <meta name="title" content="Contact Information" />
       <meta name="robots" content="noindex, nofollow" />
-      <link rel="canonical" href={`${edscHost}/contact_info`} />
+      <link rel="canonical" href={`${edscHost}/contact-info`} />
     </Helmet>
     <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
       <div className="route-wrapper__content">

--- a/static/src/public/robots.txt
+++ b/static/src/public/robots.txt
@@ -5,4 +5,4 @@ User-Agent: *
 Disallow: /downloads
 Disallow: /projects
 Disallow: /search/granules
-Disallow: /contact_info
+Disallow: /contact-info


### PR DESCRIPTION
# Overview

### What is the feature?

The Contact Information route should use a hypen instead of an underscore to match our the other routes. Fix #1541


### What is the Solution?

Routes have been renamed


### What areas of the application does this impact?

URL to access contact information




# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
