### PR TITLE
EDSC-3746: Reset shapefile and project status when calling RESTORE_FROM_URL

### DIFF
--- a/static/src/js/components/Map/ShapefileLayer.js
+++ b/static/src/js/components/Map/ShapefileLayer.js
@@ -80,7 +80,11 @@ class ShapefileLayerExtended extends L.Layer {
   }
 
   onRemovedFile() {
-    if (this.jsonLayer != null) { this.map.removeLayer(this.jsonLayer) }
+    if (this.jsonLayer != null) {
+      this.map.removeLayer(this.jsonLayer)
+    }
+
+    this.fileHash = null
   }
 
   // Leaflet 1.0+ changed the way that MultiPolygons are handled.

--- a/static/src/js/reducers/__tests__/autocomplete.test.js
+++ b/static/src/js/reducers/__tests__/autocomplete.test.js
@@ -306,6 +306,19 @@ describe('RESTORE_FROM_URL', () => {
       payload
     }
 
+    const initial = {
+      selected: [
+        {
+          type: 'science_keywords',
+          value: 'Atmosphere:Clouds:Cloud Properties:Cloud Frequency:Cloud Frequency'
+        },
+        {
+          type: 'science_keywords',
+          value: 'Atmosphere:Aerosols:Aerosol Backscatter:Stratospheric Aerosols'
+        }
+      ]
+    }
+
     const expectedState = {
       ...initialState,
       selected: [{
@@ -314,7 +327,7 @@ describe('RESTORE_FROM_URL', () => {
       }]
     }
 
-    expect(autocompleteReducer(undefined, action)).toEqual(expectedState)
+    expect(autocompleteReducer(initial, action)).toEqual(expectedState)
   })
 })
 

--- a/static/src/js/reducers/__tests__/collectionMetadata.test.js
+++ b/static/src/js/reducers/__tests__/collectionMetadata.test.js
@@ -209,11 +209,20 @@ describe('RESTORE_FROM_URL', () => {
       payload: { collections: payload }
     }
 
+    const initial = {
+      collectionId: {
+        id: 'collectionId',
+        conceptId: 'collectionId',
+        mock: 'metadata',
+        graphqlMock: 'new metadata'
+      }
+    }
+
     const expectedState = {
       ...initialState,
       ...payload
     }
 
-    expect(collectionMetadataReducer(undefined, action)).toEqual(expectedState)
+    expect(collectionMetadataReducer(initial, action)).toEqual(expectedState)
   })
 })

--- a/static/src/js/reducers/__tests__/facetsParams.test.js
+++ b/static/src/js/reducers/__tests__/facetsParams.test.js
@@ -63,9 +63,15 @@ describe('cmrFacetsReducer', () => {
         }
       }
 
+      const initial = {
+        science_keywords_h: [{
+          topic: 'Argriculture'
+        }]
+      }
+
       const expectedState = cmrFacets
 
-      expect(cmrFacetsReducer(undefined, action)).toEqual(expectedState)
+      expect(cmrFacetsReducer(initial, action)).toEqual(expectedState)
     })
   })
 
@@ -192,9 +198,13 @@ describe('featureFacetsReducer', () => {
         }
       }
 
+      const initial = {
+        mapImagery: true
+      }
+
       const expectedState = featureFacets
 
-      expect(featureFacetsReducer(undefined, action)).toEqual(expectedState)
+      expect(featureFacetsReducer(initial, action)).toEqual(expectedState)
     })
   })
 

--- a/static/src/js/reducers/__tests__/map.test.js
+++ b/static/src/js/reducers/__tests__/map.test.js
@@ -2,25 +2,26 @@ import mapReducer from '../map'
 import { UPDATE_MAP, RESTORE_FROM_URL } from '../../constants/actionTypes'
 import projections from '../../util/map/projections'
 
