### PR TITLE
EDD-10: Support EULA callback to EDD

### DIFF
--- a/serverless/src/edlLogin/__tests__/handler.test.js
+++ b/serverless/src/edlLogin/__tests__/handler.test.js
@@ -31,6 +31,33 @@ describe('edlLogin', () => {
     })
   })
 
+  test('successfully redirects a user to earthdata login with an eddRedirect parameter', async () => {
+    jest.spyOn(getEdlConfig, 'getEdlConfig').mockImplementationOnce(() => ({
+      client: {
+        id: 'edlClientId'
+      }
+    }))
+
+    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementationOnce(() => ({
+      edlHost: 'http://edl.example.com',
+      redirectUriPath: '/search'
+    }))
+
+    const response = await edlLogin({
+      queryStringParameters: {
+        ee: 'prod',
+        eddRedirect: 'http://edsc-state.nasa.gov'
+      }
+    })
+
+    expect(response).toEqual({
+      statusCode: 307,
+      headers: {
+        Location: 'http://edl.example.com/oauth/authorize?response_type=code&client_id=edlClientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fsearch&state=http%3A%2F%2Fedsc-state.nasa.gov%3Fee%3Dprod'
+      }
+    })
+  })
+
   test('successfully keeps array values in order during the redirect to earthdata login', async () => {
     jest.spyOn(getEdlConfig, 'getEdlConfig').mockImplementationOnce(() => ({
       client: {

--- a/serverless/src/edlLogin/handler.js
+++ b/serverless/src/edlLogin/handler.js
@@ -11,7 +11,11 @@ import { getEdlConfig } from '../util/getEdlConfig'
 const edlLogin = async (event) => {
   const { queryStringParameters } = event
 
-  const { ee: earthdataEnvironment, state } = queryStringParameters
+  const { ee: earthdataEnvironment, eddRedirect } = queryStringParameters
+  let { state } = queryStringParameters
+
+  // In order to make EDD more reusable, it is going to pass a `eddRedirect` parameter which is what we send to EDL as `state`
+  if (!state) state = eddRedirect
 
   // The client id is part of our Earthdata Login credentials
   const edlConfig = await getEdlConfig(earthdataEnvironment)

--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -168,14 +168,18 @@ export class OrderStatusItem extends PureComponent {
     if (shortName) downloadId = `${shortName}_${versionId}`
 
     // Build the `getLinks` URL to tell EDD where to find the download links
-    const { apiHost } = getEnvironmentConfig()
+    const { apiHost, edscHost } = getEnvironmentConfig()
     const getLinksUrl = `${apiHost}/granule_links?id=${retrievalCollectionId}&flattenLinks=true&linkTypes=${linkType}&ee=${earthdataEnvironment}`
 
     // Build the authUrl to tell EDD how to authenticate the user
-    const returnUrl = 'earthdata-download://authCallback'
-    const authUrl = `${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(returnUrl)}`
+    const authReturnUrl = 'earthdata-download://authCallback'
+    const authUrl = `${apiHost}/login?ee=${earthdataEnvironment}&eddRedirect=${encodeURIComponent(authReturnUrl)}`
 
-    const link = `earthdata-download://startDownload?getLinks=${encodeURIComponent(getLinksUrl)}&downloadId=${downloadId}&token=Bearer ${authToken}&authUrl=${encodeURIComponent(authUrl)}`
+    // Build the eulaRedirectUrl to tell EDD how to get back after the user accepts a EULA
+    const eulaCallback = 'earthdata-download://eulaCallback'
+    const eulaRedirectUrl = `${edscHost}/auth_callback?eddRedirect=${encodeURIComponent(eulaCallback)}`
+
+    const link = `earthdata-download://startDownload?getLinks=${encodeURIComponent(getLinksUrl)}&downloadId=${downloadId}&token=Bearer ${authToken}&authUrl=${encodeURIComponent(authUrl)}&eulaRedirectUrl=${encodeURIComponent(eulaRedirectUrl)}`
 
     return link
   }

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -338,7 +338,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26state%3Dearthdata-download%253A%252F%252FauthCallback')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -428,7 +428,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26state%3Dearthdata-download%253A%252F%252FauthCallback')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -439,7 +439,7 @@ describe('OrderStatusItem', () => {
       expect(browseTab.props().title).toEqual('Browse Imagery')
       expect(browseTab.childAt(0).props().granuleCount).toEqual(100)
       expect(browseTab.childAt(0).props().browseUrls).toEqual(['http://example.com'])
-      expect(browseTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Dbrowse%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26state%3Dearthdata-download%253A%252F%252FauthCallback')
+      expect(browseTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Dbrowse%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
     })
   })
 
@@ -581,7 +581,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.props().title).toEqual('Download Files')
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().downloadLinks).toEqual(['http://example.com'])
-      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26state%3Dearthdata-download%253A%252F%252FauthCallback')
+      expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -1913,7 +1913,7 @@ describe('OrderStatusItem', () => {
         expect(linksTab.childAt(0).props().downloadLinks).toEqual([
           'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony/gdal/a75ebeba-978e-4e68-9131-e36710fb800e/006_04_00feff_asia_west_regridded.png'
         ])
-        expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=testDataset_1&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26state%3Dearthdata-download%253A%252F%252FauthCallback')
+        expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=testDataset_1&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
 
         const stacLinksTab = tabs.childAt(1)
         expect(stacLinksTab.childAt(0).props().granuleCount).toEqual(100)

--- a/static/src/js/components/TextWindowActions/TextWindowActions.js
+++ b/static/src/js/components/TextWindowActions/TextWindowActions.js
@@ -260,7 +260,7 @@ export const TextWindowActions = ({
         size="md"
         body={(
           <div className="d-flex flex-column align-items-center">
-            <h3 className="font-weight-bolder h5 mt-3 text-center w-75">Opening Earthdata Download to download your your files...</h3>
+            <h3 className="font-weight-bolder h5 mt-3 text-center w-75">Opening Earthdata Download to download your files...</h3>
             <EDSCIcon
               className="mt-4 text-window-actions__modal-icon"
               icon={FaExternalLinkAlt}

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -39,6 +39,29 @@ export const AuthCallbackContainer = ({
       redirect = '/'
     } = params
 
+    // Verify that the redirect params are real URLs
+    try {
+      let redirectUrl
+      if (eddRedirect) redirectUrl = new URL(eddRedirect)
+      if (redirect && redirect !== '/') redirectUrl = new URL(redirect)
+      console.log('🚀 ~ file: AuthCallbackContainer.js:46 ~ useEffect ~ redirectUrl:', redirectUrl)
+
+      if (
+        redirectUrl
+        && redirectUrl.protocol !== 'http:'
+        && redirectUrl.protocol !== 'https:'
+        && redirectUrl.protocol !== 'earthdata-download:'
+      ) {
+        // The redirectUrl is not a valid protocol
+        console.log('The redirectUrl is not a valid protocol')
+        window.location.replace('/')
+        return
+      }
+    } catch (error) {
+      window.location.replace('/')
+      return
+    }
+
     // If the redirect includes earthdata-download, redirect to the edd callback
     if (eddRedirect || redirect.includes('earthdata-download')) {
       let eddRedirectUrl = eddRedirect || redirect

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -33,18 +33,20 @@ export const AuthCallbackContainer = ({
 
     const params = parse(search, { ignoreQueryPrefix: true })
     const {
+      eddRedirect,
       jwt = '',
-      accessToken
+      accessToken,
+      redirect = '/'
     } = params
-    let { redirect = '/' } = params
 
     // If the redirect includes earthdata-download, redirect to the edd callback
-    if (redirect.includes('earthdata-download')) {
-      redirect += `&token=${accessToken}`
+    if (eddRedirect || redirect.includes('earthdata-download')) {
+      let eddRedirectUrl = eddRedirect || redirect
+      if (accessToken) eddRedirectUrl += `&token=${accessToken}`
 
       // Add the redirect information to the store
       onAddEarthdataDownloadRedirect({
-        redirect
+        redirect: eddRedirectUrl
       })
 
       // Redirect to the edd callback

--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.js
@@ -44,7 +44,6 @@ export const AuthCallbackContainer = ({
       let redirectUrl
       if (eddRedirect) redirectUrl = new URL(eddRedirect)
       if (redirect && redirect !== '/') redirectUrl = new URL(redirect)
-      console.log('🚀 ~ file: AuthCallbackContainer.js:46 ~ useEffect ~ redirectUrl:', redirectUrl)
 
       if (
         redirectUrl

--- a/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
+++ b/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
@@ -139,4 +139,38 @@ describe('AuthCallbackContainer component', () => {
     expect(window.location.replace.mock.calls.length).toBe(1)
     expect(window.location.replace.mock.calls[0]).toEqual(['/'])
   })
+
+  test('does not follow the redirect if the redirect param is not valid', () => {
+    const setSpy = jest.spyOn(tinyCookie, 'set')
+    delete window.location
+    window.location = { replace: jest.fn() }
+
+    setup({
+      location: {
+        search: '?redirect=javascript:alert(document.domain);'
+      }
+    })
+
+    expect(setSpy).toBeCalledTimes(0)
+
+    expect(window.location.replace.mock.calls.length).toBe(1)
+    expect(window.location.replace.mock.calls[0]).toEqual(['/'])
+  })
+
+  test('does not follow the redirect if the eddRedirect param is not valid', () => {
+    const setSpy = jest.spyOn(tinyCookie, 'set')
+    delete window.location
+    window.location = { replace: jest.fn() }
+
+    setup({
+      location: {
+        search: '?eddRedirect=javascript:alert(document.domain);'
+      }
+    })
+
+    expect(setSpy).toBeCalledTimes(0)
+
+    expect(window.location.replace.mock.calls.length).toBe(1)
+    expect(window.location.replace.mock.calls[0]).toEqual(['/'])
+  })
 })

--- a/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
+++ b/static/src/js/containers/AuthCallbackContainer/__tests__/AuthCallbackContainer.test.js
@@ -80,7 +80,7 @@ describe('AuthCallbackContainer component', () => {
     expect(window.location.replace.mock.calls[0]).toEqual(['http://localhost:8080/search'])
   })
 
-  test('updates redux and redirects to earthdata-download-callback', () => {
+  test('updates redux and redirects to earthdata-download-callback for authCallback', () => {
     const setSpy = jest.spyOn(tinyCookie, 'set')
     delete window.location
     window.location = { replace: jest.fn() }
@@ -98,6 +98,27 @@ describe('AuthCallbackContainer component', () => {
     expect(props.onAddEarthdataDownloadRedirect).toHaveBeenCalledTimes(1)
     expect(props.onAddEarthdataDownloadRedirect).toHaveBeenCalledWith({
       redirect: 'earthdata-download://authCallback&token=mock-token'
+    })
+  })
+
+  test('updates redux and redirects to earthdata-download-callback for eulaCallback', () => {
+    const setSpy = jest.spyOn(tinyCookie, 'set')
+    delete window.location
+    window.location = { replace: jest.fn() }
+
+    const { props } = setup({
+      location: {
+        search: 'eddRedirect=earthdata-download%3A%2F%2FeulaCallback'
+      }
+    })
+
+    expect(setSpy).toHaveBeenCalledTimes(0)
+
+    expect(window.location.replace).toHaveBeenCalledTimes(0)
+
+    expect(props.onAddEarthdataDownloadRedirect).toHaveBeenCalledTimes(1)
+    expect(props.onAddEarthdataDownloadRedirect).toHaveBeenCalledWith({
+      redirect: 'earthdata-download://eulaCallback'
     })
   })
 

--- a/static/src/js/containers/EarthdataDownloadRedirectContainer/EarthdataDownloadRedirectContainer.js
+++ b/static/src/js/containers/EarthdataDownloadRedirectContainer/EarthdataDownloadRedirectContainer.js
@@ -22,7 +22,7 @@ export const EarthdataDownloadRedirectContainer = ({
 
   return (
     <div className="container d-flex flex-column align-items-center text-center">
-      <h3 className="font-weight-bolder h5 mt-3 text-center w-75">Opening Earthdata Download to download your your files...</h3>
+      <h3 className="font-weight-bolder h5 mt-3 text-center w-75">Opening Earthdata Download to download your files...</h3>
       <EDSCIcon
         className="mt-4 text-window-actions__modal-icon"
         icon={FaExternalLinkAlt}

--- a/static/src/js/containers/EarthdataDownloadRedirectContainer/__tests__/EarthdataDownloadRedirectContainer.test.js
+++ b/static/src/js/containers/EarthdataDownloadRedirectContainer/__tests__/EarthdataDownloadRedirectContainer.test.js
@@ -35,7 +35,7 @@ describe('EarthdataDownloadRedirectContainer', () => {
       />
     )
 
-    expect(screen.getByText('Opening Earthdata Download to download your your files...')).toBeDefined()
+    expect(screen.getByText('Opening Earthdata Download to download your files...')).toBeDefined()
     expect(screen.getByTestId('earthdata-download-redirect-button')).toHaveAttribute('href', 'earthdata-download://authCallback')
 
     expect(window.location.replace).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
# Overview

### What is the feature?

Earthdata Download needs to be able to send a user to EDL to accept a EULA, and then be returned to EDD, through an EDSC redirect. This adds that redirect capability.

### What areas of the application does this impact?

EDD Downloads

# Testing

### Reproduction steps

You need a collection that is behind a EULA, and a user that has not accepted the EULA. Try to download the files through EDD and you will be redirected to EDL to accept the EULA, then to EDSC to the earthdata-download-redirect page to re-open EDD

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
