### PR TITLE
EDSC-3630: Updates exportSearch cmr-graphql query to use correct fields

### DIFF
--- a/serverless/src/exportSearch/__tests__/handler.test.js
+++ b/serverless/src/exportSearch/__tests__/handler.test.js
@@ -31,11 +31,27 @@ describe('exportSearch', () => {
             items: [{
               conceptId: 'C100000-EDSC',
               title: 'Test collection',
-              platforms: [{ shortName: 'platform' }]
+              platforms: [{ shortName: 'platform' }],
+              processingLevel: {
+                id: '1'
+              },
+              provider: 'EDSC',
+              shortName: 'TestShortName',
+              timeStart: '2018-07-11T00:00:00.000Z',
+              timeEnd: '2023-08-31T00:00:00.000Z',
+              version: 'v1'
             }, {
               conceptId: 'C100001-EDSC',
               title: 'Test collection 1',
-              platforms: [{ shortName: 'platform' }]
+              platforms: [{ shortName: 'platform' }],
+              processingLevel: {
+                id: '1'
+              },
+              provider: 'EDSC',
+              shortName: 'TestShortName',
+              timeStart: '2018-07-11T00:00:00.000Z',
+              timeEnd: '2023-08-31T00:00:00.000Z',
+              version: 'v1'
             }]
           }
         }