+const initialState = {
+  base: {
+    blueMarble: true,
+    trueColor: false,
+    landWaterMap: false
+  },
+  latitude: 0,
+  longitude: 0,
+  overlays: {
+    referenceFeatures: true,
+    coastlines: false,
+    referenceLabels: true
+  },
+  projection: projections.geographic,
+  zoom: 2
+}
+
 describe('INITIAL_STATE', () => {
   test('is correct', () => {
     const action = { type: 'dummy_action' }
-    const initialState = {
-      base: {
-        blueMarble: true,
-        trueColor: false,
-        landWaterMap: false
-      },
-      latitude: 0,
-      longitude: 0,
-      overlays: {
-        referenceFeatures: true,
-        coastlines: false,
-        referenceLabels: true
-      },
-      projection: projections.geographic,
-      zoom: 2
-    }
 
     expect(mapReducer(undefined, action)).toEqual(initialState)
   })
@@ -74,6 +75,15 @@ describe('RESTORE_FROM_URL', () => {
       zoom: 2
     }
 
+    const initial = {
+      ...initialState,
+      base: {
+        blueMarble: false,
+        trueColor: false,
+        landWaterMap: true
+      }
+    }
+
     const action = {
       type: RESTORE_FROM_URL,
       payload: {
@@ -83,6 +93,6 @@ describe('RESTORE_FROM_URL', () => {
 
     const expectedState = map
 
-    expect(mapReducer(undefined, action)).toEqual(expectedState)
+    expect(mapReducer(initial, action)).toEqual(expectedState)
   })
 })

--- a/static/src/js/reducers/__tests__/project.test.js
+++ b/static/src/js/reducers/__tests__/project.test.js
@@ -497,6 +497,17 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
+    const initial = {
+      ...initialState,
+      collections: {
+        allIds: ['existingCollectionId', 'anotherExistingCollectionId'],
+        byId: {
+          existingCollectionId: {},
+          anotherExistingCollectionId: {}
+        }
+      }
+    }
+
     const expectedState = {
       ...initialState,
       collections: {
@@ -507,7 +518,7 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
-    expect(projectReducer(undefined, action)).toEqual(expectedState)
+    expect(projectReducer(initial, action)).toEqual(expectedState)
   })
 })
 

--- a/static/src/js/reducers/__tests__/query.test.js
+++ b/static/src/js/reducers/__tests__/query.test.js
@@ -132,6 +132,16 @@ describe('RESTORE_FROM_URL', () => {
         }
       }
 
+      const initial = {
+        ...initialState,
+        collection: {
+          keyword: 'old keyword',
+          spatial: {
+            point: '0,0'
+          }
+        }
+      }
+
       const expectedState = {
         ...initialState,
         ...query,
@@ -141,7 +151,7 @@ describe('RESTORE_FROM_URL', () => {
         }
       }
 
-      expect(queryReducer(undefined, action)).toEqual(expectedState)
+      expect(queryReducer(initial, action)).toEqual(expectedState)
     })
   })
 

--- a/static/src/js/reducers/__tests__/shapefile.test.js
+++ b/static/src/js/reducers/__tests__/shapefile.test.js
@@ -160,12 +160,22 @@ describe('RESTORE_FROM_URL', () => {
       payload
     }
 
+    const initial = {
+      ...initialState,
+      isLoading: false,
+      isLoaded: true,
+      isErrored: false,
+      shapefileId: 'some-id',
+      shapefileName: 'some-name',
+      shapefileSize: 'some-size'
+    }
+
     const expectedState = {
       ...initialState,
       shapefileId: 'test-id'
     }
 
-    expect(shapefileReducer(undefined, action)).toEqual(expectedState)
+    expect(shapefileReducer(initial, action)).toEqual(expectedState)
   })
 })
 

--- a/static/src/js/reducers/__tests__/timeline.test.js
+++ b/static/src/js/reducers/__tests__/timeline.test.js
@@ -89,8 +89,23 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
-    const expectedState = timeline
+    const initial = {
+      intervals: {
+        collectionId: [
+          [
+            1298937600,
+            1304208000,
+            3
+          ]
+        ]
+      }
+    }
 
-    expect(timelineReducer(undefined, action)).toEqual(expectedState)
+    const expectedState = {
+      ...initialState,
+      ...timeline
+    }
+
+    expect(timelineReducer(initial, action)).toEqual(expectedState)
   })
 })

--- a/static/src/js/reducers/__tests__/ui.test.js
+++ b/static/src/js/reducers/__tests__/ui.test.js
@@ -456,6 +456,10 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
+    const initial = {
+      timeline: { isOpen: false }
+    }
+
     const expectedState = {
       ...initialState,
       deprecatedParameterModal: {
@@ -464,7 +468,7 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
-    expect(uiReducer(undefined, action)).toEqual(expectedState)
+    expect(uiReducer(initial, action)).toEqual(expectedState)
   })
 
   test('returns the original state if no deprecatedUrlParams were found', () => {
@@ -475,10 +479,15 @@ describe('RESTORE_FROM_URL', () => {
       }
     }
 
+    const initial = {
+      ...initialState,
+      timeline: { isOpen: false }
+    }
+
     const expectedState = {
       ...initialState
     }
 
-    expect(uiReducer(undefined, action)).toEqual(expectedState)
+    expect(uiReducer(initial, action)).toEqual(expectedState)
   })
 })

