### PR TITLE
EDSC-3761: Fixes query parameters used in AWS, and ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
   deploy:
     if: success() && github.ref == 'refs/heads/main' # only run on main success
-    needs: [jest, cypress] # only run after jest and cypress jobs complete
+    needs: [jest, cypress, playwright] # only run after jest and cypress jobs complete
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -17,6 +17,7 @@ config="`jq '.application.feedbackApp = $newValue' --arg newValue $bamboo_FEEDBA
 config="`jq '.application.analytics.gtmPropertyId = $newValue' --arg newValue $bamboo_GTM_ID <<< $config`"
 config="`jq '.application.granuleLinksPageSize = $newValue' --arg newValue $bamboo_GRANULE_LINKS_PAGE_SIZE <<< $config`"
 config="`jq '.application.openSearchGranuleLinksPageSize = $newValue' --arg newValue $bamboo_OPEN_SEARCH_GRANULE_LINKS_PAGE_SIZE <<< $config`"
+config="`jq '.application.disableEddDownload = $newValue' --arg newValue $bamboo_DISABLE_EDD_DOWNLOAD <<< $config`"
 config="`jq '.environment.production.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.environment.production.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
 
@@ -87,8 +88,6 @@ dockerRun() {
         -e "SUBNET_ID_A=$bamboo_SUBNET_ID_A" \
         -e "SUBNET_ID_B=$bamboo_SUBNET_ID_B" \
         -e "VPC_ID=$bamboo_VPC_ID" \
-        -e "DISABLE_ORDERING=$bamboo_DISABLE_ORDERING" \
-        -e "DISABLE_EDD_DOWNLOAD=$bamboo_DISABLE_EDD_DOWNLOAD" \
         $dockerTag "$@"
 }
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,9 +40,6 @@ provider:
     geocodingService: ${self:custom.variables.geocodingService}
     geocodingIncludePolygons: ${self:custom.variables.geocodingIncludePolygons}
 
-    disableOrdering: ${self:custom.variables.disableOrdering}
-    disableEddDownload: ${self:custom.variables.disableEddDownload}
-
     NODE_OPTIONS: '--enable-source-maps'
 
   vpc:
@@ -128,8 +125,6 @@ custom:
     obfuscationSpinShapefiles: ${env:OBFUSCATION_SPIN_SHAPEFILES, ''}
     geocodingService: ${env:GEOCODING_SERVICE, 'nominatim'}
     geocodingIncludePolygons: ${env:GEOCODING_INCLUDE_POLYGONS, 'false'}
-    disableOrdering: ${env:DISABLE_ORDERING, 'true'}
-    disableEddDownload: ${env:DISABLE_EDD_DOWNLOAD, 'true'}
 
     cloudfrontToCloudwatchBucketPrefixApi:
       Fn::Join:

--- a/serverless/src/edlAuthorizer/handler.js
+++ b/serverless/src/edlAuthorizer/handler.js
@@ -11,10 +11,12 @@ import { downcaseKeys } from '../util/downcaseKeys'
 const edlAuthorizer = async (event) => {
   const {
     headers = {},
-    methodArn
+    methodArn,
+    queryStringParameters = {}
   } = event
 
-  const earthdataEnvironment = determineEarthdataEnvironment(headers)
+  let { ee: earthdataEnvironment } = queryStringParameters || {}
+  if (!earthdataEnvironment) earthdataEnvironment = determineEarthdataEnvironment(headers)
 
   const { authorization: authorizationToken = '' } = downcaseKeys(headers)
 

--- a/serverless/src/retrieveGranuleLinks/__tests__/fetchCmrLinks.test.js
+++ b/serverless/src/retrieveGranuleLinks/__tests__/fetchCmrLinks.test.js
@@ -46,7 +46,7 @@ describe('fetchCmrLinks', () => {
         echo_collection_id: 'C1214470488-ASF',
         two_d_coordinate_system: {}
       },
-      linkTypes: ['data', 's3'],
+      linkTypes: 'data,s3',
       requestId: '1234',
       token: 'mock-token'
     })

