### PR TITLE
EDSC-3559: Do not deselect a granule when panning the map

### DIFF
--- a/cypress/e2e/map/map.cy.js
+++ b/cypress/e2e/map/map.cy.js
@@ -1716,6 +1716,44 @@ describe('Map interactions', () => {
             cy.get('.granule-spatial-label-temporal').should('not.exist')
           })
         })
+
+        describe('when panning the map', () => {
+          it('does not remove the stickied granule', () => {
+            // Drag the map
+            cy.get('.map').dragMapFromCenter({
+              yMoveFactor: 1 / 8
+            })
+
+            cy.get('.leaflet-interactive').eq(1).should('have.attr', 'd', 'M991 446L994 458L1010 455L1007 443L991 446z')
+            cy.get('.granule-spatial-label-temporal').should('have.text', '2021-05-31 15:31:202021-05-31 15:31:48')
+          })
+        })
+
+        describe('when zooming the map', () => {
+          it('does not remove the stickied granule', () => {
+            // Zoom the map
+            cy.get('.leaflet-control-zoom-in').click()
+
+            cy.get('.leaflet-interactive').eq(1).should('have.attr', 'd', 'M1282 458L1287 482L1319 475L1314 452L1282 458z')
+            cy.get('.granule-spatial-label-temporal').should('have.text', '2021-05-31 15:31:202021-05-31 15:31:48')
+          })
+        })
+
+        describe('when clicking on an empty spot on the map', () => {
+          it('removes the stickied granule', () => {
+            cy.get('.map').click(1100, 750)
+
+            cy.get('.granule-spatial-label-temporal').should('not.exist')
+          })
+        })
+
+        describe('when clicking the same granule again', () => {
+          it('removes the stickied granule', () => {
+            cy.get('.map').click(1000, 450)
+
+            cy.get('.granule-spatial-label-temporal').should('not.exist')
+          })
+        })
       })
     })
 

--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -821,7 +821,11 @@ export class GranuleGridLayerExtended extends L.GridLayer {
         this._onEdscStickygranule({ granule: null })
       } else {
         const [granule] = defaultGranules.filter((g) => g.id === focusedGranuleId)
-        this._onEdscStickygranule({ granule })
+
+        // If this._stickied is the focusedGranule from props, the stickied granule should not change.
+        if (this._stickied !== granule) {
+          this._onEdscStickygranule({ granule })
+        }
       }
     }
 

--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -820,7 +820,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       if (focusedGranuleId === '') {
         this._onEdscStickygranule({ granule: null })
       } else {
-        const [granule] = defaultGranules.filter((g) => g.id === focusedGranuleId)
+        const granule = defaultGranules.find((granule) => granule.id === focusedGranuleId)
 
         // If this._stickied is the focusedGranule from props, the stickied granule should not change.
         if (this._stickied !== granule) {


### PR DESCRIPTION
# Overview

### What is the feature?

If a user pans the map after selecting a granule, that granule no longer looks selected on the map

### What is the Solution?

If the current 'stickied' granule is the same as the focused granule when `setResults` is called in `GranuleGridLayerExtended.js`, then don't call `_onEdscStickygranule`. This ensures the 'stickied' granule remains visible

### What areas of the application does this impact?

Map

# Testing

### Reproduction steps

View a collection with granules (C2105092163-LAADS is a good option). Click on a granule to select it. Pan and/or zoom the map and the granule will not become deselected. Clicking on the granule again, or clicking on an empty part of the map will deselect the granule.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
