### PR TITLE
EDSC-3743: Avoid sending duplicate requests to CMR when multiple shapes are selected in a shapefile

### DIFF
--- a/static/src/js/actions/__tests__/shapefiles.test.js
+++ b/static/src/js/actions/__tests__/shapefiles.test.js
@@ -197,6 +197,9 @@ describe('saveShapefile', () => {
       await store.dispatch(fetchShapefile('1')).then(() => {
         const storeActions = store.getActions()
         expect(storeActions[0]).toEqual({
+          type: LOADING_SHAPEFILE
+        })
+        expect(storeActions[1]).toEqual({
           type: UPDATE_SHAPEFILE,
           payload: {
             file: 'mock shapefile',

--- a/static/src/js/actions/shapefiles.js
+++ b/static/src/js/actions/shapefiles.js
@@ -78,6 +78,7 @@ export const saveShapefile = (data) => (dispatch, getState) => {
  */
 export const fetchShapefile = (shapefileId) => (dispatch, getState) => {
   const state = getState()
+  dispatch(shapefileLoading())
 
   // Retrieve data from Redux using selectors
   const earthdataEnvironment = getEarthdataEnvironment(state)

--- a/static/src/js/components/Map/ShapefileLayer.js
+++ b/static/src/js/components/Map/ShapefileLayer.js
@@ -420,12 +420,13 @@ const updateLayer = (instance, props) => {
 
   const {
     file: toFile,
+    isLoading,
     shapefileId: toShapefileId,
     shapefileName,
     selectedFeatures
   } = shapefile
 
-  if (toShapefileId && !toFile) {
+  if (toShapefileId && !toFile && !isLoading) {
     onFetchShapefile(toShapefileId)
   }
 

--- a/static/src/js/components/SpatialSelection/SpatialSelection.js
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.js
@@ -9,6 +9,7 @@ import React, {
 import PropTypes from 'prop-types'
 import {
   difference,
+  isEqual,
   startCase,
   uniq
 } from 'lodash'
@@ -273,20 +274,25 @@ const SpatialSelection = (props) => {
       // Add new selected shape to any existing spatial, keep existing spatial of different types as well
       const existingSearch = getExistingSearch(type)
 
-      // Save existing spatial params for all types, while adding the currently selected points from layerType
-      // Set types to undefined if no spatial search exists, to remove that value from the redux store
-      onChangeQuery({
-        collection: {
-          spatial: {
-            boundingBox: spatialSearchOrUndefined(boundingBoxSearch.current),
-            circle: spatialSearchOrUndefined(circleSearch.current),
-            line: spatialSearchOrUndefined(lineSearch.current),
-            point: spatialSearchOrUndefined(pointSearch.current),
-            polygon: spatialSearchOrUndefined(polygonSearch.current),
-            [type]: spatialSearchOrUndefined(uniq([...existingSearch, points]))
+      const typeSpatial = spatialSearchOrUndefined(uniq([...existingSearch, points]))
+
+      // Only call onChangeQuery if the search has actually changed
+      if (!isEqual(existingSearch, typeSpatial)) {
+        // Save existing spatial params for all types, while adding the currently selected points from layerType
+        // Set types to undefined if no spatial search exists, to remove that value from the redux store
+        onChangeQuery({
+          collection: {
+            spatial: {
+              boundingBox: spatialSearchOrUndefined(boundingBoxSearch.current),
+              circle: spatialSearchOrUndefined(circleSearch.current),
+              line: spatialSearchOrUndefined(lineSearch.current),
+              point: spatialSearchOrUndefined(pointSearch.current),
+              polygon: spatialSearchOrUndefined(polygonSearch.current),
+              [type]: typeSpatial
+            }
           }
-        }
-      })
+        })
+      }
     } else {
       drawnLayers.current = [newDrawnLayer]
 

--- a/static/src/js/reducers/__tests__/shapefile.test.js
+++ b/static/src/js/reducers/__tests__/shapefile.test.js
@@ -82,15 +82,44 @@ describe('LOADING_SHAPEFILE', () => {
       payload
     }
 
-    const expectedState = {
+    const initial = {
       ...initialState,
+      shapefileId: 123
+    }
+
+    const expectedState = {
+      ...initial,
       isErrored: false,
       isLoaded: false,
       isLoading: true,
       shapefileName: 'test-name'
     }
 
-    expect(shapefileReducer(undefined, action)).toEqual(expectedState)
+    expect(shapefileReducer(initial, action)).toEqual(expectedState)
+  })
+
+  test('returns the correct state when name is not included', () => {
+    const payload = {}
+
+    const action = {
+      type: UPDATE_SHAPEFILE,
+      payload
+    }
+
+    const initial = {
+      ...initialState,
+      shapefileId: 123
+    }
+
+    const expectedState = {
+      ...initial,
+      isErrored: false,
+      isLoaded: true,
+      isLoading: false,
+      shapefileName: undefined
+    }
+
+    expect(shapefileReducer(initial, action)).toEqual(expectedState)
   })
 })
 

--- a/static/src/js/reducers/shapefile.js
+++ b/static/src/js/reducers/shapefile.js
@@ -33,11 +33,13 @@ const shapefileReducer = (state = initialState, action = {}) => {
       }
     }
     case LOADING_SHAPEFILE: {
-      const { payload } = action
+      const { payload = {} } = action
       const {
-        name
+        name = ''
       } = payload
+
       return {
+        ...state,
         isErrored: false,
         isLoading: true,
         isLoaded: false,


### PR DESCRIPTION
# Overview

### What is the feature?

Refreshing the page, or visiting a new page like the project page when a shapefile is loaded and many shapes are selected is causing duplicate requests to be sent to CMR for collections and granules. Also multiple requests are being made to retrieve the shapefile from our database.

### What is the Solution?

* Check the isLoading property for the shapefile in the redux store. Don't call onFetchShapefile if the file is already loading. This fixes the multiple calls to retrieve the shapefile
* As each selected shape's constraints are added to the query in SpatialSelection, check to make sure the query is actually going to change before calling onChangeQuery. This fixes the duplicate calls to collections, which in turn removes the duplicate calls to granules

### What areas of the application does this impact?

Shapefiles

# Testing

### Reproduction steps

Load a shapefile with many shapes.
Select a few of the shapes.
Refresh the page and watch the network tab in devtools.
Ensure only one request for the shapefileId occurs
Ensure only one collections request occurs

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
