### PR TITLE
EDSC-3596: Convert AuthCallbackContainer AuthTokenContainer and NotFound components to functional components.

### DIFF
--- a/static/src/js/components/Errors/NotFound.js
+++ b/static/src/js/components/Errors/NotFound.js
@@ -1,11 +1,11 @@
-import React, { memo, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { eventEmitter } from '../../events/events'
 import LoggerRequest from '../../util/request/loggerRequest'
 import { locationPropType } from '../../util/propTypes/location'
 
-export const NotFound = memo(({
+export const NotFound = ({
   location
 }) => {
   useEffect(() => {
@@ -13,7 +13,7 @@ export const NotFound = memo(({
     return () => {
       eventEmitter.emit('error.global', false)
     }
-  })
+  }, [])
 
   const guid = uuidv4()
 
@@ -51,7 +51,7 @@ export const NotFound = memo(({
       </div>
     </div>
   )
-})
+}
 
 NotFound.propTypes = {
   location: locationPropType.isRequired

--- a/static/src/js/components/Errors/NotFound.js
+++ b/static/src/js/components/Errors/NotFound.js
@@ -1,59 +1,57 @@
-import React, { Component } from 'react'
+import React, { memo, useEffect } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { eventEmitter } from '../../events/events'
 import LoggerRequest from '../../util/request/loggerRequest'
 import { locationPropType } from '../../util/propTypes/location'
 
-class NotFound extends Component {
-  UNSAFE_componentWillMount() {
+export const NotFound = memo(({
+  location
+}) => {
+  useEffect(() => {
     eventEmitter.emit('error.global', true)
-  }
+    return () => {
+      eventEmitter.emit('error.global', false)
+    }
+  })
 
-  componentWillUnmount() {
-    eventEmitter.emit('error.global', false)
-  }
+  const guid = uuidv4()
 
-  render() {
-    const { location } = this.props
-    const guid = uuidv4()
+  const requestObject = new LoggerRequest()
+  requestObject.log({
+    error: {
+      guid,
+      message: '404 Not Found',
+      location
+    }
+  })
 
-    const requestObject = new LoggerRequest()
-    requestObject.log({
-      error: {
-        guid,
-        message: '404 Not Found',
-        location
-      }
-    })
-
-    return (
-      <div className="wrap">
-        <h2 className="h1">Sorry! The page you were looking for does not exist.</h2>
-        <p>
-          Please refer to the ID
-          {' '}
-          <strong>
-            {guid}
-          </strong>
-          {' '}
-          when contacting
-          {' '}
-          <a href="mailto:support@earthdata.nasa.gov">Earthdata Operations</a>
-          .
-        </p>
-        <p>
-          <a href="/">Click here</a>
-          {' '}
-          to return to the home page.
-        </p>
-        <div className="earth">
-          <div className="orbit" />
-        </div>
+  return (
+    <div className="wrap">
+      <h2 className="h1">Sorry! The page you were looking for does not exist.</h2>
+      <p>
+        Please refer to the ID
+        {' '}
+        <strong>
+          {guid}
+        </strong>
+        {' '}
+        when contacting
+        {' '}
+        <a href="mailto:support@earthdata.nasa.gov">Earthdata Operations</a>
+        .
+      </p>
+      <p>
+        <a href="/">Click here</a>
+        {' '}
+        to return to the home page.
+      </p>
+      <div className="earth">
+        <div className="orbit" />
       </div>
-    )
-  }
-}
+    </div>
+  )
+})
 
 NotFound.propTypes = {
   location: locationPropType.isRequired

--- a/static/src/js/components/Errors/__tests__/NotFound.test.js
+++ b/static/src/js/components/Errors/__tests__/NotFound.test.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import nock from 'nock'
+import { v4 as uuidv4 } from 'uuid'
+import LoggerRequest from '../../../util/request/loggerRequest'
+import '@testing-library/jest-dom'
+
+import NotFound from '../NotFound'
+
+jest.mock('uuid')
+uuidv4.mockImplementation(() => 'mock-request-id')
+
+const setup = (props) => {
+  act(() => {
+    render(
+      <NotFound {...props} />
+    )
+  })
+}
+
+describe('NotFound component', () => {
+  test('should render the NotFound component', () => {
+    nock(/localhost/)
+      .post(/error_logger/)
+      .reply(200)
+
+    const loggerMock = jest.spyOn(LoggerRequest.prototype, 'log')
+
+    setup({
+      location: {
+        search: ''
+      }
+    })
+    expect(screen.getByRole('heading', { name: /Sorry! The page you were looking for does not exist./i })).toBeInTheDocument()
+    expect(loggerMock).toBeCalledTimes(1)
+    expect(loggerMock).toHaveBeenCalledWith({
+      error: {
+        guid: 'mock-request-id',
+        message: '404 Not Found',
+        location: {
+          search: ''
+        }
+      }
+    })
+  })
+})

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { set } from 'tiny-cookie'
 import { connect } from 'react-redux'
 import { parse } from 'qs'
@@ -15,7 +15,7 @@ export const mapStateToProps = (state) => ({
  * the user to the correct location based on where they were trying to get before logging
  * in.
  */
-export const AuthCallbackContainer = memo(({
+export const AuthCallbackContainer = ({
   location
 }) => {
   useEffect(() => {
@@ -37,7 +37,7 @@ export const AuthCallbackContainer = memo(({
   return (
     <div className="route-wrapper" />
   )
-})
+}
 
 AuthCallbackContainer.propTypes = {
   location: locationPropType.isRequired

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import React, { memo, useEffect } from 'react'
 import { set } from 'tiny-cookie'
 import { connect } from 'react-redux'
 import { parse } from 'qs'
@@ -18,19 +18,21 @@ export const mapStateToProps = (state) => ({
 export const AuthCallbackContainer = memo(({
   location
 }) => {
-  const { search } = location
+  useEffect(() => {
+    const { search } = location
 
-  const params = parse(search, { ignoreQueryPrefix: true })
-  const {
-    jwt = '',
-    redirect = '/'
-  } = params
+    const params = parse(search, { ignoreQueryPrefix: true })
+    const {
+      jwt = '',
+      redirect = '/'
+    } = params
 
-  // Set the authToken cookie
-  set('authToken', jwt)
+    // Set the authToken cookie
+    set('authToken', jwt)
 
-  // Redirect the user to the correct location
-  window.location.replace(redirect)
+    // Redirect the user to the correct location
+    window.location.replace(redirect)
+  }, [])
 
   return (
     <div className="route-wrapper" />

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { memo } from 'react'
 import { set } from 'tiny-cookie'
 import { connect } from 'react-redux'
 import { parse } from 'qs'
@@ -15,31 +15,27 @@ export const mapStateToProps = (state) => ({
  * the user to the correct location based on where they were trying to get before logging
  * in.
  */
-export class AuthCallbackContainer extends Component {
-  UNSAFE_componentWillMount() {
-    // Pull the jwt and redirect params out of the URL
-    const { location } = this.props
-    const { search } = location
+export const AuthCallbackContainer = memo(({
+  location
+}) => {
+  const { search } = location
 
-    const params = parse(search, { ignoreQueryPrefix: true })
-    const {
-      jwt = '',
-      redirect = '/'
-    } = params
+  const params = parse(search, { ignoreQueryPrefix: true })
+  const {
+    jwt = '',
+    redirect = '/'
+  } = params
 
-    // Set the authToken cookie
-    set('authToken', jwt)
+  // Set the authToken cookie
+  set('authToken', jwt)
 
-    // Redirect the user to the correct location
-    window.location.replace(redirect)
-  }
+  // Redirect the user to the correct location
+  window.location.replace(redirect)
 
-  render() {
-    return (
-      <div className="route-wrapper" />
-    )
-  }
-}
+  return (
+    <div className="route-wrapper" />
+  )
+})
 
 AuthCallbackContainer.propTypes = {
   location: locationPropType.isRequired

--- a/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
+++ b/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
 import * as tinyCookie from 'tiny-cookie'
 
 import { AuthCallbackContainer, mapStateToProps } from '../AuthCallbackContainer'
 
-Enzyme.configure({ adapter: new Adapter() })
-
-function setup(overrideProps) {
+const setup = (overrideProps) => {
   const props = {
     location: {
       search: '?jwt=mockjwttoken&redirect=http%3A%2F%2Flocalhost%3A8080%2Fsearch'
@@ -15,18 +13,12 @@ function setup(overrideProps) {
     ...overrideProps
   }
 
-  const enzymeWrapper = shallow(<AuthCallbackContainer {...props} />)
-
-  return {
-    enzymeWrapper,
-    props
-  }
+  act(() => {
+    render(
+      <AuthCallbackContainer {...props} />
+    )
+  })
 }
-
-beforeEach(() => {
-  jest.restoreAllMocks()
-  jest.clearAllMocks()
-})
 
 describe('mapStateToProps', () => {
   test('returns the correct state', () => {

--- a/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
+++ b/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'tiny-cookie'
 import { connect } from 'react-redux'
@@ -23,12 +23,14 @@ export const AuthTokenContainer = memo(({
   onSetUserFromJwt,
   onUpdateAuthToken
 }) => {
-  const jwtToken = get('authToken')
+  useEffect(() => {
+    const jwtToken = get('authToken')
 
-  onUpdateAuthToken(jwtToken || '')
-  onSetPreferencesFromJwt(jwtToken)
-  onSetContactInfoFromJwt(jwtToken)
-  onSetUserFromJwt(jwtToken)
+    onUpdateAuthToken(jwtToken || '')
+    onSetPreferencesFromJwt(jwtToken)
+    onSetContactInfoFromJwt(jwtToken)
+    onSetUserFromJwt(jwtToken)
+  }, [])
 
   return children
 })

--- a/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
+++ b/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import { memo } from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'tiny-cookie'
 import { connect } from 'react-redux'
@@ -16,29 +16,22 @@ export const mapDispatchToProps = (dispatch) => ({
     (token) => dispatch(actions.updateAuthToken(token))
 })
 
-export class AuthTokenContainer extends Component {
-  UNSAFE_componentWillMount() {
-    const {
-      onSetContactInfoFromJwt,
-      onSetPreferencesFromJwt,
-      onSetUserFromJwt,
-      onUpdateAuthToken
-    } = this.props
+export const AuthTokenContainer = memo(({
+  children,
+  onSetContactInfoFromJwt,
+  onSetPreferencesFromJwt,
+  onSetUserFromJwt,
+  onUpdateAuthToken
+}) => {
+  const jwtToken = get('authToken')
 
-    const jwtToken = get('authToken')
+  onUpdateAuthToken(jwtToken || '')
+  onSetPreferencesFromJwt(jwtToken)
+  onSetContactInfoFromJwt(jwtToken)
+  onSetUserFromJwt(jwtToken)
 
-    onUpdateAuthToken(jwtToken || '')
-    onSetPreferencesFromJwt(jwtToken)
-    onSetContactInfoFromJwt(jwtToken)
-    onSetUserFromJwt(jwtToken)
-  }
-
-  render() {
-    const { children } = this.props
-
-    return children
-  }
-}
+  return children
+})
 
 AuthTokenContainer.propTypes = {
   children: PropTypes.node.isRequired,

--- a/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
+++ b/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.js
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react'
+import { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'tiny-cookie'
 import { connect } from 'react-redux'
@@ -16,7 +16,7 @@ export const mapDispatchToProps = (dispatch) => ({
     (token) => dispatch(actions.updateAuthToken(token))
 })
 
-export const AuthTokenContainer = memo(({
+export const AuthTokenContainer = ({
   children,
   onSetContactInfoFromJwt,
   onSetPreferencesFromJwt,
@@ -33,7 +33,7 @@ export const AuthTokenContainer = memo(({
   }, [])
 
   return children
-})
+}
 
 AuthTokenContainer.propTypes = {
   children: PropTypes.node.isRequired,

--- a/static/src/js/containers/AuthTokenContainer/__tests__/AuthTokenContainer.test.js
+++ b/static/src/js/containers/AuthTokenContainer/__tests__/AuthTokenContainer.test.js
@@ -1,28 +1,17 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
 import * as tinyCookie from 'tiny-cookie'
 
 import actions from '../../../actions'
 import { AuthTokenContainer, mapDispatchToProps } from '../AuthTokenContainer'
 
-Enzyme.configure({ adapter: new Adapter() })
-
-function setup() {
-  const props = {
-    children: 'children',
-    onSetContactInfoFromJwt: jest.fn(),
-    onSetPreferencesFromJwt: jest.fn(),
-    onSetUserFromJwt: jest.fn(),
-    onUpdateAuthToken: jest.fn()
-  }
-
-  const enzymeWrapper = shallow(<AuthTokenContainer {...props} />)
-
-  return {
-    enzymeWrapper,
-    props
-  }
+const setup = (props) => {
+  act(() => {
+    render(
+      <AuthTokenContainer {...props} />
+    )
+  })
 }
 
 beforeEach(() => {
@@ -78,9 +67,15 @@ describe('AuthTokenContainer component', () => {
       return ''
     })
 
-    const { enzymeWrapper, props } = setup()
+    const props = {
+      children: 'children',
+      onSetContactInfoFromJwt: jest.fn(),
+      onSetPreferencesFromJwt: jest.fn(),
+      onSetUserFromJwt: jest.fn(),
+      onUpdateAuthToken: jest.fn()
+    }
+    setup(props)
 
-    expect(enzymeWrapper).toBeDefined()
     expect(props.onUpdateAuthToken).toHaveBeenCalled()
     expect(props.onUpdateAuthToken.mock.calls[0]).toEqual(['token'])
     expect(props.onSetContactInfoFromJwt).toHaveBeenCalled()


### PR DESCRIPTION
# Overview

### What is the feature?

AuthCallbackContainer, AuthTokenContainer, and NotFound are all class components that use the React UNSAFE_componentWillMount() method. They can be converted to functional components using the useEffect hook instead.

### What is the Solution?

Replaced UNSAFE_componentWillMount() with useEffect, replaced the use of Enzyme testing library with React testing library, added a test for the NotFound component.

### What areas of the application does this impact?

EDL authentication process and Earthdata Search 404 page.

# Testing

### Reproduction steps

To test AuthCallbackContainer and AuthTokenContainer locally:
1. Go to Earthdata Search.
2. Click on the "Earthdata Login" button at the top right and verify that you're at the same page you were on before the authentication page appeared.
3. I'm not really sure how to test that AuthTokenContainer works individually, but when it doesn't work, the authentication process doesn't work.

To test the NotFound component locally:
1. Go to Earthdata Search.
2. Change the URL to something different like http://localhost:8080/searchtest
3. NotFound component should show up

### Attachments
<img width="1725" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/5e665ce0-81b4-4539-b113-510d367df066">
<img width="1728" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/41e4c0d9-7b2e-4076-8836-976f2b977a24">
<img width="1728" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/1cd5fae1-60a5-4eac-96b2-39e188774c4e">

<img width="1728" alt="image" src="https://github.com/nasa/earthdata-search/assets/45649183/3bf9ea24-14ae-4776-bb12-84b949a59103">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
