### PR TITLE
EDSC-3678: Ensure getProjectCollections waits for savedAccessConfigs

### DIFF
--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -182,13 +182,13 @@ export const getProjectCollections = () => async (dispatch, getState) => {
   }
 
   // Fetch the saved access configurations for the project collections
-  let savedAccessConfigs
+  let savedAccessConfigs = {}
   try {
     const savedAccessConfigsRequestObject = new SavedAccessConfigsRequest(
       authToken,
       earthdataEnvironment
     )
-    savedAccessConfigsRequestObject.search(
+    await savedAccessConfigsRequestObject.search(
       { collectionIds: filteredIds }
     ).then((response) => {
       const { data } = response

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -188,12 +188,13 @@ export const getProjectCollections = () => async (dispatch, getState) => {
       authToken,
       earthdataEnvironment
     )
-    await savedAccessConfigsRequestObject.search(
+
+    const savedAccessConfigsResponse = await savedAccessConfigsRequestObject.search(
       { collectionIds: filteredIds }
-    ).then((response) => {
-      const { data } = response
-      savedAccessConfigs = data
-    })
+    )
+
+    const { data } = savedAccessConfigsResponse
+    savedAccessConfigs = data
   } catch (error) {
     dispatch(actions.handleError({
       error,


### PR DESCRIPTION
# Overview

### What is the feature?

Occasionally the graphql call to load project collections returns before the call the retrieve the saved access configs. I'm not able to reproduce locally, but I also saw that a similar error is displayed when the call to retrieve the saved access config fails

### What is the Solution?

`await` the call to retrieve the saved access configs, and default the saved access configs value to ensure access methods are still loaded without a successful saved access configs response
