### PR TITLE
EDSC-3731: Download history page returning "Internal server error"

### DIFF
--- a/serverless/src/getRetrievals/__tests__/handler.test.js
+++ b/serverless/src/getRetrievals/__tests__/handler.test.js
@@ -37,7 +37,7 @@ afterEach(() => {
 describe('getRetrievals', () => {
   test('correctly retrieves retrievals', async () => {
     const determineEarthdataEnvironmentMock = jest.spyOn(determineEarthdataEnvironment, 'determineEarthdataEnvironment')
-
+    // [{\"id\":\"7023641925\",\"created_at\":\"2019-08-25T11:58:14.390Z\",\"jsondata\":{},\"environment\":\"prod\",\"collections\":[{\"titles\":{\"title\":\"Collection Title Three\"}}]},{\"id\":\"4517239960\",\"created_at\":\"2019-08-25T11:58:14.390Z\",\"jsondata\":{},\"environment\":\"prod\",\"collections\":[{\"titles\":{\"title\":\"Collection Title One\"}},{\"titles\":{\"title\":\"Collection Title Two\"}}]}]
     dbTracker.on('query', (query) => {
       query.response([{
         id: 1,
@@ -82,7 +82,7 @@ describe('getRetrievals', () => {
         environment: 'prod',
         collections: [
           {
-            title: 'Collection Title Three'
+            titles: { title: 'Collection Title Three' }
           }
         ]
       },
@@ -93,10 +93,10 @@ describe('getRetrievals', () => {
         environment: 'prod',
         collections: [
           {
-            title: 'Collection Title One'
+            titles: { title: 'Collection Title One' }
           },
           {
-            title: 'Collection Title Two'
+            titles: { title: 'Collection Title Two' }
           }
         ]
       }

--- a/serverless/src/getRetrievals/__tests__/handler.test.js
+++ b/serverless/src/getRetrievals/__tests__/handler.test.js
@@ -37,7 +37,6 @@ afterEach(() => {
 describe('getRetrievals', () => {
   test('correctly retrieves retrievals', async () => {
     const determineEarthdataEnvironmentMock = jest.spyOn(determineEarthdataEnvironment, 'determineEarthdataEnvironment')
-    // [{\"id\":\"7023641925\",\"created_at\":\"2019-08-25T11:58:14.390Z\",\"jsondata\":{},\"environment\":\"prod\",\"collections\":[{\"titles\":{\"title\":\"Collection Title Three\"}}]},{\"id\":\"4517239960\",\"created_at\":\"2019-08-25T11:58:14.390Z\",\"jsondata\":{},\"environment\":\"prod\",\"collections\":[{\"titles\":{\"title\":\"Collection Title One\"}},{\"titles\":{\"title\":\"Collection Title Two\"}}]}]
     dbTracker.on('query', (query) => {
       query.response([{
         id: 1,

--- a/serverless/src/getRetrievals/handler.js
+++ b/serverless/src/getRetrievals/handler.js
@@ -61,12 +61,15 @@ export default async function getRetrievals(event, context) {
         environment
       } = firstRow
 
+      const collectionMetadata = retrievalRecord.map((record) => record.collection_metadata)
+      const titles = collectionMetadata.map((collection) => ({ titles: collection }))
+
       retrievalsResponse.push({
         id,
         created_at: createdAt,
         jsondata,
         environment,
-        collections: retrievalRecord.map((record) => record.collection_metadata)
+        collections: titles
       })
     })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Removing some of the fields which are being passed to the get history of downloads page. Many are not needed and this is likely causing a user issue in Prod due to the payload growing too large

### What is the Solution?

Removing extraneous fields from what is passed to the history page

### What areas of the application does this impact?

download history page

# Testing

### Reproduction steps

Download some collections and then check your download history to make sure that the page populates

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