@@ -64,7 +80,7 @@ describe('exportSearch', () => {
 
     const result = await exportSearch(event, {})
 
-    expect(result.body).toEqual('Data Provider,Short Name,Version,Entry Title,Processing Level,Platform,Start Time,End Time\r\n,,,"Test collection",,"platform",,\r\n,,,"Test collection 1",,"platform",,\r\n')
+    expect(result.body).toEqual('Data Provider,Short Name,Version,Entry Title,Processing Level,Platform,Start Time,End Time\r\n"EDSC","TestShortName","v1","Test collection","1","platform","2018-07-11T00:00:00.000Z","2023-08-31T00:00:00.000Z"\r\n"EDSC","TestShortName","v1","Test collection 1","1","platform","2018-07-11T00:00:00.000Z","2023-08-31T00:00:00.000Z"\r\n')
   })
 
   test('returns json response correctly', async () => {
@@ -82,11 +98,27 @@ describe('exportSearch', () => {
             items: [{
               conceptId: 'C100000-EDSC',
               title: 'Test collection',
-              platforms: [{ shortName: 'platform' }]
+              platforms: [{ shortName: 'platform' }],
+              processingLevel: {
+                id: '1'
+              },
+              provider: 'EDSC',
+              shortName: 'TestShortName',
+              timeStart: '2018-07-11T00:00:00.000Z',
+              timeEnd: '2023-08-31T00:00:00.000Z',
+              version: 'v1'
             }, {
               conceptId: 'C100001-EDSC',
               title: 'Test collection 1',
-              platforms: [{ shortName: 'platform' }]
+              platforms: [{ shortName: 'platform' }],
+              processingLevel: {
+                id: '1'
+              },
+              provider: 'EDSC',
+              shortName: 'TestShortName',
+              timeStart: '2018-07-11T00:00:00.000Z',
+              timeEnd: '2023-08-31T00:00:00.000Z',
+              version: 'v1'
             }]
           }
         }
@@ -115,7 +147,7 @@ describe('exportSearch', () => {
 
     const result = await exportSearch(event, {})
 
-    expect(result.body).toEqual('[{"conceptId":"C100000-EDSC","title":"Test collection","platforms":[{"shortName":"platform"}]},{"conceptId":"C100001-EDSC","title":"Test collection 1","platforms":[{"shortName":"platform"}]}]')
+    expect(result.body).toEqual('[{"conceptId":"C100000-EDSC","title":"Test collection","platforms":[{"shortName":"platform"}],"processingLevel":{"id":"1"},"provider":"EDSC","shortName":"TestShortName","timeStart":"2018-07-11T00:00:00.000Z","timeEnd":"2023-08-31T00:00:00.000Z","version":"v1"},{"conceptId":"C100001-EDSC","title":"Test collection 1","platforms":[{"shortName":"platform"}],"processingLevel":{"id":"1"},"provider":"EDSC","shortName":"TestShortName","timeStart":"2018-07-11T00:00:00.000Z","timeEnd":"2023-08-31T00:00:00.000Z","version":"v1"}]')
   })
 
   test('responds correctly on http error', async () => {

--- a/serverless/src/exportSearch/__tests__/jsonToCsv.test.js
+++ b/serverless/src/exportSearch/__tests__/jsonToCsv.test.js
@@ -5,9 +5,11 @@ describe('jsonToCsv', () => {
     const json = [{
       provider: 'test provider',
       shortName: 'test shortName',
-      versionId: 'test versionId',
+      version: 'test versionId',
       title: 'test title',
-      processingLevelId: 'test processingLevelId',
+      processingLevel: {
+        id: 'test processingLevelId'
+      },
       platforms: [{ shortName: 'test platforms' }],
       timeStart: 'test timeStart',
       timeEnd: 'test timeEnd'
@@ -22,9 +24,11 @@ describe('jsonToCsv', () => {
     const json = [{
       provider: 'test provider',
       shortName: 'test shortName',
-      versionId: 'test versionId',
+      version: 'test versionId',
       title: 'test title',
-      processingLevelId: 'test processingLevelId',
+      processingLevel: {
+        id: 'test processingLevelId'
+      },
       platforms: [{
         shortName: 'test platform 1'
       }, {
@@ -43,9 +47,11 @@ describe('jsonToCsv', () => {
     const json = [{
       provider: 'test provider',
       shortName: 'test shortName',
-      versionId: 'test versionId',
+      version: 'test versionId',
       title: 'test title',
-      processingLevelId: 'test processingLevelId',
+      processingLevel: {
+        id: 'test processingLevelId'
+      },
       platforms: [{ shortName: 'test platforms' }],
       timeStart: 'test timeStart',
       timeEnd: null

--- a/serverless/src/exportSearch/handler.js
+++ b/serverless/src/exportSearch/handler.js
@@ -65,7 +65,10 @@ const exportSearch = async (event, context) => {
           query,
           variables: {
             ...variables,
-            cursor
+            params: {
+              ...variables.params,
+              cursor
+            }
           }
         },
         headers: requestHeaders

--- a/serverless/src/exportSearch/jsonToCsv.js
+++ b/serverless/src/exportSearch/jsonToCsv.js
@@ -14,9 +14,9 @@ const headers = [
 const keysToMap = [
   'provider',
   'shortName',
-  'versionId',
+  'version',
   'title',
-  'processingLevelId',
+  'processingLevel',
   'platforms',
   'timeStart',
   'timeEnd'
@@ -46,6 +46,11 @@ export const jsonToCsv = (jsonArray) => {
         const shortNames = collection[key].map((platform) => platform.shortName)
 
         collectionValues.push(JSON.stringify(shortNames.join(', '), replacer))
+      } else if (key === 'processingLevel') {
+        // Use the ID field in processingLevel
+        const { id } = collection[key]
+
+        collectionValues.push(`"${id}"`)
       } else {
         collectionValues.push(JSON.stringify(collection[key], replacer))
       }

--- a/static/src/js/actions/exportSearch.js
+++ b/static/src/js/actions/exportSearch.js
@@ -35,85 +35,20 @@ export const exportSearch = (format) => (dispatch, getState) => {
   const graphQlRequestObject = new ExportSearchRequest(authToken, earthdataEnvironment)
 
   const graphQuery = `
-    query SearchCollections(
-      $boundingBox: [String]
-      $circle: [String]
-      $cloudHosted: Boolean
-      $collectionDataType: [String]
-      $dataCenter: String
-      $dataCenterH: [String]
-      $facetsSize: Int
-      $granuleDataFormat: String
-      $granuleDataFormatH: [String]
-      $hasGranulesOrCwic: Boolean
-      $horizontalDataResolutionRange: [String]
-      $instrument: String
-      $instrumentH: [String]
-      $keyword: String
-      $line: [String]
-      $offset: Int
-      $options: JSON
-      $platform: String
-      $platformH: [String]
-      $point: [String]
-      $polygon: [String]
-      $processingLevelIdH: [String]
-      $project: String
-      $projectH: [String]
-      $provider: String
-      $scienceKeywordsH: JSON
-      $serviceType: [String]
-      $sortKey: [String]
-      $spatialKeyword: String
-      $tagKey: [String]
-      $temporal: String
-      $twoDCoordinateSystemName: [String]
-      $limit: Int
-      $cursor: String
+    query ExportCollections (
+      $params: CollectionsInput
     ) {
       collections (
-        boundingBox: $boundingBox
-        circle: $circle
-        collectionDataType: $collectionDataType
-        cloudHosted: $cloudHosted
-        dataCenter: $dataCenter
-        dataCenterH: $dataCenterH
-        facetsSize: $facetsSize
-        granuleDataFormat: $granuleDataFormat
-        granuleDataFormatH: $granuleDataFormatH
-        hasGranulesOrCwic: $hasGranulesOrCwic
-        horizontalDataResolutionRange: $horizontalDataResolutionRange
-        instrument: $instrument
-        instrumentH: $instrumentH
-        keyword: $keyword
-        line: $line
-        offset: $offset
-        options: $options
-        platform: $platform
-        platformH: $platformH
-        point: $point
-        polygon: $polygon
-        processingLevelIdH: $processingLevelIdH
-        project: $project
-        projectH: $projectH
-        provider: $provider
-        scienceKeywordsH: $scienceKeywordsH
-        serviceType: $serviceType
-        sortKey: $sortKey
-        spatialKeyword: $spatialKeyword
-        tagKey: $tagKey
-        temporal: $temporal
-        twoDCoordinateSystemName: $twoDCoordinateSystemName
-        limit: $limit,
-        cursor: $cursor
+        params: $params
       ) {
         cursor
+        count
         items {
           provider
           shortName
-          versionId
+          version
           title
-          processingLevelId
+          processingLevel
           platforms
           timeStart
           timeEnd
@@ -122,14 +57,16 @@ export const exportSearch = (format) => (dispatch, getState) => {
     }`
 
   const response = graphQlRequestObject.search(graphQuery, {
-    ...buildCollectionSearchParams(collectionParams),
-    limit: 1000,
-    // These params include data that is not used in exporting collections. Setting them to undefined to remove the params
-    includeFacets: undefined,
-    includeGranuleCounts: undefined,
-    includeTags: undefined,
-    pageNum: undefined,
-    pageSize: undefined
+    params: {
+      ...buildCollectionSearchParams(collectionParams),
+      limit: 1000,
+      // These params include data that is not used in exporting collections. Setting them to undefined to remove the params
+      includeFacets: undefined,
+      includeGranuleCounts: undefined,
+      includeTags: undefined,
+      pageNum: undefined,
+      pageSize: undefined
+    }
   }, format)
     .then((response) => {
       const { data } = response


### PR DESCRIPTION
# Overview

### What is the feature?

Exporting collection search results has been using an incorrect parameter name (`platformH` instead of `platformsH`). It was also using deprecated parameters and deprecated fields.

### What is the Solution?

Update the cmr-graphql query to use the correct parameters and field names for exporting collection search results.

### What areas of the application does this impact?

Export collection search results

# Testing

### Reproduction steps

Export collection search results. Specifically export when the following parameters have been added to the search context:
* Platforms
* Latency
* "Include only EOSDIS collections"

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
