### PR TITLE
EDSC-3852: Account for links and relatedUrls being null when looking for an OpenSearch OSDD

### DIFF
--- a/sharedUtils/__tests__/getOpenSearchOsddLink.test.js
+++ b/sharedUtils/__tests__/getOpenSearchOsddLink.test.js
@@ -5,29 +5,12 @@ describe('getOpenSearchOsddLink', () => {
     expect(getOpenSearchOsddLink({})).toBe(undefined)
   })
 
-  test('returns undefined if no link exists', () => {
-    const links = [
-      {
-        length: '0.0KB',
-        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
-        hreflang: 'en-US',
-        href: 'https://esatellus.service-now.com/csp?id=esa_simple_request'
-      },
-      {
-        length: '0.0KB',
-        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
-        hreflang: 'en-US',
-        href: 'https://eoportal.org/web/eoportal/fedeo?parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products'
-      },
-      {
-        length: '0.0KB',
-        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
-        hreflang: 'en-US',
-        href: 'https://fedeo.esa.int/opensearch/request/?httpAccept=application/vnd.iso.19139-2%2Bxml&parentIdentifier=EOP:ESA:EARTH-ONLINE&uid=CryoSat.products&recordSchema=iso19139-2'
-      }
-    ]
+  test('returns undefined when links is null', () => {
+    expect(getOpenSearchOsddLink({ links: null })).toBe(undefined)
+  })
 
-    expect(getOpenSearchOsddLink(links)).toBe(undefined)
+  test('returns undefined when relatedUrls is null', () => {
+    expect(getOpenSearchOsddLink({ relatedUrls: null })).toBe(undefined)
   })
 
   test('returns the OSDD link from the links', () => {

--- a/sharedUtils/getOpenSearchOsddLink.js
+++ b/sharedUtils/getOpenSearchOsddLink.js
@@ -16,43 +16,47 @@ export const getOpenSearchOsddLink = (metadata) => {
   let value
 
   // Check for an OpenSearch link
-  links.forEach((link) => {
-    const {
-      href, rel = ''
-    } = link
+  if (links) {
+    links.forEach((link) => {
+      const {
+        href, rel = ''
+      } = link
 
-    if (rel.indexOf('/search#') !== -1) {
-      value = href
-    }
-  })
-
-  relatedUrls.forEach((relatedUrl) => {
-    const {
-      contentType,
-      subtype,
-      urlContentType,
-      url,
-      urls = []
-    } = relatedUrl
-
-    if (urlContentType === 'DistributionURL' && subtype === 'OpenSearch') {
-      value = url
-      return
-    }
-
-    if (contentType === 'DistributionURL' && urls.length > 0) {
-      const foundUrl = urls.find((distributionURL) => {
-        const { subtype } = distributionURL
-
-        return subtype === 'OpenSearch'
-      })
-
-      if (foundUrl) {
-        const { url } = foundUrl
-        value = url
+      if (rel.indexOf('/search#') !== -1) {
+        value = href
       }
-    }
-  })
+    })
+  }
+
+  if (relatedUrls) {
+    relatedUrls.forEach((relatedUrl) => {
+      const {
+        contentType,
+        subtype,
+        urlContentType,
+        url,
+        urls = []
+      } = relatedUrl
+
+      if (urlContentType === 'DistributionURL' && subtype === 'OpenSearch') {
+        value = url
+        return
+      }
+
+      if (contentType === 'DistributionURL' && urls.length > 0) {
+        const foundUrl = urls.find((distributionURL) => {
+          const { subtype } = distributionURL
+
+          return subtype === 'OpenSearch'
+        })
+
+        if (foundUrl) {
+          const { url } = foundUrl
+          value = url
+        }
+      }
+    })
+  }
 
   // Fallback to the tag data if a link doesn't exist
   if (!value && !hasGranules) {


### PR DESCRIPTION
# Overview

### What is the feature?

When looking for an OpenSearch OSDD the code was expecting links and relatedUrls to default to an empty array. But when those values are provided by cmr-graphql, if they are missing they are returned as null.

### What is the Solution?

Check for existence of those values before calling `.forEach()` on them

### What areas of the application does this impact?

Viewing collections

# Testing

### Reproduction steps

This link should show granule results, not a red banner at the top of the screen. http://localhost:8080/search/granules?p=C2011599335-ASF&pg[0][v]=f&pg[0][gsk]=-start_date&q=C2011599335-ASF&tl=1690405258.454!3!!

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
