### PR TITLE
EDSC-3713: Return urs email address in jwt in order to populate echo forms

### DIFF
--- a/serverless/src/util/__tests__/createJwtToken.test.js
+++ b/serverless/src/util/__tests__/createJwtToken.test.js
@@ -26,6 +26,7 @@ describe('util#createJwtToken', () => {
         collectionListView: 'default'
       },
       urs_profile: {
+        email_address: 'test@example.com',
         first_name: 'test'
       }
     }
@@ -55,6 +56,7 @@ describe('util#createJwtToken', () => {
       },
       username: 'testuser',
       ursProfile: {
+        email_address: 'test@example.com',
         first_name: 'test'
       }
     }))

--- a/serverless/src/util/createJwtToken.js
+++ b/serverless/src/util/createJwtToken.js
@@ -21,6 +21,7 @@ export const createJwtToken = (user, earthdataEnvironment) => {
     username,
     preferences,
     ursProfile: {
+      email_address: ursProfile.email_address,
       first_name: ursProfile.first_name
     },
     earthdataEnvironment

--- a/static/src/js/components/ContactInfo/ContactInfo.js
+++ b/static/src/js/components/ContactInfo/ContactInfo.js
@@ -132,7 +132,7 @@ class ContactInfo extends Component {
 
         <h3>Update Notification Preference Level</h3>
 
-        <p>
+        <div className="mb-2">
           <label htmlFor="notificationLevel">
             Receive delayed access notifications
           </label>
@@ -151,7 +151,7 @@ class ContactInfo extends Component {
                 <option value="NONE">Never</option>
               </select>
             )}
-        </p>
+        </div>
 
         <Button
           className="contact-info-form__update-notification-level"


### PR DESCRIPTION
# Overview

### What is the feature?

The email address in ESI forms should be populated by the user's URS profile's email address, but that value isn't available on the project page.

### What is the Solution?

Return the email_address in the JWT when a user logs in. This will ensure the email address is available on the project page.

### What areas of the application does this impact?

Logging in/ESI forms

# Testing

### Reproduction steps

Load the project page with a collection that has a ESI service. Ensure your email address is populated in the form

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
