### PR TITLE
EDSC-3794: Fix ProjectHeader enter bug.

### DIFF
--- a/static/src/js/components/ProjectCollections/ProjectHeader.js
+++ b/static/src/js/components/ProjectCollections/ProjectHeader.js
@@ -82,6 +82,8 @@ export const ProjectHeader = memo(({
   const handleNameKeyPress = ((e) => {
     if (e.key === 'Enter') {
       handleEditClick()
+      e.stopPropagation()
+      e.preventDefault()
     }
   })
 
@@ -155,7 +157,7 @@ export const ProjectHeader = memo(({
                 role="button"
                 tabIndex={0}
                 data-testid="project-header__span"
-                onKeyUp={handleNameKeyPress}
+                onKeyDown={handleNameKeyPress}
               >
                 {projectName}
               </span>
@@ -168,7 +170,7 @@ export const ProjectHeader = memo(({
               value={projectName}
               onFocus={handleOnFocus}
               onChange={onInputChange}
-              onKeyUp={handleKeypress}
+              onKeyDown={handleKeypress}
               ref={projectTitleInput}
             />
           </div>


### PR DESCRIPTION
# Overview

### What is the feature?

Heather found while testing in UAT that EDSC-3599 created a bug where pressing Enter while editing a project name after the Download Data button loaded would take a user to the download page instead of submitting their new project name. 

### What is the Solution?

While writing EDSC-3599, I replaced the code that triggered the project name submission upon pressing Enter with onKeyUp (from the original onKeyPress) because I heard that onKeyPress was being deprecated. To fix the Enter bug, I used onKeyDown instead of onKeyUp.

### What areas of the application does this impact?

This bug fix impacts users who are trying to edit their project name from the keyboard instead of pressing the submit button.

# Testing

### Reproduction steps

1. Go to Earthdata-Search and add granules to a project.
2. Go to the project and attempt to change the project name.
3. Verify that pressing the Enter button while editing the name does not start downloading the data (make sure you do this after the Download Data button has loaded since I think that is why the bug wasn't caught earlier).

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
