### PR TITLE
EDSC-3739: Removes unnecessary data from submitRetrieval payload

### DIFF
--- a/static/src/js/util/__tests__/retrievals.test.js
+++ b/static/src/js/util/__tests__/retrievals.test.js
@@ -8,6 +8,11 @@ describe('retrievals', () => {
       metadata: {
         collections: {
           'C100000-EDSC': {
+            conceptId: 'C100000-EDSC',
+            dataCenter: 'EDSC',
+            directDistributionInformation: {},
+            isCSDA: false,
+            shortName: 'mock shortName',
             title: 'Vestibulum id ligula porta felis euismod semper.'
           }
         }
@@ -82,44 +87,21 @@ describe('retrievals', () => {
       authToken: 'auth-token',
       collections: [{
         access_method: {
-          id: 'S100000-EDSC',
-          isValid: true,
-          longName: 'Cras justo odio, dapibus ac facilisis in, egestas eget quam.',
           mbr: {
             neLat: 34.00000001,
             neLng: -76.99999999,
             swLat: 33.99999999,
             swLng: -77.00000001
           },
-          name: 'harmony/gdal-argo Subsetter and Reformatter.',
           selectedOutputProjection: 'EPSG:4326',
-          supportedOutputFormats: [
-            'TIFF',
-            'PNG',
-            'GIF'
-          ],
-          supportedOutputProjections: [
-            'EPSG:4326'
-          ],
           type: 'Harmony',
-          url: 'https://harmony.sit.earthdata.nasa.gov',
-          variables: {
-            'V100000-EDSC': {
-              conceptId: 'V100000-EDSC',
-              definition: 'Alpha channel value',
-              longName: 'Alpha channel ',
-              name: 'alpha_var',
-              scienceKeywords: [
-                {
-                  category: 'EARTH SCIENCE',
-                  topic: 'ATMOSPHERE',
-                  term: 'ATMOSPHERIC PRESSURE'
-                }
-              ]
-            }
-          }
+          url: 'https://harmony.sit.earthdata.nasa.gov'
         },
         collection_metadata: {
+          conceptId: 'C100000-EDSC',
+          dataCenter: 'EDSC',
+          directDistributionInformation: {},
+          isCSDA: false,
           title: 'Vestibulum id ligula porta felis euismod semper.'
         },
         granule_count: 100,

--- a/static/src/js/util/retrievals.js
+++ b/static/src/js/util/retrievals.js
@@ -1,3 +1,4 @@
+import { pick } from 'lodash'
 import { mbr } from '@edsc/geo-utils'
 
 import {
@@ -12,6 +13,30 @@ import {
   getProjectCollectionsMetadata
 } from '../selectors/project'
 import { getEarthdataEnvironment } from '../selectors/earthdataEnvironment'
+
+// Limit the fields we send with the retrieval to save space in the payload
+const permittedCollectionMetadataFields = [
+  'conceptId',
+  'dataCenter',
+  'datasetId',
+  'directDistributionInformation',
+  'isCSDA',
+  'links',
+  'title'
+]
+const permittedAccessMethodFields = [
+  'enableTemporalSubsetting',
+  'mbr',
+  'model',
+  'optionDefinition',
+  'rawModel',
+  'selectedOutputFormat',
+  'selectedOutputProjection',
+  'supportsBoundingBoxSubsetting',
+  'supportsShapefileSubsetting',
+  'type',
+  'url'
+]
 
 /**
  * Prepare parameters used in submitRetrieval() based on current Redux State
@@ -50,7 +75,7 @@ export const prepareRetrievalParams = (state) => {
 
     returnValue.id = collectionId
     returnValue.granule_count = granuleCount
-    returnValue.collection_metadata = collectionMetadata
+    returnValue.collection_metadata = pick(collectionMetadata, permittedCollectionMetadataFields)
 
     const extractedGranuleParams = extractProjectCollectionGranuleParams(state, collectionId)
 
@@ -62,7 +87,10 @@ export const prepareRetrievalParams = (state) => {
     const params = buildGranuleSearchParams(preparedParams)
 
     returnValue.granule_params = params
-    returnValue.access_method = accessMethods[selectedAccessMethod]
+    returnValue.access_method = pick(
+      accessMethods[selectedAccessMethod],
+      permittedAccessMethodFields
+    )
 
     const {
       boundingBox = [],


### PR DESCRIPTION
# Overview

### What is the feature?

With the changes in EDSC-3611, specifically to return orderOptions in the getProjectCollections cmr-graphql request, they payload we send when submitting a retrieval has gotten too large.

### What is the Solution?

We save collection metadata and access methods when submitting a new retrieval. This PR removes the bulk of that metadata, and only sends the fields which are used to submit or to view retrievals

### What areas of the application does this impact?

Retrievals

# Testing

### Reproduction steps

Submit retrievals of every kind, ensure successful sending and viewing of those retrievals