### PR TITLE
EDSC-3558: Removes focused granule when returning to collection results

### DIFF
--- a/cypress/e2e/map/map.cy.js
+++ b/cypress/e2e/map/map.cy.js
@@ -1696,12 +1696,25 @@ describe('Map interactions', () => {
           cy.get('.map').click(1000, 450)
         })
 
+        it('shows the granule and a label on the map', () => {
+          cy.get('.leaflet-interactive').eq(1).should('have.attr', 'd', 'M991 446L994 458L1010 455L1007 443L991 446z')
+          cy.get('.granule-spatial-label-temporal').should('have.text', '2021-05-31 15:31:202021-05-31 15:31:48')
+        })
+
         it('focuses the selected granule', () => {
           getByTestId('granule-results-item').should('have.class', 'granule-results-item--active')
         })
 
         it('updates the URL', () => {
           cy.url().should('match', /\/search\/granules.*g=G2061183408-ASF/)
+        })
+
+        describe('when returning to the collections results list', () => {
+          it('removes the granule label from the map', () => {
+            getByTestId('breadcrumb-button').contains('Search Results').click()
+
+            cy.get('.granule-spatial-label-temporal').should('not.exist')
+          })
         })
       })
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5395,9 +5395,9 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
@@ -14352,9 +14352,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -32821,9 +32821,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
@@ -39832,9 +39832,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-deceiver": {
       "version": "1.2.7",

--- a/static/src/js/components/Map/GranuleGridLayer.js
+++ b/static/src/js/components/Map/GranuleGridLayer.js
@@ -172,7 +172,11 @@ const updateGranuleGridLayer = (instance, props, prevProps) => {
 
   // Nothing should be drawn, remove any existing layers
   if (layerDataCollectionIds.length === 0) {
-    Object.values(layers).forEach((layer) => instance.removeLayer(layer))
+    Object.values(layers).forEach((layer) => {
+      if (layer._granuleFocusLayer) layer._granuleFocusLayer.onRemove(instance._map)
+      if (layer._granuleStickyLayer) layer._granuleStickyLayer.onRemove(instance._map)
+      instance.removeLayer(layer)
+    })
   } else if (layerDataCollectionIds.length < Object.keys(prevLayerData).length) {
     // If there is less data than before, figure out which collection was removed and remove the layer
 

--- a/static/src/js/components/Panels/PanelGroupHeader.js
+++ b/static/src/js/components/Panels/PanelGroupHeader.js
@@ -125,6 +125,7 @@ export const PanelGroupHeader = ({
                       icon={icon}
                       label={title}
                       onClick={onClick}
+                      dataTestId="breadcrumb-button"
                     >
                       {title}
                     </Button>
@@ -144,6 +145,7 @@ export const PanelGroupHeader = ({
                         pathname,
                         search
                       }}
+                      dataTestId="breadcrumb-button"
                     >
                       {title}
                     </PortalLinkContainer>


### PR DESCRIPTION
# Overview

### What is the feature?

When viewing a collection, and clicking on a granule to 'focus' the granule. Returning to the collection results list is not removing the focused granule from the map

### What is the Solution?

When the granule layer is removed, specifically call remove on `_granuleFocusLayer` and `_granuleStickyLayer` if they exist

### What areas of the application does this impact?

Map

# Testing

### Reproduction steps

View a collection with granules (C2105092163-LAADS is a good option). Click on a granule to focus it. Click 'Search Results' to return to the collection search results. Ensure the granule is no longer visible on the map

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
