### PR TITLE
EDSC-3599: Convert TemporalDisplay and ProjectHeader class components to functional components.

### DIFF
--- a/static/src/js/components/ProjectCollections/ProjectHeader.js
+++ b/static/src/js/components/ProjectCollections/ProjectHeader.js
@@ -1,5 +1,10 @@
 /* eslint-disable jsx-a11y/img-redundant-alt */
-import React, { Component } from 'react'
+import React, {
+  memo,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { PropTypes } from 'prop-types'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import abbreviate from 'number-abbreviate'
@@ -18,289 +23,244 @@ import './ProjectHeader.scss'
 
 /**
  * Renders ProjectHeader.
- * @param {object} props - The props passed into the component.
- * @param {object} props.collections - Collections passed from redux store.
- * @param {object} props.project - Project collections passed from redux store.
- * @param {object} props.savedProject - Saved Project information (name) passed from redux store
- * @param {function} props.onUpdateProjectName - Function to updated the saved project name
+ * @param {function} onUpdateProjectName - Function to updated the saved project name
+ * @param {object} project - Project collections passed from redux store.
+ * @param {object} savedProject - Saved Project information (name) passed from redux store
  */
 
-export class ProjectHeader extends Component {
-  constructor(props) {
-    super(props)
+export const ProjectHeader = memo(({
+  onUpdateProjectName,
+  project,
+  savedProject
+}) => {
+  const projectTitleInput = useRef()
+  const projectTitleText = useRef()
 
-    const { savedProject } = props
-    const { name = '' } = savedProject
+  const { name = '' } = savedProject
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [projectName, setProjectName] = useState(name || 'Untitled Project')
 
-    this.state = {
-      isEditingName: false,
-      projectName: name || 'Untitled Project'
+  const renderInput = (() => {
+    const input = projectTitleInput.current
+    const text = projectTitleText.current
+
+    input.style.width = `${text.getBoundingClientRect().width}px`
+  })
+
+  const focusTextField = (() => {
+    projectTitleInput.current.focus()
+  })
+
+  const handleEditClick = (() => {
+    setIsEditingName(true)
+    focusTextField()
+  })
+
+  useEffect(() => {
+    if (isEditingName) {
+      focusTextField()
     }
+    renderInput()
+  }, [isEditingName])
 
-    this.projectTitleInput = React.createRef()
-    this.projectTitleText = React.createRef()
-
-    this.onInputChange = this.onInputChange.bind(this)
-    this.handleNameSubmit = this.handleNameSubmit.bind(this)
-    this.handleEditClick = this.handleEditClick.bind(this)
-    this.handleKeypress = this.handleKeypress.bind(this)
-    this.handleOnFocus = this.handleOnFocus.bind(this)
-    this.focusTextField = this.focusTextField.bind(this)
-    this.handleNameKeyPress = this.handleNameKeyPress.bind(this)
-  }
-
-  componentDidMount() {
-    this.renderInput()
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { savedProject } = this.props
-    const { name = '' } = savedProject
-
-    const { savedProject: nextSavedProject } = nextProps
-    const { name: nextName } = nextSavedProject
-    if (name !== nextName) {
-      this.setState({
-        projectName: nextName
-      },
-      () => this.renderInput())
-    }
-  }
-
-  handleNameSubmit() {
-    const { onUpdateProjectName } = this.props
-    const { projectName } = this.state
-
+  const handleNameSubmit = (() => {
     const newName = projectName || 'Untitled Project'
-
-    this.setState({
-      projectName: newName,
-      isEditingName: false
-    },
-    () => this.renderInput())
-
+    setProjectName(newName)
+    setIsEditingName(false)
+    renderInput()
     onUpdateProjectName(projectName)
-  }
+  })
 
-  handleKeypress(event) {
+  const handleKeypress = ((event) => {
     if (event.key === 'Enter') {
-      this.handleNameSubmit()
+      handleNameSubmit()
       event.stopPropagation()
       event.preventDefault()
     }
-  }
+  })
 
-  handleEditClick() {
-    this.setState({
-      isEditingName: true
-    }, () => this.focusTextField())
-  }
-
-  handleNameKeyPress(e) {
+  const handleNameKeyPress = ((e) => {
     if (e.key === 'Enter') {
-      this.handleEditClick()
+      handleEditClick()
     }
-  }
+  })
 
-  handleOnFocus() {
-    this.setState({ isEditingName: true })
-  }
+  const handleOnFocus = (() => {
+    setIsEditingName(true)
+  })
 
-  onInputChange(event) {
-    this.setState({
-      projectName: event.target.value
-    }, () => this.renderInput())
-  }
+  const onInputChange = ((event) => {
+    setProjectName(event.target.value)
+    renderInput()
+  })
 
-  focusTextField() {
-    this.projectTitleInput.current.focus()
-  }
+  const { collections: projectCollections } = project
+  const {
+    allIds: projectCollectionIds,
+    byId: projectCollectionById
+  } = projectCollections
 
-  renderInput() {
-    const input = this.projectTitleInput.current
-    const text = this.projectTitleText.current
+  let totalGranules = 0
+  let size = 0
 
-    input.style.width = `${text.getBoundingClientRect().width}px`
-  }
+  const granuleLoadingStates = []
 
-  render() {
-    const { isEditingName, projectName } = this.state
-
+  projectCollectionIds.forEach((collectionId) => {
+    const { [collectionId]: projectCollection = {} } = projectCollectionById
+    const { granules = {} } = projectCollection
     const {
-      project
-    } = this.props
+      hits: granulesCount,
+      isLoaded,
+      singleGranuleSize
+    } = granules
 
-    const { collections: projectCollections } = project
+    granuleLoadingStates.push(isLoaded)
 
-    const {
-      allIds: projectCollectionIds,
-      byId: projectCollectionById
-    } = projectCollections
+    totalGranules += granulesCount
 
-    let totalGranules = 0
-    let size = 0
+    const granuleSize = granulesCount * singleGranuleSize
 
-    const granuleLoadingStates = []
-
-    projectCollectionIds.forEach((collectionId) => {
-      // const collection = projectCollectionsMetadata[collectionId]
-      // const { byId: collectionsQueryById } = collectionsQuery
-      // const { [collectionId]: collectionQuery } = collectionsQueryById
-      // const { granules: granuleQuery } = collectionQuery
-
-      const { [collectionId]: projectCollection = {} } = projectCollectionById
-      const { granules = {} } = projectCollection
-      const {
-        hits: granulesCount,
-        isLoaded,
-        singleGranuleSize
-      } = granules
-
-      granuleLoadingStates.push(isLoaded)
-
-      totalGranules += granulesCount
-
-      const granuleSize = granulesCount * singleGranuleSize
-
-      const convertedSize = convertSizeToMB({
-        size: granuleSize,
-        unit: 'MB'
-      })
-
-      size += convertedSize
+    const convertedSize = convertSizeToMB({
+      size: granuleSize,
+      unit: 'MB'
     })
 
-    const totalSize = convertSize(size)
+    size += convertedSize
+  })
 
-    const {
-      size: totalProjectSize,
-      unit: totalUnit
-    } = totalSize
+  const totalSize = convertSize(size)
 
-    const projectHeaderNameClasses = classNames([
-      'project-header__name',
-      {
-        'project-header__name--is-editing': isEditingName
-      }
-    ])
+  const {
+    size: totalProjectSize,
+    unit: totalUnit
+  } = totalSize
 
-    return (
-      <header className="project-header">
-        <div className={projectHeaderNameClasses}>
-          <div className="project-header__name-wrap">
-            <div className="project-header__name-saved">
-              <h2 className="project-header__title">
-                <span
-                  className="project-header__text-wrap"
-                  ref={this.projectTitleText}
-                  onClick={this.handleEditClick}
-                  role="button"
-                  tabIndex={0}
-                  onKeyPress={this.handleNameKeyPress}
-                >
-                  {projectName}
-                </span>
-              </h2>
-            </div>
-            <div className="project-header__name-editing">
-              <input
-                className="project-header__title"
-                name="projectName"
-                value={projectName}
-                onFocus={this.handleOnFocus}
-                onChange={this.onInputChange}
-                onKeyPress={this.handleKeypress}
-                ref={this.projectTitleInput}
-              />
-            </div>
+  const projectHeaderNameClasses = classNames([
+    'project-header__name',
+    {
+      'project-header__name--is-editing': isEditingName
+    }
+  ])
+
+  return (
+    <header className="project-header">
+      <div className={projectHeaderNameClasses}>
+        <div className="project-header__name-wrap">
+          <div className="project-header__name-saved">
+            <h2 className="project-header__title">
+              <span
+                className="project-header__text-wrap"
+                ref={projectTitleText}
+                onClick={handleEditClick}
+                role="button"
+                tabIndex={0}
+                data-testid="project-header__span"
+                onKeyUp={handleNameKeyPress}
+              >
+                {projectName}
+              </span>
+            </h2>
           </div>
-          {
-            isEditingName && (
-              <button
-                type="button"
-                className="project-header__button project-header__button--submit"
-                label="Submit project name"
-                onClick={this.handleNameSubmit}
-              >
-                <EDSCIcon icon={FaCheck} />
-              </button>
-            )
-          }
-          {
-            !isEditingName && (
-              <button
-                type="button"
-                className="project-header__button project-header__button--edit"
-                label="Edit project name"
-                onClick={this.handleEditClick}
-              >
-                <EDSCIcon icon={FaEdit} />
-              </button>
-            )
-          }
+          <div className="project-header__name-editing">
+            <input
+              className="project-header__title"
+              name="projectName"
+              value={projectName}
+              onFocus={handleOnFocus}
+              onChange={onInputChange}
+              onKeyUp={handleKeypress}
+              ref={projectTitleInput}
+            />
+          </div>
         </div>
         {
-          granuleLoadingStates.every((isLoaded) => isLoaded === true) ? (
-            <ul className="project-header__stats-list">
-              <li
-                className="project-header__stats-item project-header__stats-item--granules"
-              >
-                <span className="project-header__stats-val">
-                  {`${abbreviate(totalGranules, 1)} `}
-                </span>
-                {pluralize('Granule', totalGranules)}
-              </li>
-              <li
-                className="project-header__stats-item project-header__stats-item--collections"
-              >
-                <span className="project-header__stats-val">
-                  {`${commafy(projectCollectionIds.length)} `}
-                </span>
-                {pluralize('Collection', projectCollectionIds.length)}
-              </li>
-              <li
-                className="project-header__stats-item project-header__stats-item--size"
-              >
-                <span className="project-header__stats-val">
-                  {`${totalProjectSize} `}
-                </span>
-                {totalUnit}
-
-                <OverlayTrigger
-                  placement="right"
-                  overlay={(
-                    <Tooltip
-                      className="tooltip--large tooltip--ta-left tooltip--wide"
-                    >
-                      This is the estimated overall size of your project. If no size
-                      information exists in a granule&apos;s metadata, it will not be
-                      included in this number. The size is estimated based upon the
-                      first 20 granules added to your project from each collection.
-                    </Tooltip>
-                  )}
-                >
-                  <EDSCIcon icon={FaInfoCircle} className="project-header__stats-icon" />
-                </OverlayTrigger>
-              </li>
-            </ul>
-          ) : (
-            <Skeleton
-              containerStyle={{
-                height: '21px',
-                width: '100%'
-              }}
-              shapes={projectHeader}
-            />
+          isEditingName && (
+            <button
+              type="button"
+              className="project-header__button project-header__button--submit"
+              label="Submit project name"
+              data-testid="submit_button"
+              onClick={handleNameSubmit}
+            >
+              <EDSCIcon icon={FaCheck} />
+            </button>
           )
         }
+        {
+          !isEditingName && (
+            <button
+              type="button"
+              className="project-header__button project-header__button--edit"
+              label="Edit project name"
+              data-testid="edit_button"
+              onClick={handleEditClick}
+            >
+              <EDSCIcon icon={FaEdit} />
+            </button>
+          )
+        }
+      </div>
+      {
+        granuleLoadingStates.every((isLoaded) => isLoaded === true) ? (
+          <ul className="project-header__stats-list">
+            <li
+              className="project-header__stats-item project-header__stats-item--granules"
+            >
+              <span className="project-header__stats-val">
+                {`${abbreviate(totalGranules, 1)} `}
+              </span>
+              {pluralize('Granule', totalGranules)}
+            </li>
+            <li
+              className="project-header__stats-item project-header__stats-item--collections"
+            >
+              <span className="project-header__stats-val">
+                {`${commafy(projectCollectionIds.length)} `}
+              </span>
+              {pluralize('Collection', projectCollectionIds.length)}
+            </li>
+            <li
+              className="project-header__stats-item project-header__stats-item--size"
+            >
+              <span className="project-header__stats-val">
+                {`${totalProjectSize} `}
+              </span>
+              {totalUnit}
 
-      </header>
-    )
-  }
-}
+              <OverlayTrigger
+                placement="right"
+                overlay={(
+                  <Tooltip
+                    className="tooltip--large tooltip--ta-left tooltip--wide"
+                  >
+                    This is the estimated overall size of your project. If no size
+                    information exists in a granule&apos;s metadata, it will not be
+                    included in this number. The size is estimated based upon the
+                    first 20 granules added to your project from each collection.
+                  </Tooltip>
+                )}
+              >
+                <EDSCIcon icon={FaInfoCircle} className="project-header__stats-icon" />
+              </OverlayTrigger>
+            </li>
+          </ul>
+        ) : (
+          <Skeleton
+            dataTestId="project-header__skeleton"
+            containerStyle={{
+              height: '21px',
+              width: '100%'
+            }}
+            shapes={projectHeader}
+          />
+        )
+      }
+
+    </header>
+  )
+})
 
 ProjectHeader.propTypes = {
-  collectionsQuery: PropTypes.shape({}).isRequired,
   onUpdateProjectName: PropTypes.func.isRequired,
   project: PropTypes.shape({
     collections: PropTypes.shape({

--- a/static/src/js/components/Skeleton/Skeleton.js
+++ b/static/src/js/components/Skeleton/Skeleton.js
@@ -24,6 +24,7 @@ const normalizeSizeValues = (obj) => mapValues(obj, (value) => {
  */
 export const Skeleton = ({
   className,
+  dataTestId,
   containerStyle,
   shapes,
   variant
@@ -67,6 +68,7 @@ export const Skeleton = ({
   return (
     <div
       className={classes}
+      data-testid={dataTestId}
       style={{ ...normalizedStyles }}
     >
       <div
@@ -80,11 +82,13 @@ export const Skeleton = ({
 
 Skeleton.defaultProps = {
   className: '',
+  dataTestId: undefined,
   variant: null
 }
 
 Skeleton.propTypes = {
   className: PropTypes.string,
+  dataTestId: PropTypes.string,
   containerStyle: PropTypes.shape({}).isRequired,
   shapes: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   variant: PropTypes.string

--- a/static/src/js/components/Skeleton/__tests__/Skeleton.js
+++ b/static/src/js/components/Skeleton/__tests__/Skeleton.js
@@ -58,6 +58,7 @@ function setup(options) {
 
   const props = {
     className: 'test-class',
+    dataTestId: 'test-id',
     containerStyle: testStyles,
     shapes: testSkeleton
   }
@@ -75,6 +76,7 @@ describe('Skeleton component', () => {
     const { enzymeWrapper } = setup()
 
     expect(enzymeWrapper.type()).toBe('div')
+    expect(enzymeWrapper.find({ 'data-testid': 'test-id' })).toBeTruthy()
     expect(enzymeWrapper.hasClass('skeleton')).toBe(true)
     expect(enzymeWrapper.hasClass('test-class')).toBe(true)
   })

--- a/static/src/js/components/TemporalDisplay/TemporalDisplay.js
+++ b/static/src/js/components/TemporalDisplay/TemporalDisplay.js
@@ -1,6 +1,10 @@
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
+import React, {
+  memo,
+  useEffect,
+  useState
+} from 'react'
 import moment from 'moment'
+import PropTypes from 'prop-types'
 import { FaCalendarAlt } from 'react-icons/fa'
 
 import TemporalDisplayEntry from './TemporalDisplayEntry'
@@ -9,103 +13,73 @@ import FilterStackContents from '../FilterStack/FilterStackContents'
 
 import './TemporalDisplay.scss'
 
-class TemporalDisplay extends PureComponent {
-  constructor(props) {
-    super(props)
+/**
+ * Renders TemporalDisplay.
+ * @param {function} onRemoveTimelineFilter - Function to remove temporal display component
+ * @param {String} temporalSearch.endDate - Stopping date for collection search query
+ * @param {Boolean} temporalSearch.isRecurring - Whether the data is collected periodically
+ * @param {String} temporalSearch.startDate - Starting date for collection search query
+ */
+export const TemporalDisplay = memo(({
+  onRemoveTimelineFilter,
+  temporalSearch
+}) => {
+  const [endDate, setEndDate] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [isRecurring, setIsRecurring] = useState(false)
 
-    this.state = {
-      endDate: '',
-      startDate: '',
-      isRecurring: false
-    }
-    this.onTimelineRemove = this.onTimelineRemove.bind(this)
-  }
-
-  componentDidMount() {
-    const {
-      temporalSearch
-    } = this.props
-
-    const { endDate, startDate, isRecurring } = temporalSearch
-
-    this.setState({
-      endDate,
-      startDate,
-      isRecurring
-    })
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const {
-      temporalSearch
-    } = this.props
-
-    if (temporalSearch !== nextProps.temporalSearch) {
-      const { endDate, startDate, isRecurring } = nextProps.temporalSearch
-
-      this.setState({
-        endDate,
-        startDate,
-        isRecurring
-      })
-    }
-  }
-
-  onTimelineRemove() {
-    const { onRemoveTimelineFilter } = this.props
+  const onTimelineRemove = (() => {
     onRemoveTimelineFilter()
+  })
+
+  useEffect(() => {
+    const { endDate, startDate, isRecurring } = temporalSearch
+    setEndDate(endDate)
+    setStartDate(startDate)
+    setIsRecurring(isRecurring)
+  }, [temporalSearch])
+
+  if (!startDate && !endDate) {
+    return null
   }
 
-  render() {
-    const {
-      endDate,
-      startDate,
-      isRecurring
-    } = this.state
+  const format = 'YYYY-MM-DDTHH:m:s.SSSZ'
+  const startDateObject = moment.utc(startDate, format, true)
+  const endDateObject = moment.utc(endDate, format, true)
+  const temporalStartDisplay = startDate
+    ? <TemporalDisplayEntry type="start" startDate={startDateObject} isRecurring={isRecurring} />
+    : null
+  const temporalEndDisplay = endDate
+    ? <TemporalDisplayEntry type="end" endDate={endDateObject} isRecurring={isRecurring} />
+    : null
+  const temporalRangeDisplay = isRecurring
+    ? <TemporalDisplayEntry type="range" startDate={startDateObject} endDate={endDateObject} isRecurring={isRecurring} shouldFormat={false} />
+    : null
 
-    if (!startDate && !endDate) {
-      return null
-    }
-
-    const format = 'YYYY-MM-DDTHH:m:s.SSSZ'
-    const startDateObject = moment.utc(startDate, format, true)
-    const endDateObject = moment.utc(endDate, format, true)
-
-    const temporalStartDisplay = startDate
-      ? <TemporalDisplayEntry type="start" startDate={startDateObject} isRecurring={isRecurring} />
-      : null
-    const temporalEndDisplay = endDate
-      ? <TemporalDisplayEntry type="end" endDate={endDateObject} isRecurring={isRecurring} />
-      : null
-    const temporalRangeDisplay = isRecurring
-      ? <TemporalDisplayEntry type="range" startDate={startDateObject} endDate={endDateObject} isRecurring={isRecurring} shouldFormat={false} />
-      : null
-
-    return (
-      <FilterStackItem
-        icon={FaCalendarAlt}
-        title="Temporal"
-        onRemove={this.onTimelineRemove}
-      >
-        <FilterStackContents
-          body={temporalStartDisplay}
-          title="Start"
-          showLabel
-        />
-        <FilterStackContents
-          body={temporalEndDisplay}
-          title="Stop"
-          showLabel
-        />
-        <FilterStackContents
-          body={temporalRangeDisplay}
-          title="Range"
-          showLabel
-        />
-      </FilterStackItem>
-    )
-  }
-}
+  return (
+    <FilterStackItem
+      icon={FaCalendarAlt}
+      title="Temporal"
+      onRemove={onTimelineRemove}
+    >
+      <FilterStackContents
+        body={temporalStartDisplay}
+        title="Start"
+        showLabel
+      />
+      <FilterStackContents
+        body={temporalEndDisplay}
+        title="Stop"
+        showLabel
+      />
+      <FilterStackContents
+        body={temporalRangeDisplay}
+        title="Range"
+        showLabel
+      />
+    </FilterStackItem>
+  )
+})
 
 TemporalDisplay.defaultProps = {
   temporalSearch: {}


### PR DESCRIPTION
# Overview

### What is the feature?

These components use the deprecated UNSAFE_componentWillReceiveProps() and are a priority for conversion to React functional components. The TemporalDisplay component sets date ranges for collection searches and the ProjectHeader component sets the project name and meta-information about granules for a project.

### What is the Solution?

Functional components use React hooks such as useState and useEffect to substitute the behavior of props and class components.

### What areas of the application does this impact?

The TemporalDisplay and ProjectCollections components are affected by changes to temporalDisplay.js and projectHeader.js

# Testing

### Reproduction steps

To test temporalDisplay.js locally:
1. Open Earthdata Search
2. Click on the calendar icon under the search bar
3. Select variations of start dates, end dates, and isRecurring values and verify that the number of matching collections changes.
4. Check that clicking Remove makes the component go away.

To test projectHeader.js locally:
1. Add some granules to a project
2. Navigate to your project
3. Change the name of the project by clicking on the edit icon and then clicking on the submit icon
4. Change the name of the project by clicking on the project name and then pressing enter on your keyboard
5. Verify that if you add more granules to the project, the information under the project name should update accordingly.

### Attachments
Temporal Display component options 
<img width="909" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/1a762f7f-4c24-4210-8d5b-7ffbb0477e19">
Temporal Display when start and end date set (see Remove button)
<img width="941" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/e2c686f7-b82c-4d10-b7e4-10bc62d2550c">

Add a collection to a project and go to the project
<img width="1728" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/21a7711f-0805-4c96-915b-de937da67ead">
<img width="1725" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/8c401fdb-2b34-4f0b-8143-9f9c042fbe66">
Edit the project name either by clicking on the green area or the red area
<img width="1022" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/d7c8cc16-ed91-4c30-ba68-8d766180ff36">
Press enter or click the check mark to update the project name
<img width="806" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/a511c0c8-1d01-417f-b366-95c8778bcc3d">
Adding more granules should result in different information being displayed about the project size
<img width="1012" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/60fd9667-359d-404b-9080-2d59c5229195">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
