### PR TITLE
EDSC-3546: Unload previous portal's styles when loading a portal

### DIFF
--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -43,7 +43,10 @@ export const updateStore = ({
   timeline
 }, newPathname) => async (dispatch, getState) => {
   const state = getState()
-  const { router } = state
+  const {
+    portal: previousPortal = {},
+    router
+  } = state
   const { location } = router
   const { pathname } = location
 
@@ -57,6 +60,18 @@ export const updateStore = ({
 
   let portal = {}
   if (portalId) {
+    const {
+      hasStyles: previousPortalHasStyles,
+      portalId: previousPortalId
+    } = previousPortal
+
+    // If the previous portal is different than the new portal, and it did have a styles file,
+    // unload those styles
+    if (previousPortalId && portalId !== previousPortalId && previousPortalHasStyles) {
+      const css = require(`../../../../portals/${previousPortalId}/styles.scss`)
+      css.unuse()
+    }
+
     portal = buildConfig(availablePortals[portalId])
 
     const { hasStyles } = portal
@@ -200,7 +215,7 @@ export const changePath = (path = '') => async (dispatch, getState) => {
   }
 
   // Fetch collections in the project
-  const { project = {} } = decodedParams
+  const { project = {} } = decodedParams || {}
   const { collections: projectCollections = {} } = project
   const { allIds = [] } = projectCollections
 


### PR DESCRIPTION
# Overview

### What is the feature?

When switching between many portals, it is possible to see the wrong portal's logo in the sidebar header. 

### What is the Solution?

Chrome devtools showed many css rules for `#portal-logo`. When we are loading a new portal's styles, first check if the previous portal has styles, and if they do, unload them using `css.unuse()`

### What areas of the application does this impact?

Portals

# Testing

### Reproduction steps

I was able to replicate this in SIT by switching between portals ~10 times. By unloading the previous styles I was able to switch many more times without seeing the wrong logo appear in the search sidebar

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
