### PR TITLE
EDSC-3598: Convert class components to functional components (GranuleImage)

### DIFF
--- a/static/src/js/components/CollectionResults/CollectionResultsList.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsList.js
@@ -70,7 +70,7 @@ export const CollectionResultsList = ({
   const sizeMap = React.useRef({})
 
   // If visibleMiddleIndex is set, that means we want to scroll to a particular item. react-window
-  // will immediatly render the items at the default index, which calls setVisibleIndex and resets
+  // will immediately render the items at the default index, which calls setVisibleIndex and resets
   // the values. visibleMiddleIndexRef will hold on to this value so it can be used once the listRef
   // is defined and we can call scrollToItem.
   const visibleMiddleIndexRef = useRef(visibleMiddleIndex)

--- a/static/src/js/components/EDSCTable/EDSCTable.js
+++ b/static/src/js/components/EDSCTable/EDSCTable.js
@@ -157,7 +157,7 @@ const EDSCTable = ({
   const infiniteLoaderRef = useRef(null)
 
   // If visibleMiddleIndex is set, that means we want to scroll to a particular item. react-window
-  // will immediatly render the items at the default index, which calls setVisibleIndex and resets
+  // will immediately render the items at the default index, which calls setVisibleIndex and resets
   // the values. visibleMiddleIndexRef will hold on to this value so it can be used once the listRef
   // is defined and we can call scrollToItem.
   const visibleMiddleIndexRef = useRef(visibleMiddleIndex)

--- a/static/src/js/components/GranuleImage/GranuleImage.js
+++ b/static/src/js/components/GranuleImage/GranuleImage.js
@@ -14,12 +14,9 @@ import './GranuleImage.scss'
  * @param {String} imageSrc - The image source.
  */
 
-// todo this should just inherit things from the parent container
-
 export const GranuleImage = ({
   imageSrc
 }) => {
-  console.log('🚀 ~ file: GranuleImage.js:23 ~ imageSrc:', imageSrc)
   const [isOpen, setIsOpen] = useState(true)
   const [isLoaded, setIsLoaded] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -36,46 +33,21 @@ export const GranuleImage = ({
   })
 
   const handleToggleImage = (() => {
-    // todo Set state to the opposite state it is currently in
-    // const [isOpen, setIsOpen] = useState(!isOpen)
-    console.log('🚀 ~ file: GranuleImage.js:43 ~ handleToggleImage ~ isOpen:', isOpen)
-    // const toggleIsOpen = (isOpen) => !isOpen
     setIsOpen(!isOpen)
-    // todo why does this work but, not show up in console?
-    console.log('🚀 ~ file: GranuleImage.js:45 ~ handleToggleImage ~ isOpen:', isOpen)
   })
 
-  // todo set these values here
-
-  // todo functions for managing state switches
   const handleImageLoaded = (() => {
-  // this.setState({
-    //   isLoaded: true,
-    //   isLoading: false,
-    //   isErrored: false
-    // })
-    // const [isLoaded, setIsLoaded] = useState(true)
-    // const [isLoading, setIsLoading] = useState(false)
-    // const [isErrored, setIsErrored] = useState(true)
     setIsLoaded(true)
     setIsLoading(false)
     setIsErrored(false)
   })
 
   const handleImageErrored = (() => {
-    // this.setState({
-    //   isLoaded: false,
-    //   isLoading: false,
-    //   isErrored: true
-    // })
-    // const [isLoaded, setIsLoaded] = useState(false)
-    // const [isLoading, setIsLoading] = useState(false)
-    // const [isErrored, setIsErrored] = useState(true)
     setIsLoaded(false)
     setIsLoading(false)
     setIsErrored(true)
   })
-  // todo wait for the image to load
+
   const loadImage = () => {
     setIsErrored(false)
     setIsLoaded(false)
@@ -135,130 +107,6 @@ export const GranuleImage = ({
     </div>
   )
 }
-
-// class GranuleImage extends Component {
-//   constructor(props) {
-//     super(props)
-
-//     this.state = {
-//       isOpen: true,
-//       isLoaded: false,
-//       isLoading: true,
-//       isErrored: false
-//     }
-
-//     this.handleToggleImage = this.handleToggleImage.bind(this)
-//     this.handleImageLoaded = this.handleImageLoaded.bind(this)
-//     this.handleImageErrored = this.handleImageErrored.bind(this)
-//   }
-
-//   UNSAFE_componentWillReceiveProps(nextProps) {
-//     const { imageSrc } = this.props
-//     const { imageSrc: nextImageSrc } = nextProps
-//     if (nextImageSrc && imageSrc !== nextImageSrc) {
-//       this.setState({
-//         isLoaded: false,
-//         isLoading: true,
-//         isErrored: false
-//       })
-//     }
-//   }
-
-//   handleToggleImage() {
-//     const {
-//       isOpen
-//     } = this.state
-
-//     this.setState({
-//       isOpen: !isOpen
-//     })
-//   }
-
-//   handleImageLoaded() {
-//     this.setState({
-//       isLoaded: true,
-//       isLoading: false,
-//       isErrored: false
-//     })
-//   }
-
-//   handleImageErrored() {
-//     this.setState({
-//       isLoaded: false,
-//       isLoading: false,
-//       isErrored: true
-//     })
-//   }
-
-//   render() {
-//     const {
-//       isErrored,
-//       isLoaded,
-//       isLoading,
-//       isOpen
-//     } = this.state
-
-//     const { imageSrc } = this.props
-
-//     const containerClassName = classNames({
-//       'granule-image': true,
-//       'granule-image--is-open': isOpen
-//     })
-
-//     const imageClassName = classNames({
-//       'granule-image__image': true,
-//       'granule-image__image--is-loaded': isLoaded
-//     })
-
-//     if (!imageSrc) return null
-
-//     return (
-//       <div className={containerClassName}>
-//         {
-//           isOpen ? (
-//             <Button
-//               className="granule-image__button granule-image__button--close"
-//               icon={FaTimes}
-//               onClick={this.handleToggleImage}
-//               label="Close browse image"
-//             />
-//           ) : (
-//             <Button
-//               className="granule-image__button granule-image__button--open"
-//               icon={FaPlus}
-//               onClick={this.handleToggleImage}
-//               label="Open browse image"
-//             />
-//           )
-//         }
-//         <div className="granule-image__container">
-//           {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
-//           <img
-//             className={imageClassName}
-//             src={imageSrc}
-//             alt="Browse Image"
-//             onLoad={this.handleImageLoaded}
-//             onError={this.handleImageErrored}
-//           />
-//           {
-//             isLoading && (
-//               <div className="granule-image__placeholder">
-//                 <Spinner type="dots" color="green" size="small" />
-//               </div>
-//             )
-//           }
-//           {
-//             isErrored && (
-//               <div className="granule-image__placeholder">
-//                 <span>Error loading granule image</span>
-//               </div>
-//             )
-//           }
-//         </div>
-//       </div>
-//     )
-//   }
-// }
 
 GranuleImage.propTypes = {
   imageSrc: PropTypes.string.isRequired

--- a/static/src/js/components/GranuleImage/GranuleImage.js
+++ b/static/src/js/components/GranuleImage/GranuleImage.js
@@ -9,11 +9,11 @@ import Spinner from '../Spinner/Spinner'
 import './GranuleImage.scss'
 
 /**
- * Renders GranuleImage.
+ * Renders GranuleImage component. This component displays the image of a granule if it has one
+ * the image can be open or closed with buttons
  * @param {Object} props - The props passed into the component.
- * @param {String} imageSrc - The image source.
+ * @param {String} props.imageSrc - The image source.
  */
-
 export const GranuleImage = ({
   imageSrc
 }) => {
@@ -48,28 +48,26 @@ export const GranuleImage = ({
     setIsErrored(true)
   })
 
-  const loadImage = () => {
+  // When the imageSrc changes value then load the new image
+  useEffect(() => {
     setIsErrored(false)
     setIsLoaded(false)
     setIsLoading(true)
-  }
-
-  // When the imageSrc changes value then load the new image
-  useEffect(() => {
-    loadImage()
   }, [imageSrc])
 
   if (!imageSrc) return null
 
   return (
-    <div className={containerClassName}>
+    <div
+      className={containerClassName}
+    >
       { isOpen ? (
         <Button
           className="granule-image__button granule-image__button--close"
           icon={FaTimes}
           onClick={handleToggleImage}
           label="Close browse image"
-          data-testid="granule-image__button granule-image__button--close"
+          dataTestId="granule-image__button--close"
         />
       ) : (
         <Button
@@ -77,10 +75,13 @@ export const GranuleImage = ({
           icon={FaPlus}
           onClick={handleToggleImage}
           label="Open browse image"
-          data-testid="granule-image__button granule-image__button--open"
+          dataTestId="granule-image__button--open"
         />
       )}
-      <div className="granule-image__container">
+      <div
+        className="granule-image__container"
+        data-testid="granule-image"
+      >
         {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
         <img
           className={imageClassName}

--- a/static/src/js/components/GranuleImage/GranuleImage.js
+++ b/static/src/js/components/GranuleImage/GranuleImage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { FaPlus, FaTimes } from 'react-icons/fa'
@@ -13,129 +13,252 @@ import './GranuleImage.scss'
  * @param {Object} props - The props passed into the component.
  * @param {String} imageSrc - The image source.
  */
-class GranuleImage extends Component {
-  constructor(props) {
-    super(props)
 
-    this.state = {
-      isOpen: true,
-      isLoaded: false,
-      isLoading: true,
-      isErrored: false
-    }
+// todo this should just inherit things from the parent container
 
-    this.handleToggleImage = this.handleToggleImage.bind(this)
-    this.handleImageLoaded = this.handleImageLoaded.bind(this)
-    this.handleImageErrored = this.handleImageErrored.bind(this)
+export const GranuleImage = ({
+  imageSrc
+}) => {
+  console.log('🚀 ~ file: GranuleImage.js:23 ~ imageSrc:', imageSrc)
+  const [isOpen, setIsOpen] = useState(true)
+  const [isLoaded, setIsLoaded] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isErrored, setIsErrored] = useState(false)
+
+  const containerClassName = classNames({
+    'granule-image': true,
+    'granule-image--is-open': isOpen
+  })
+
+  const imageClassName = classNames({
+    'granule-image__image': true,
+    'granule-image__image--is-loaded': isLoaded
+  })
+
+  const handleToggleImage = (() => {
+    // todo Set state to the opposite state it is currently in
+    // const [isOpen, setIsOpen] = useState(!isOpen)
+    console.log('🚀 ~ file: GranuleImage.js:43 ~ handleToggleImage ~ isOpen:', isOpen)
+    // const toggleIsOpen = (isOpen) => !isOpen
+    setIsOpen(!isOpen)
+    // todo why does this work but, not show up in console?
+    console.log('🚀 ~ file: GranuleImage.js:45 ~ handleToggleImage ~ isOpen:', isOpen)
+  })
+
+  // todo set these values here
+
+  // todo functions for managing state switches
+  const handleImageLoaded = (() => {
+  // this.setState({
+    //   isLoaded: true,
+    //   isLoading: false,
+    //   isErrored: false
+    // })
+    // const [isLoaded, setIsLoaded] = useState(true)
+    // const [isLoading, setIsLoading] = useState(false)
+    // const [isErrored, setIsErrored] = useState(true)
+    setIsLoaded(true)
+    setIsLoading(false)
+    setIsErrored(false)
+  })
+
+  const handleImageErrored = (() => {
+    // this.setState({
+    //   isLoaded: false,
+    //   isLoading: false,
+    //   isErrored: true
+    // })
+    // const [isLoaded, setIsLoaded] = useState(false)
+    // const [isLoading, setIsLoading] = useState(false)
+    // const [isErrored, setIsErrored] = useState(true)
+    setIsLoaded(false)
+    setIsLoading(false)
+    setIsErrored(true)
+  })
+  // todo wait for the image to load
+  const loadImage = () => {
+    setIsErrored(false)
+    setIsLoaded(false)
+    setIsLoading(true)
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { imageSrc } = this.props
-    const { imageSrc: nextImageSrc } = nextProps
-    if (nextImageSrc && imageSrc !== nextImageSrc) {
-      this.setState({
-        isLoaded: false,
-        isLoading: true,
-        isErrored: false
-      })
-    }
-  }
+  // When the imageSrc changes value then load the new image
+  useEffect(() => {
+    loadImage()
+  }, [imageSrc])
 
-  handleToggleImage() {
-    const {
-      isOpen
-    } = this.state
+  if (!imageSrc) return null
 
-    this.setState({
-      isOpen: !isOpen
-    })
-  }
-
-  handleImageLoaded() {
-    this.setState({
-      isLoaded: true,
-      isLoading: false,
-      isErrored: false
-    })
-  }
-
-  handleImageErrored() {
-    this.setState({
-      isLoaded: false,
-      isLoading: false,
-      isErrored: true
-    })
-  }
-
-  render() {
-    const {
-      isErrored,
-      isLoaded,
-      isLoading,
-      isOpen
-    } = this.state
-
-    const { imageSrc } = this.props
-
-    const containerClassName = classNames({
-      'granule-image': true,
-      'granule-image--is-open': isOpen
-    })
-
-    const imageClassName = classNames({
-      'granule-image__image': true,
-      'granule-image__image--is-loaded': isLoaded
-    })
-
-    if (!imageSrc) return null
-
-    return (
-      <div className={containerClassName}>
+  return (
+    <div className={containerClassName}>
+      { isOpen ? (
+        <Button
+          className="granule-image__button granule-image__button--close"
+          icon={FaTimes}
+          onClick={handleToggleImage}
+          label="Close browse image"
+          data-testid="granule-image__button granule-image__button--close"
+        />
+      ) : (
+        <Button
+          className="granule-image__button granule-image__button--open"
+          icon={FaPlus}
+          onClick={handleToggleImage}
+          label="Open browse image"
+          data-testid="granule-image__button granule-image__button--open"
+        />
+      )}
+      <div className="granule-image__container">
+        {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
+        <img
+          className={imageClassName}
+          src={imageSrc}
+          alt="Browse Image"
+          onLoad={handleImageLoaded}
+          onError={handleImageErrored}
+        />
         {
-          isOpen ? (
-            <Button
-              className="granule-image__button granule-image__button--close"
-              icon={FaTimes}
-              onClick={this.handleToggleImage}
-              label="Close browse image"
-            />
-          ) : (
-            <Button
-              className="granule-image__button granule-image__button--open"
-              icon={FaPlus}
-              onClick={this.handleToggleImage}
-              label="Open browse image"
-            />
+          isLoading && (
+            <div className="granule-image__placeholder">
+              <Spinner type="dots" color="white" size="small" />
+            </div>
           )
         }
-        <div className="granule-image__container">
-          {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
-          <img
-            className={imageClassName}
-            src={imageSrc}
-            alt="Browse Image"
-            onLoad={this.handleImageLoaded}
-            onError={this.handleImageErrored}
-          />
-          {
-            isLoading && (
-              <div className="granule-image__placeholder">
-                <Spinner type="dots" color="white" size="small" />
-              </div>
-            )
-          }
-          {
-            isErrored && (
-              <div className="granule-image__placeholder">
-                <span>Error loading granule image</span>
-              </div>
-            )
-          }
-        </div>
+        {
+          isErrored && (
+            <div className="granule-image__placeholder">
+              <span>Error loading granule image</span>
+            </div>
+          )
+        }
       </div>
-    )
-  }
+    </div>
+  )
 }
+
+// class GranuleImage extends Component {
+//   constructor(props) {
+//     super(props)
+
+//     this.state = {
+//       isOpen: true,
+//       isLoaded: false,
+//       isLoading: true,
+//       isErrored: false
+//     }
+
+//     this.handleToggleImage = this.handleToggleImage.bind(this)
+//     this.handleImageLoaded = this.handleImageLoaded.bind(this)
+//     this.handleImageErrored = this.handleImageErrored.bind(this)
+//   }
+
+//   UNSAFE_componentWillReceiveProps(nextProps) {
+//     const { imageSrc } = this.props
+//     const { imageSrc: nextImageSrc } = nextProps
+//     if (nextImageSrc && imageSrc !== nextImageSrc) {
+//       this.setState({
+//         isLoaded: false,
+//         isLoading: true,
+//         isErrored: false
+//       })
+//     }
+//   }
+
+//   handleToggleImage() {
+//     const {
+//       isOpen
+//     } = this.state
+
+//     this.setState({
+//       isOpen: !isOpen
+//     })
+//   }
+
+//   handleImageLoaded() {
+//     this.setState({
+//       isLoaded: true,
+//       isLoading: false,
+//       isErrored: false
+//     })
+//   }
+
+//   handleImageErrored() {
+//     this.setState({
+//       isLoaded: false,
+//       isLoading: false,
+//       isErrored: true
+//     })
+//   }
+
+//   render() {
+//     const {
+//       isErrored,
+//       isLoaded,
+//       isLoading,
+//       isOpen
+//     } = this.state
+
+//     const { imageSrc } = this.props
+
+//     const containerClassName = classNames({
+//       'granule-image': true,
+//       'granule-image--is-open': isOpen
+//     })
+
+//     const imageClassName = classNames({
+//       'granule-image__image': true,
+//       'granule-image__image--is-loaded': isLoaded
+//     })
+
+//     if (!imageSrc) return null
+
+//     return (
+//       <div className={containerClassName}>
+//         {
+//           isOpen ? (
+//             <Button
+//               className="granule-image__button granule-image__button--close"
+//               icon={FaTimes}
+//               onClick={this.handleToggleImage}
+//               label="Close browse image"
+//             />
+//           ) : (
+//             <Button
+//               className="granule-image__button granule-image__button--open"
+//               icon={FaPlus}
+//               onClick={this.handleToggleImage}
+//               label="Open browse image"
+//             />
+//           )
+//         }
+//         <div className="granule-image__container">
+//           {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
+//           <img
+//             className={imageClassName}
+//             src={imageSrc}
+//             alt="Browse Image"
+//             onLoad={this.handleImageLoaded}
+//             onError={this.handleImageErrored}
+//           />
+//           {
+//             isLoading && (
+//               <div className="granule-image__placeholder">
+//                 <Spinner type="dots" color="green" size="small" />
+//               </div>
+//             )
+//           }
+//           {
+//             isErrored && (
+//               <div className="granule-image__placeholder">
+//                 <span>Error loading granule image</span>
+//               </div>
+//             )
+//           }
+//         </div>
+//       </div>
+//     )
+//   }
+// }
 
 GranuleImage.propTypes = {
   imageSrc: PropTypes.string.isRequired

--- a/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
+++ b/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
@@ -1,70 +1,161 @@
 import React from 'react'
 import Enzyme, { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
 import GranuleImage from '../GranuleImage'
+import configureStore from '../../../store/configureStore'
 
-Enzyme.configure({ adapter: new Adapter() })
+const store = configureStore()
 
-function setup(overrideProps) {
-  const props = {
-    imageSrc: '',
-    ...overrideProps
-  }
-
-  const enzymeWrapper = shallow(<GranuleImage {...props} />)
-
-  return {
-    enzymeWrapper,
-    props
-  }
+const setup = (props) => {
+  act(() => {
+    render(
+      <Provider store={store}>
+        <GranuleImage imageSrc={props.imageSrc} />
+      </Provider>
+    )
+  })
 }
-
+// todo make sure this is actually covering the test case and
+// todo not just passing because it is null
 describe('GranuleImage component', () => {
   describe('when no image is present', () => {
     test('renders itself correctly', () => {
-      const { enzymeWrapper } = setup()
-
-      expect(enzymeWrapper.type()).toBe(null)
+      const props = {
+        imageSrc: ''
+      }
+      setup(props)
+      // const granuleImage = screen.getByRole('GranuleImage')
+      // expect(screen.queryByText('GranuleImage')).toBeNull()
+      // expect(screen.getByRole('img')).not().toHaveClass('granule-image__image')
+      // expect(screen.getByRole('img')).toBeNull()
+      expect(screen.queryByRole('button')).toBeNull()
+      // expect(setup(props)).toBeNull()
     })
   })
 
   describe('when an image is present', () => {
     test('renders itself correctly', () => {
-      const { enzymeWrapper } = setup({
+      const props = {
         imageSrc: '/some/image/src'
-      })
-
-      expect(enzymeWrapper.type()).toBe('div')
-    })
-  })
-
-  describe('buttons', () => {
-    test('when clicking the close button, closes the image', () => {
-      const { enzymeWrapper } = setup({
-        imageSrc: '/some/image/src'
-      })
-
-      expect(enzymeWrapper.state().isOpen).toEqual(true)
-
-      enzymeWrapper.find('.granule-image__button').simulate('click')
-
-      expect(enzymeWrapper.state().isOpen).toEqual(false)
-    })
-
-    test('when clicking the open button, closes the image', () => {
-      const { enzymeWrapper } = setup({
-        imageSrc: '/some/image/src'
-      })
-
-      enzymeWrapper.setState({
-        isOpen: false
-      })
-
-      expect(enzymeWrapper.state().isOpen).toEqual(false)
-
-      enzymeWrapper.find('.granule-image__button').simulate('click')
-
-      expect(enzymeWrapper.state().isOpen).toEqual(true)
+      }
+      setup(props)
+      // todo should we be using test-ids?
+      expect(screen.queryByRole('button')).toBeTruthy()
+      // expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
+      // expect(screen.getByRole('img')).toHaveClass('granule-image__image')
     })
   })
 })
+
+describe('buttons', () => {
+  test('when clicking the close button, closes the image', async () => {
+    const newProps = {
+      imageSrc: '/some/image/src'
+    }
+    const user = userEvent.setup()
+    setup(newProps)
+    const closeButton = screen.getByRole('button')
+    // console.log('🐨 ~ file: GranuleImage.test.js:68 ~ test.only ~ closebutton1:', closebutton1)
+    // const closeButton = screen.queryByTestId('granule-image__button granule-image__button--close')
+    console.log('🚀 ~ file: GranuleImage.test.js:68 ~ test ~ closeButton:', closeButton)
+    // todo mock the handle toggleImage
+    await user.click(closeButton)
+    // close button is gone and has been toggled so now the only button is the open button
+    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
+  })
+
+  test('when clicking the open button, opens the image', async () => {
+    const props = {
+      imageSrc: '/some/image/src'
+    }
+    const user = userEvent.setup()
+    setup(props)
+    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
+    const closeButton = screen.getByRole('button')
+    await user.click(closeButton)
+
+    // todo now only the open button is in here
+    const openButton = screen.getByRole('button')
+    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
+    await user.click(openButton)
+    console.log('🚀 ~ file: GranuleImage.test.js:89 ~ test ~ openButton:', openButton)
+    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
+    // expect(screen.getByRole('img')).toHaveClass('granule-image__image')
+  })
+})
+
+// Enzyme.configure({ adapter: new Adapter() })
+
+// function setup(overrideProps) {
+//   const props = {
+//     imageSrc: '',
+//     ...overrideProps
+//   }
+
+//   const enzymeWrapper = shallow(<GranuleImage {...props} />)
+
+//   return {
+//     enzymeWrapper,
+//     props
+//   }
+// }
+
+// describe('GranuleImage component', () => {
+//   describe('when no image is present', () => {
+//     test('renders itself correctly', () => {
+//       const { enzymeWrapper } = setup()
+
+//       expect(enzymeWrapper.type()).toBe(null)
+//     })
+//   })
+
+//   describe('when an image is present', () => {
+//     test('renders itself correctly', () => {
+//       const { enzymeWrapper } = setup({
+//         imageSrc: '/some/image/src'
+//       })
+
+//       expect(enzymeWrapper.type()).toBe('div')
+//     })
+//   })
+
+//   describe('buttons', () => {
+//     test('when clicking the close button, closes the image', () => {
+//       const { enzymeWrapper } = setup({
+//         imageSrc: '/some/image/src'
+//       })
+
+//       expect(enzymeWrapper.state().isOpen).toEqual(true)
+
+//       enzymeWrapper.find('.granule-image__button').simulate('click')
+
+//       expect(enzymeWrapper.state().isOpen).toEqual(false)
+//     })
+
+//     test('when clicking the open button, closes the image', () => {
+//       const { enzymeWrapper } = setup({
+//         imageSrc: '/some/image/src'
+//       })
+
+//       enzymeWrapper.setState({
+//         isOpen: false
+//       })
+
+//       expect(enzymeWrapper.state().isOpen).toEqual(false)
+
+//       enzymeWrapper.find('.granule-image__button').simulate('click')
+
+//       expect(enzymeWrapper.state().isOpen).toEqual(true)
+//     })
+//   })
+// })

--- a/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
+++ b/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
@@ -1,32 +1,21 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import { Provider } from 'react-redux'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import {
-  fireEvent,
   render,
-  screen,
-  waitFor,
+  screen
 } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import GranuleImage from '../GranuleImage'
-import configureStore from '../../../store/configureStore'
-
-const store = configureStore()
 
 const setup = (props) => {
   act(() => {
     render(
-      <Provider store={store}>
-        <GranuleImage imageSrc={props.imageSrc} />
-      </Provider>
+      <GranuleImage imageSrc={props.imageSrc} />
     )
   })
 }
-// todo make sure this is actually covering the test case and
-// todo not just passing because it is null
+
 describe('GranuleImage component', () => {
   describe('when no image is present', () => {
     test('renders itself correctly', () => {
@@ -34,12 +23,7 @@ describe('GranuleImage component', () => {
         imageSrc: ''
       }
       setup(props)
-      // const granuleImage = screen.getByRole('GranuleImage')
-      // expect(screen.queryByText('GranuleImage')).toBeNull()
-      // expect(screen.getByRole('img')).not().toHaveClass('granule-image__image')
-      // expect(screen.getByRole('img')).toBeNull()
       expect(screen.queryByRole('button')).toBeNull()
-      // expect(setup(props)).toBeNull()
     })
   })
 
@@ -49,28 +33,20 @@ describe('GranuleImage component', () => {
         imageSrc: '/some/image/src'
       }
       setup(props)
-      // todo should we be using test-ids?
       expect(screen.queryByRole('button')).toBeTruthy()
-      // expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
-      // expect(screen.getByRole('img')).toHaveClass('granule-image__image')
     })
   })
 })
 
 describe('buttons', () => {
   test('when clicking the close button, closes the image', async () => {
-    const newProps = {
+    const props = {
       imageSrc: '/some/image/src'
     }
     const user = userEvent.setup()
-    setup(newProps)
+    setup(props)
     const closeButton = screen.getByRole('button')
-    // console.log('🐨 ~ file: GranuleImage.test.js:68 ~ test.only ~ closebutton1:', closebutton1)
-    // const closeButton = screen.queryByTestId('granule-image__button granule-image__button--close')
-    console.log('🚀 ~ file: GranuleImage.test.js:68 ~ test ~ closeButton:', closeButton)
-    // todo mock the handle toggleImage
     await user.click(closeButton)
-    // close button is gone and has been toggled so now the only button is the open button
     expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
   })
 
@@ -84,78 +60,9 @@ describe('buttons', () => {
     const closeButton = screen.getByRole('button')
     await user.click(closeButton)
 
-    // todo now only the open button is in here
     const openButton = screen.getByRole('button')
     expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
     await user.click(openButton)
-    console.log('🚀 ~ file: GranuleImage.test.js:89 ~ test ~ openButton:', openButton)
     expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
-    // expect(screen.getByRole('img')).toHaveClass('granule-image__image')
   })
 })
-
-// Enzyme.configure({ adapter: new Adapter() })
-
-// function setup(overrideProps) {
-//   const props = {
-//     imageSrc: '',
-//     ...overrideProps
-//   }
-
-//   const enzymeWrapper = shallow(<GranuleImage {...props} />)
-
-//   return {
-//     enzymeWrapper,
-//     props
-//   }
-// }
-
-// describe('GranuleImage component', () => {
-//   describe('when no image is present', () => {
-//     test('renders itself correctly', () => {
-//       const { enzymeWrapper } = setup()
-
-//       expect(enzymeWrapper.type()).toBe(null)
-//     })
-//   })
-
-//   describe('when an image is present', () => {
-//     test('renders itself correctly', () => {
-//       const { enzymeWrapper } = setup({
-//         imageSrc: '/some/image/src'
-//       })
-
-//       expect(enzymeWrapper.type()).toBe('div')
-//     })
-//   })
-
-//   describe('buttons', () => {
-//     test('when clicking the close button, closes the image', () => {
-//       const { enzymeWrapper } = setup({
-//         imageSrc: '/some/image/src'
-//       })
-
-//       expect(enzymeWrapper.state().isOpen).toEqual(true)
-
-//       enzymeWrapper.find('.granule-image__button').simulate('click')
-
-//       expect(enzymeWrapper.state().isOpen).toEqual(false)
-//     })
-
-//     test('when clicking the open button, closes the image', () => {
-//       const { enzymeWrapper } = setup({
-//         imageSrc: '/some/image/src'
-//       })
-
-//       enzymeWrapper.setState({
-//         isOpen: false
-//       })
-
-//       expect(enzymeWrapper.state().isOpen).toEqual(false)
-
-//       enzymeWrapper.find('.granule-image__button').simulate('click')
-
-//       expect(enzymeWrapper.state().isOpen).toEqual(true)
-//     })
-//   })
-// })

--- a/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
+++ b/static/src/js/components/GranuleImage/__tests__/GranuleImage.test.js
@@ -3,17 +3,14 @@ import {
   render,
   screen
 } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import GranuleImage from '../GranuleImage'
 
 const setup = (props) => {
-  act(() => {
-    render(
-      <GranuleImage imageSrc={props.imageSrc} />
-    )
-  })
+  render(
+    <GranuleImage imageSrc={props.imageSrc} />
+  )
 }
 
 describe('GranuleImage component', () => {
@@ -23,7 +20,8 @@ describe('GranuleImage component', () => {
         imageSrc: ''
       }
       setup(props)
-      expect(screen.queryByRole('button')).toBeNull()
+      // getByTestId will return an error if it cannot find element queryBy returns null if it cannot
+      expect(screen.queryByTestId('granule-image')).toBeNull()
     })
   })
 
@@ -33,7 +31,7 @@ describe('GranuleImage component', () => {
         imageSrc: '/some/image/src'
       }
       setup(props)
-      expect(screen.queryByRole('button')).toBeTruthy()
+      expect(screen.getByTestId('granule-image')).toBeTruthy()
     })
   })
 })
@@ -45,9 +43,9 @@ describe('buttons', () => {
     }
     const user = userEvent.setup()
     setup(props)
-    const closeButton = screen.getByRole('button')
+    const closeButton = screen.getByTestId('granule-image__button--close')
     await user.click(closeButton)
-    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
+    expect(screen.getByTestId('granule-image__button--open')).toBeTruthy()
   })
 
   test('when clicking the open button, opens the image', async () => {
@@ -56,13 +54,11 @@ describe('buttons', () => {
     }
     const user = userEvent.setup()
     setup(props)
-    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
-    const closeButton = screen.getByRole('button')
+    const closeButton = screen.getByTestId('granule-image__button--close')
     await user.click(closeButton)
 
-    const openButton = screen.getByRole('button')
-    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--open')
+    const openButton = screen.getByTestId('granule-image__button--open')
     await user.click(openButton)
-    expect(screen.getByRole('button')).toHaveClass('granule-image__button granule-image__button--close')
+    expect(screen.getByTestId('granule-image__button--close')).toBeTruthy()
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Convert class components to functional components (GranuleImage)

### What is the Solution?

Changed the class component to use functional components and changed the accompanying test to use
react-testing-library instead of enzyme

### What areas of the application does this impact?

Granule images

# Testing

### Reproduction steps
Select a collection that has images
select a granule and see if the granule image component comes up
ensure that the open and close functionality is working
ensure that loading dots appear if you try to switch between granules and ensure that these
load correctly

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
