### PR TITLE
EDSC-3093: Remove has_granules_or_cwic from sort key when not used

### DIFF
--- a/cypress/e2e/paths/search/search.cy.js
+++ b/cypress/e2e/paths/search/search.cy.js
@@ -1032,7 +1032,7 @@ describe('Path /search', () => {
           url: '**/search/collections.json'
         },
         (req) => {
-          expect(req.body).to.eq('include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.*,opensearch.granule.osdd&page_num=1&page_size=20&sort_key[]=has_granules_or_cwic&sort_key[]=-usage_score')
+          expect(req.body).to.eq('include_facets=v2&include_granule_counts=true&include_has_granules=true&include_tags=edsc.*,opensearch.granule.osdd&page_num=1&page_size=20&sort_key[]=-usage_score')
 
           req.reply({
             body: noGranulesBody,

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -190,6 +190,10 @@ export const buildCollectionSearchParams = (params) => {
     keywordWithWildcard = `${keyword.replace(/\s+/g, '* ')}*`
   }
 
+  const sortKey = [...selectedSortKey]
+  // Only include has_granules_or_cwic sort key if the parameter is being used
+  if (hasGranulesOrCwic) sortKey.unshift('has_granules_or_cwic')
+
   // Set up params that are not driven by the URL
   const defaultParams = {
     includeFacets: 'v2',
@@ -198,7 +202,7 @@ export const buildCollectionSearchParams = (params) => {
     includeTags: `${tagName('*', 'edsc')},opensearch.granule.osdd`,
     options: {},
     pageSize: defaultCmrPageSize,
-    sortKey: ['has_granules_or_cwic', ...selectedSortKey]
+    sortKey
   }
 
   if (facetsToSend.science_keywords_h && facetsToSend.science_keywords_h.length > 1) {


### PR DESCRIPTION
# Overview

### What is the feature?

When sorting by dates, and the `Include collections without granules` checkbox checked, incorrect results are being displayed. This is because we are still including the `has_granules_or_cwic` sort key (the value behind the checkbox).

### What is the Solution?

Remove `has_granules_or_cwic` from the sort key array when the value is not set in the collections query

### What areas of the application does this impact?

Sorting collection results

# Testing

### Reproduction steps

On the collection search page, check the `Include collections without granules` checkbox. In the network tab of the browser devtools ensure the sort key parameter does not include `has_granules_or_cwic`
