### PR TITLE
EDSC-3833: Improve Customizable facet messaging

### DIFF
--- a/static/src/js/components/Facets/Facets.js
+++ b/static/src/js/components/Facets/Facets.js
@@ -54,6 +54,7 @@ const Facets = (props) => {
     featuresFacet.children.push({
       applied: featureFacets.customizable,
       title: 'Customizable',
+      description: 'Include only collections that support customization (temporal, spatial, or variable subsetting, reformatting, etc.)',
       type: 'feature'
     })
   }

--- a/static/src/js/components/Facets/FacetsItem.js
+++ b/static/src/js/components/Facets/FacetsItem.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types'
 import { kebabCase, uniqueId } from 'lodash'
 import classNames from 'classnames'
 
+import { Tooltip, OverlayTrigger } from 'react-bootstrap'
+import { FaQuestionCircle } from 'react-icons/fa'
+import EDSCIcon from '../EDSCIcon/EDSCIcon'
+
 import { generateFacetArgs } from '../../util/facets'
 
 import './FacetsItem.scss'
@@ -93,10 +97,26 @@ class FacetsItem extends Component {
             className="facets-item__checkbox"
             data-testid={`facet_item-${kebabCase(facet.title)}`}
             type="checkbox"
+            name={facet.title}
             checked={applied}
             onChange={this.onFacetChange.bind(this, changeHandlerArgs)}
           />
-          <span className="facets-item__title">{facet.title}</span>
+          <span className="facets-item__title">
+            {facet.title}
+            {facet.description
+            && (
+            <OverlayTrigger
+              placement="top"
+              overlay={(
+                <Tooltip style={{ width: '20rem' }}>
+                  {facet.description}
+                </Tooltip>
+              )}
+            >
+              <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" />
+            </OverlayTrigger>
+            )}
+          </span>
           { (!applied || !children) && <span className="facets-item__total">{facet.count}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
@@ -117,7 +137,8 @@ FacetsItem.propTypes = {
     applied: PropTypes.bool,
     children: PropTypes.arrayOf(PropTypes.shape({})),
     count: PropTypes.number,
-    title: PropTypes.string
+    title: PropTypes.string,
+    description: PropTypes.string
   }).isRequired,
   facetCategory: PropTypes.string.isRequired,
   level: PropTypes.number.isRequired,

--- a/static/src/js/components/Facets/__tests__/Facets.test.js
+++ b/static/src/js/components/Facets/__tests__/Facets.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {
-  render, screen, getByText, getAllByText, getAllByRole
+  render, screen, waitFor, getByText, getAllByText, getAllByRole
 } from '@testing-library/react'
 
 import userEvent from '@testing-library/user-event'
@@ -644,6 +644,8 @@ describe('Facets Features Map Imagery component', () => {
     expect(screen.queryByRole('button', { name: /View All/i })).toBeNull()
 
     await user.click(getAllByRole(container, 'button').at(5))
+
+    await waitFor(() => { screen.getByRole('button', { name: /View All/i }) })
 
     expect(screen.getByRole('button', { name: /View All/i })).toBeInTheDocument()
 

--- a/static/src/js/components/Facets/__tests__/Facets.test.js
+++ b/static/src/js/components/Facets/__tests__/Facets.test.js
@@ -272,7 +272,9 @@ describe('Facets Features Map Imagery component', () => {
     const customizableComp = screen.getByText('Customizable')
     expect(customizableComp).toBeInTheDocument()
     expect(customizableComp.children).toHaveLength(1)
-    await user.hover(customizableComp.children[0])
+    await waitFor(async () => {
+      await user.hover(customizableComp.children[0])
+    })
     const tooltip = screen.getByRole('tooltip')
     expect(tooltip).toBeInTheDocument()
     expect(getByText(tooltip, 'Include only collections that support customization (temporal, spatial, or variable subsetting, reformatting, etc.)')).toBeInTheDocument()
@@ -644,8 +646,6 @@ describe('Facets Features Map Imagery component', () => {
     expect(screen.queryByRole('button', { name: /View All/i })).toBeNull()
 
     await user.click(getAllByRole(container, 'button').at(5))
-
-    await waitFor(() => { screen.getByRole('button', { name: /View All/i }) })
 
     expect(screen.getByRole('button', { name: /View All/i })).toBeInTheDocument()
 


### PR DESCRIPTION
# Overview

### What is the feature?

- Added a '?' to the end of the customizable and made it so when hovered over it gives more detailed information as a tooltip on what selecting the checkbox will do.
- Also updated the tests for Facets.js to use React Testing Framework instead of Enzyme.

### What is the Solution?

Added a new prop to the FacetItem called description that when contains a string, the '?' icon will show up at the end of the checkbox with that description showing up on hover.

### What areas of the application does this impact?

Just the Facets.js/FacetsItem.js.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. go to /search.
2. Navigate to the Customizable checkbox and hover over the '?' icon at the end of it.
3. Ensure the popup shows up with the correct message.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
<img width="619" alt="image" src="https://github.com/nasa/earthdata-search/assets/8591291/bc096a5c-4258-4749-ad8c-c42319d73d15">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings