### PR TITLE
CMR-9266: 2000 granule get-permission call taking too long

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -88,6 +88,7 @@ dockerRun() {
         -e "NODE_OPTIONS=--max_old_space_size=4096" \
         -e "OBFUSCATION_SPIN_SHAPEFILES=$bamboo_OBFUSCATION_SPIN_SHAPEFILES" \
         -e "OBFUSCATION_SPIN=$bamboo_OBFUSCATION_SPIN" \
+        -e "ORDER_DELAY_SECONDS=$bamboo_ORDER_DELAY_SECONDS" \
         -e "SUBNET_ID_A=$bamboo_SUBNET_ID_A" \
         -e "SUBNET_ID_B=$bamboo_SUBNET_ID_B" \
         -e "VPC_ID=$bamboo_VPC_ID" \

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,6 +32,8 @@ provider:
     obfuscationSpin: ${self:custom.variables.obfuscationSpin}
     obfuscationSpinShapefiles: ${self:custom.variables.obfuscationSpinShapefiles}
 
+    orderDelaySeconds: ${self:custom.variables.orderDelaySeconds}
+
     configSecretId:
       Fn::ImportValue: ${self:provider.stage}-DbPasswordSecret
 
@@ -123,6 +125,7 @@ custom:
     # Default values for environment variables used to set environment variables
     obfuscationSpin: ${env:OBFUSCATION_SPIN, ''}
     obfuscationSpinShapefiles: ${env:OBFUSCATION_SPIN_SHAPEFILES, ''}
+    orderDelaySeconds: ${env:ORDER_DELAY_SECONDS, '1'}
     geocodingService: ${env:GEOCODING_SERVICE, 'nominatim'}
     geocodingIncludePolygons: ${env:GEOCODING_INCLUDE_POLYGONS, 'false'}
 

--- a/serverless/src/submitRetrieval/__tests__/handler.test.js
+++ b/serverless/src/submitRetrieval/__tests__/handler.test.js
@@ -43,6 +43,7 @@ beforeEach(() => {
   // Manage resetting ENV variables
   // TODO: This is causing problems with mocking knex but is noted as important for managing process.env
   // jest.resetModules()
+  process.env.orderDelaySeconds = 30
   process.env = { ...OLD_ENV }
   delete process.env.NODE_ENV
 })
@@ -140,6 +141,14 @@ describe('submitRetrieval', () => {
         query.response([{
           id: 5
         }])
+      } else if (step === 7) {
+        query.response([{
+          id: 5
+        }])
+      } else if (step === 8) {
+        query.response([{
+          id: 5
+        }])
       } else {
         query.response([])
       }
@@ -149,12 +158,17 @@ describe('submitRetrieval', () => {
       .mockImplementationOnce(() => [{
         page_num: 1,
         page_size: 2000
+      },{
+        page_num: 2,
+        page_size: 2000
+      },{
+        page_num: 3,
+        page_size: 2000
       }])
 
     const orderResponse = await submitRetrieval(echoOrderPayload, {})
 
     const { queries } = dbTracker.queries
-
     expect(queries[0].sql).toContain('BEGIN')
     expect(queries[1].method).toEqual('insert')
     expect(queries[2].method).toEqual('insert')
@@ -168,12 +182,28 @@ describe('submitRetrieval', () => {
     // add new access configuration
     expect(queries[4].method).toEqual('insert')
     expect(queries[5].method).toEqual('insert')
-    expect(queries[6].sql).toContain('COMMIT')
+    expect(queries[6].method).toEqual('insert')
+    expect(queries[7].method).toEqual('insert')
+    expect(queries[8].sql).toContain('COMMIT')
     expect(mockSend.mock.calls[0]).toEqual([{
       QueueUrl: 'http://example.com/echoQueue',
       Entries: [{
         DelaySeconds: 3,
         Id: '2-1',
+        MessageBody: JSON.stringify({
+          accessToken: '2e8e995e7511c2c6620336797b',
+          id: 5
+        })
+      },{
+        DelaySeconds: 33,
+        Id: '2-2',
+        MessageBody: JSON.stringify({
+          accessToken: '2e8e995e7511c2c6620336797b',
+          id: 5
+        })
+      },{
+        DelaySeconds: 63,
+        Id: '2-3',
         MessageBody: JSON.stringify({
           accessToken: '2e8e995e7511c2c6620336797b',
           id: 5

--- a/serverless/src/submitRetrieval/__tests__/handler.test.js
+++ b/serverless/src/submitRetrieval/__tests__/handler.test.js
@@ -158,10 +158,10 @@ describe('submitRetrieval', () => {
       .mockImplementationOnce(() => [{
         page_num: 1,
         page_size: 2000
-      },{
+      }, {
         page_num: 2,
         page_size: 2000
-      },{
+      }, {
         page_num: 3,
         page_size: 2000
       }])
@@ -194,14 +194,14 @@ describe('submitRetrieval', () => {
           accessToken: '2e8e995e7511c2c6620336797b',
           id: 5
         })
-      },{
+      }, {
         DelaySeconds: 33,
         Id: '2-2',
         MessageBody: JSON.stringify({
           accessToken: '2e8e995e7511c2c6620336797b',
           id: 5
         })
-      },{
+      }, {
         DelaySeconds: 63,
         Id: '2-3',
         MessageBody: JSON.stringify({

--- a/serverless/src/submitRetrieval/__tests__/handler.test.js
+++ b/serverless/src/submitRetrieval/__tests__/handler.test.js
@@ -143,11 +143,11 @@ describe('submitRetrieval', () => {
         }])
       } else if (step === 7) {
         query.response([{
-          id: 5
+          id: 6
         }])
       } else if (step === 8) {
         query.response([{
-          id: 5
+          id: 7
         }])
       } else {
         query.response([])
@@ -199,14 +199,14 @@ describe('submitRetrieval', () => {
         Id: '2-2',
         MessageBody: JSON.stringify({
           accessToken: '2e8e995e7511c2c6620336797b',
-          id: 5
+          id: 6
         })
       }, {
         DelaySeconds: 63,
         Id: '2-3',
         MessageBody: JSON.stringify({
           accessToken: '2e8e995e7511c2c6620336797b',
-          id: 5
+          id: 7
         })
       }]
     }])


### PR DESCRIPTION
# Overview

### What is the feature?

Access-control has problems with processing very large amounts of granule permissions within the AWS lambda timeout.

### What is the Solution?

We can blunt the impact on access-control processing times by avoiding overloading the app with everything all at once.  I've added an environment var ORDER_DELAY_SECONDS which will be added to the queue delay for each page of the total order. 

### What areas of the application does this impact?

Order payload insertion into SQS.

# Testing

### Reproduction steps

- UAT, large orders of SMAP granules with large metadata sizes
- I tested with C1236624098-NSIDC_TS1

1. Order many granules
2. Monitor logs for cmr-ordering, to verify granule permission calls to access-control are batching and completing
3. Monitor access-control logs to verify permission calls are completing fast enough
4. Order completes successfully.