--- a/serverless/src/retrieveGranuleLinks/__tests__/fetchOpendapLinks.test.js
+++ b/serverless/src/retrieveGranuleLinks/__tests__/fetchOpendapLinks.test.js
@@ -30,9 +30,6 @@ describe('fetchOpendapLinks', () => {
       earthdataEnvironment: 'prod',
       event: {
         headers: {},
-        multiValueQueryStringParameters: {
-          linkTypes: ['data', 's3']
-        },
         queryStringParameters: {
           id: '1234567'
         }
@@ -84,9 +81,6 @@ describe('fetchOpendapLinks', () => {
       earthdataEnvironment: 'prod',
       event: {
         headers: {},
-        multiValueQueryStringParameters: {
-          linkTypes: ['data', 's3']
-        },
         queryStringParameters: {
           id: '1234567'
         }
@@ -140,9 +134,6 @@ describe('fetchOpendapLinks', () => {
       earthdataEnvironment: 'prod',
       event: {
         headers: {},
-        multiValueQueryStringParameters: {
-          linkTypes: ['data', 's3']
-        },
         queryStringParameters: {
           id: '1234567'
         }

--- a/serverless/src/retrieveGranuleLinks/__tests__/handler.test.js
+++ b/serverless/src/retrieveGranuleLinks/__tests__/handler.test.js
@@ -79,10 +79,8 @@ describe('retrieveGranuleLinks', () => {
 
     const event = {
       queryStringParameters: {
-        id: '1234567'
-      },
-      multiValueQueryStringParameters: {
-        linkTypes: ['data', 's3']
+        id: '1234567',
+        linkTypes: 'data,s3'
       }
     }
 
@@ -108,7 +106,7 @@ describe('retrieveGranuleLinks', () => {
         temporal: '2023-03-26T15:05:48.871Z,2023-03-27T10:48:39.230Z',
         two_d_coordinate_system: {}
       },
-      linkTypes: ['data', 's3'],
+      linkTypes: 'data,s3',
       requestId: 'mock-request-id',
       token: 'mock-access-token'
     })
@@ -148,10 +146,8 @@ describe('retrieveGranuleLinks', () => {
 
     const event = {
       queryStringParameters: {
-        id: '1234567'
-      },
-      multiValueQueryStringParameters: {
-        linkTypes: ['data', 's3']
+        id: '1234567',
+        linkTypes: 'data,s3'
       }
     }
 
@@ -213,10 +209,8 @@ describe('retrieveGranuleLinks', () => {
 
     const event = {
       queryStringParameters: {
-        id: '1234567'
-      },
-      multiValueQueryStringParameters: {
-        linkTypes: ['data', 's3']
+        id: '1234567',
+        linkTypes: 'data,s3'
       }
     }
 
@@ -233,11 +227,9 @@ describe('retrieveGranuleLinks', () => {
       collectionId: 'C1214470488-ASF',
       earthdataEnvironment: 'prod',
       event: {
-        multiValueQueryStringParameters: {
-          linkTypes: ['data', 's3']
-        },
         queryStringParameters: {
-          id: '1234567'
+          id: '1234567',
+          linkTypes: 'data,s3'
         }
       },
       granuleParams: {
@@ -320,10 +312,8 @@ describe('retrieveGranuleLinks', () => {
     const event = {
       queryStringParameters: {
         id: '1234567',
-        flattenLinks: true
-      },
-      multiValueQueryStringParameters: {
-        linkTypes: ['data', 's3']
+        flattenLinks: true,
+        linkTypes: 'data,s3'
       }
     }
 
@@ -342,10 +332,9 @@ describe('retrieveGranuleLinks', () => {
 
     const event = {
       queryStringParameters: {
-        id: '1234567'
-      },
-      multiValueQueryStringParameters: {
-        linkTypes: ['data', 's3']
+        id: '1234567',
+        flattenLinks: true,
+        linkTypes: 'data,s3'
       }
     }
 

--- a/serverless/src/retrieveGranuleLinks/fetchCmrLinks.js
+++ b/serverless/src/retrieveGranuleLinks/fetchCmrLinks.js
@@ -86,7 +86,7 @@ export const fetchCmrLinks = async ({
   const variables = {
     ...preparedGranuleParams,
     limit: parseInt(granuleLinksPageSize, 10),
-    linkTypes,
+    linkTypes: linkTypes.split(','),
     collectionConceptId: collectionId,
     cursor
   }

--- a/serverless/src/retrieveGranuleLinks/flattenGranuleLinks.js
+++ b/serverless/src/retrieveGranuleLinks/flattenGranuleLinks.js
@@ -1,7 +1,7 @@
 /**
  * Flattens an object of links to a single list of links if necessary
  * @param {Object} links Links to format
- * @param {Array} linkTypes List of types of links that need to be selected when flattening list
+ * @param {String} linkTypes Comma delimited string of types of links that need to be selected when flattening list
  * @param {String} flattenLinks Stringified boolean if the links need to be flattened to a single list
  */
 export const flattenGranuleLinks = (links, linkTypes, flattenLinks) => {

--- a/serverless/src/retrieveGranuleLinks/handler.js
+++ b/serverless/src/retrieveGranuleLinks/handler.js
@@ -22,13 +22,13 @@ const retrieveGranuleLinks = async (event, context) => {
   try {
     const {
       headers,
-      multiValueQueryStringParameters,
       queryStringParameters
     } = event
 
     const {
       id: retrievalCollectionId,
       cursor,
+      linkTypes,
       pageNum = 1,
       flattenLinks = false,
       requestId = uuidv4()
@@ -36,8 +36,6 @@ const retrieveGranuleLinks = async (event, context) => {
 
     let { ee: earthdataEnvironment } = queryStringParameters
     if (!earthdataEnvironment) earthdataEnvironment = determineEarthdataEnvironment(headers)
-
-    const { linkTypes } = multiValueQueryStringParameters
 
     // Decode the provided retrieval id
     const decodedRetrievalCollectionId = deobfuscateId(retrievalCollectionId)

--- a/serverless/src/retrieveGranuleLinks/handler.js
+++ b/serverless/src/retrieveGranuleLinks/handler.js
@@ -26,8 +26,6 @@ const retrieveGranuleLinks = async (event, context) => {
       queryStringParameters
     } = event
 
-    const earthdataEnvironment = determineEarthdataEnvironment(headers)
-
     const {
       id: retrievalCollectionId,
       cursor,
@@ -35,6 +33,10 @@ const retrieveGranuleLinks = async (event, context) => {
       flattenLinks = false,
       requestId = uuidv4()
     } = queryStringParameters
+
+    let { ee: earthdataEnvironment } = queryStringParameters
+    if (!earthdataEnvironment) earthdataEnvironment = determineEarthdataEnvironment(headers)
+
     const { linkTypes } = multiValueQueryStringParameters
 
     // Decode the provided retrieval id

--- a/static.config.json
+++ b/static.config.json
@@ -43,7 +43,8 @@
       "background": "eed-PORTAL-ENV-serverless-background",
       "client": "eed-PORTAL-ENV-serverless-client",
       "lambda": "eed-PORTAL-ENV-serverless-lambda"
-    }
+    },
+    "disableEddDownload": "false"
   },
   "environment": {
     "test": {

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -251,13 +251,13 @@ export const fetchGranuleLinks = (
 export const fetchRetrievalCollectionGranuleLinks = (data) => (dispatch) => {
   dispatch(setGranuleLinksLoading())
 
-  dispatch(fetchGranuleLinks(data, ['data', 's3', 'browse'])).then(() => {
+  dispatch(fetchGranuleLinks(data, 'data,s3,browse')).then(() => {
     dispatch(setGranuleLinksLoaded())
   })
 }
 
 export const fetchRetrievalCollectionGranuleBrowseLinks = (data) => (dispatch) => {
-  dispatch(fetchGranuleLinks(data, ['browse'])).then(() => {
+  dispatch(fetchGranuleLinks(data, 'browse')).then(() => {
     dispatch(setGranuleLinksLoaded())
   })
 }

--- a/static/src/js/actions/granules.js
+++ b/static/src/js/actions/granules.js
@@ -142,7 +142,7 @@ export const initializeCollectionGranulesQuery = (payload) => ({
 /**
  * Fetch all relevant links to the granules that are part of the provided collection
  * @param {Object} retrievalCollectionData Retrieval Collection response from the database
- * @param {Array} linkTypes List of linkTypes to retrieve
+ * @param {String} linkTypes Comma delimited string of linkTypes to retrieve
  */
 export const fetchGranuleLinks = (
   retrievalCollectionData,

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -137,7 +137,11 @@ export class OrderStatusItem extends PureComponent {
   }
 
   buildEddLink(linkType) {
-    const { authToken, collection } = this.props
+    const {
+      authToken,
+      collection,
+      earthdataEnvironment
+    } = this.props
 
     const {
       collection_metadata: collectionMetadata,
@@ -164,7 +168,7 @@ export class OrderStatusItem extends PureComponent {
     if (shortName) downloadId = `${shortName}_${versionId}`
 
     const { apiHost } = getEnvironmentConfig()
-    const retrievalUrl = `${apiHost}/granule_links?id=${retrievalCollectionId}&flattenLinks=true&linkTypes=${linkType}`
+    const retrievalUrl = `${apiHost}/granule_links?id=${retrievalCollectionId}&flattenLinks=true&linkTypes=${linkType}&ee=${earthdataEnvironment}`
     const link = `earthdata-download://startDownload?getLinks=${encodeURIComponent(retrievalUrl)}&downloadId=${downloadId}&token=Bearer ${authToken}`
 
     return link

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -338,7 +338,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata&downloadId=shortName_versionId&token=Bearer mock-token')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -428,7 +428,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata&downloadId=shortName_versionId&token=Bearer mock-token')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -439,7 +439,7 @@ describe('OrderStatusItem', () => {
       expect(browseTab.props().title).toEqual('Browse Imagery')
       expect(browseTab.childAt(0).props().granuleCount).toEqual(100)
       expect(browseTab.childAt(0).props().browseUrls).toEqual(['http://example.com'])
-      expect(browseTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Dbrowse&downloadId=shortName_versionId&token=Bearer mock-token')
+      expect(browseTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Dbrowse%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token')
     })
   })
 
@@ -581,7 +581,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.props().title).toEqual('Download Files')
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().downloadLinks).toEqual(['http://example.com'])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata&downloadId=shortName_versionId&token=Bearer mock-token')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -1913,7 +1913,7 @@ describe('OrderStatusItem', () => {
         expect(linksTab.childAt(0).props().downloadLinks).toEqual([
           'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony/gdal/a75ebeba-978e-4e68-9131-e36710fb800e/006_04_00feff_asia_west_regridded.png'
         ])
-        expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata&downloadId=testDataset_1&token=Bearer mock-token')
+        expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=testDataset_1&token=Bearer mock-token')
 
         const stacLinksTab = tabs.childAt(1)
         expect(stacLinksTab.childAt(0).props().granuleCount).toEqual(100)

--- a/static/src/js/components/TextWindowActions/TextWindowActions.js
+++ b/static/src/js/components/TextWindowActions/TextWindowActions.js
@@ -9,6 +9,7 @@ import {
 } from 'react-icons/fa'
 
 import { constructDownloadableFile } from '../../util/files/constructDownloadableFile'
+import { getApplicationConfig } from '../../../../../sharedUtils/config'
 
 import EDSCModalContainer from '../../containers/EDSCModalContainer/EDSCModalContainer'
 import Spinner from '../Spinner/Spinner'
@@ -41,7 +42,7 @@ export const TextWindowActions = ({
   modalTitle,
   eddLink
 }) => {
-  const { disableEddDownload } = process.env
+  const { disableEddDownload } = getApplicationConfig()
 
   const supportsClipboard = document.queryCommandSupported('copy')
   const textareaElRef = useRef(null)

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -1,9 +1,5 @@
 import { buildAccessMethods } from '../buildAccessMethods'
 
-beforeEach(() => {
-  process.env.disableOrdering = 'false'
-})
-
 describe('buildAccessMethods', () => {
   test('returns a download access method', () => {
     const collectionMetadata = {
@@ -111,33 +107,6 @@ describe('buildAccessMethods', () => {
         url: 'https://example.com'
       }
     })
-  })
-
-  test('does not return an echo orders access method if the disableOrdering is true', () => {
-    process.env.disableOrdering = 'true'
-
-    const collectionMetadata = {
-      services: {
-        items: [{
-          type: 'ECHO ORDERS',
-          url: {
-            urlValue: 'https://example.com'
-          },
-          orderOptions: {
-            items: [{
-              conceptId: 'OO10000-EDSC',
-              name: 'mock form',
-              form: 'mock form'
-            }]
-          }
-        }]
-      }
-    }
-    const isOpenSearch = false
-
-    const methods = buildAccessMethods(collectionMetadata, isOpenSearch)
-
-    expect(methods).toEqual({})
   })
 
   test('returns a harmony access method', () => {

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -21,8 +21,6 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
     variables: associatedVariables = {}
   } = collectionMetadata
 
-  const { disableOrdering } = process.env
-
   const accessMethods = {}
 
   let harmonyIndex = 0
@@ -80,9 +78,6 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
           if (methodKey === 'echoOrders') {
             methodKey = 'echoOrder'
           }
-
-          // Do not return any ECHO ORDERS methods if `disableOrdering` is set to `true`
-          if (disableOrdering === 'true' && methodKey === 'echoOrder') return
 
           accessMethods[`${methodKey}${orderOptionIndex}`] = method
         })


### PR DESCRIPTION
# Overview

### What is the feature?

In AWS, multiValueQueryStringParameters are not working as they do locally. This is causing no links to be returned. 

The CI workflow is also not waiting for playwright tests to pass before moving to the deploy step.

### What is the Solution?

Change linkTypes from an array, or repeated parameter, to a comma delimited string of values.
Update ci.yml

### What areas of the application does this impact?

Viewing download links

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
