### PR TITLE
EDSC-3742: Fixes duplicate css

### DIFF
--- a/static.webpack.config.common.js
+++ b/static.webpack.config.common.js
@@ -6,7 +6,6 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const ESLintPlugin = require('eslint-webpack-plugin')
 const HtmlWebpackPartialsPlugin = require('html-webpack-partials-plugin')
 const HtmlWebPackPlugin = require('html-webpack-plugin')
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const config = require('./sharedUtils/config')
 const { availablePortals } = require('./portals/index')
@@ -69,21 +68,14 @@ const StaticCommonConfig = {
         exclude: /portals/i,
         use: [
           {
-            loader: 'css-loader',
-            options: {
-              sourceMap: true
-            }
+            loader: 'css-loader'
           },
           {
-            loader: 'resolve-url-loader',
-            options: {
-              sourceMap: true
-            }
+            loader: 'resolve-url-loader'
           },
           {
             loader: 'postcss-loader',
             options: {
-              sourceMap: true,
               postcssOptions: {
                 plugins: [
                   'autoprefixer'
@@ -92,10 +84,7 @@ const StaticCommonConfig = {
             }
           },
           {
-            loader: 'sass-loader',
-            options: {
-              sourceMap: true
-            }
+            loader: 'sass-loader'
           },
           {
             loader: 'style-resources-loader',
@@ -149,7 +138,6 @@ const StaticCommonConfig = {
     ]
   },
   plugins: [
-    new MiniCssExtractPlugin(),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
       DEBUG: false

--- a/static.webpack.config.common.js
+++ b/static.webpack.config.common.js
@@ -107,33 +107,6 @@ const StaticCommonConfig = {
       {
         test: /\.(?:ico|gif|png|jpe?g)$/i,
         type: 'asset/resource'
-      },
-      {
-        test: /portals.*styles\.s?css$/i,
-        use: [
-          {
-            loader: 'style-loader',
-            options: {
-              injectType: 'lazyStyleTag',
-              esModule: false
-            }
-          },
-          {
-            loader: 'css-loader'
-          },
-          {
-            loader: 'resolve-url-loader',
-            options: {
-              sourceMap: true
-            }
-          },
-          {
-            loader: 'sass-loader',
-            options: {
-              sourceMap: true
-            }
-          }
-        ]
       }
     ]
   },

--- a/static.webpack.config.dev.js
+++ b/static.webpack.config.dev.js
@@ -34,7 +34,6 @@ const Config = mergeWithRules({
     rules: [
       {
         test: /\.(css|scss)$/,
-        exclude: /portals/i,
         use: [
           {
             loader: 'style-loader'

--- a/static.webpack.config.prod.js
+++ b/static.webpack.config.prod.js
@@ -23,8 +23,8 @@ const defaultPlugins = [
 
   // Creates a CSS file per JS file which contains CSS. It supports On-Demand-Loading of CSS and SourceMaps.
   new MiniCssExtractPlugin({
-    filename: '[name].[contenthash].min.css',
-    chunkFilename: '[id].[contenthash].min.css'
+    filename: '[name].[contenthash].css',
+    chunkFilename: '[id].[contenthash].css'
   })
 ]
 

--- a/static.webpack.config.prod.js
+++ b/static.webpack.config.prod.js
@@ -23,8 +23,8 @@ const defaultPlugins = [
 
   // Creates a CSS file per JS file which contains CSS. It supports On-Demand-Loading of CSS and SourceMaps.
   new MiniCssExtractPlugin({
-    filename: '[name].[contenthash].css',
-    chunkFilename: '[id].[contenthash].css'
+    filename: '[name].[contenthash].min.css',
+    chunkFilename: '[id].[contenthash].min.css'
   })
 ]
 
@@ -99,7 +99,6 @@ const Config = mergeWithRules({
     rules: [
       {
         test: /\.(css|scss)$/,
-        exclude: /portals/i,
         use: [
           MiniCssExtractPlugin.loader
         ]


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes duplicate css.

### What is the Solution?

Removes a misconfiguration of the `MiniCssExtractPlugin`.

### What areas of the application does this impact?

Production builds

# Testing

### Reproduction steps

- **Environment for testing:** SIT
- **Collection to test with:** n/a

1. Load SIT with the old CSS deployed
2. Load SIT with new CSS deployed
  [ ] Verify the new CSS loads

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