--- a/static/src/js/reducers/autocomplete.js
+++ b/static/src/js/reducers/autocomplete.js
@@ -115,7 +115,7 @@ const autocompleteReducer = (state = initialState, action = {}) => {
       const { autocompleteSelected = [] } = payload
 
       return {
-        ...state,
+        ...initialState,
         selected: autocompleteSelected
       }
     }

--- a/static/src/js/reducers/collectionMetadata.js
+++ b/static/src/js/reducers/collectionMetadata.js
@@ -128,7 +128,7 @@ const collectionMetadataReducer = (state = initialState, action = {}) => {
       const { collections } = action.payload
 
       return {
-        ...state,
+        ...initialState,
         ...collections
       }
     }

--- a/static/src/js/reducers/facetsParams.js
+++ b/static/src/js/reducers/facetsParams.js
@@ -37,7 +37,7 @@ export const cmrFacetsReducer = (state = initialCmrState, action = {}) => {
       const { cmrFacets } = payload
 
       return {
-        ...state,
+        ...initialCmrState,
         ...cmrFacets
       }
     }
@@ -88,7 +88,7 @@ export const featureFacetsReducer = (state = initialFeatureState, action = {}) =
       const { featureFacets } = action.payload
 
       return {
-        ...state,
+        ...initialFeatureState,
         ...featureFacets
       }
     }

--- a/static/src/js/reducers/map.js
+++ b/static/src/js/reducers/map.js
@@ -32,7 +32,7 @@ const mapReducer = (state = initialState, action = {}) => {
       Object.keys(map).forEach((key) => map[key] === undefined && delete map[key])
 
       return {
-        ...state,
+        ...initialState,
         ...map
       }
     }

--- a/static/src/js/reducers/project.js
+++ b/static/src/js/reducers/project.js
@@ -535,7 +535,7 @@ const projectReducer = (state = initialState, action = {}) => {
       const { project } = action.payload
 
       return {
-        ...state,
+        ...initialState,
         ...project
       }
     }

--- a/static/src/js/reducers/query.js
+++ b/static/src/js/reducers/query.js
@@ -210,7 +210,7 @@ const queryReducer = (state = initialState, action = {}) => {
       }
 
       return {
-        ...state,
+        ...initialState,
         ...query,
         collection: {
           ...initialCollectionQueryWithPreferences,

--- a/static/src/js/reducers/shapefile.js
+++ b/static/src/js/reducers/shapefile.js
@@ -61,7 +61,7 @@ const shapefileReducer = (state = initialState, action = {}) => {
       const { shapefile } = action.payload
 
       return {
-        ...state,
+        ...initialState,
         ...shapefile
       }
     }

--- a/static/src/js/reducers/timeline.js
+++ b/static/src/js/reducers/timeline.js
@@ -46,7 +46,7 @@ const timelineReducer = (state = initialState, action = {}) => {
       const { timeline = initialState.query } = action.payload
 
       return {
-        ...state,
+        ...initialState,
         query: {
           ...state.query,
           ...timeline

--- a/static/src/js/reducers/ui.js
+++ b/static/src/js/reducers/ui.js
@@ -267,11 +267,11 @@ const uiReducer = (state = initialState, action = {}) => {
       const { deprecatedUrlParams } = payload
       const { deprecatedParameterModal } = state
 
-      if (deprecatedUrlParams.length === 0) return state
+      if (deprecatedUrlParams.length === 0) return initialState
 
       // If any deprecated URL params are defined, display the modal
       return {
-        ...state,
+        ...initialState,
         deprecatedParameterModal: {
           ...deprecatedParameterModal,
           deprecatedUrlParams,


### PR DESCRIPTION
# Overview

### What is the feature?

When clicking the Earthdata Search title, shapefiles were not getting removed from the map, and project collections were not being removed from the store.

### What is the Solution?

Adjust the RESTORE_FROM_URL action types in the reducers to inherit from the reducer's initial state, rather than the current state. This was necessary in the shapefile and project reducer, but I adjusted all the reducers that matched that pattern to be consistent

### What areas of the application does this impact?

Shapefiles, projects

# Testing

### Reproduction steps

Add a shapefile to the map, and add a collection to your project.
Click on the EDSC title
Ensure the shapefile is no longer on the map, or the spatial display
Ensure the "My Project" button in the secondary toolbar is no longer displayed
