### PR TITLE
EDSC-3876 disables edd button for csda collections

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatusItem.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.js
@@ -630,6 +630,7 @@ export class OrderStatusItem extends PureComponent {
                           retrievalId={retrievalId}
                           retrievalCollectionId={retrievalCollectionId}
                           showTextWindowActions={!isEsi}
+                          collectionIsCSDA={collectionIsCSDA}
                         />
                       </Tab>
                     )

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.js
@@ -17,6 +17,7 @@ import TextWindowActions from '../../TextWindowActions/TextWindowActions'
  * @param {Boolean} arg0.granuleLinksIsLoading - A flag set when the granule links are loading.
  * @param {Boolean} arg0.percentDoneDownloadLinks - Percentage of the download links that have been fetched.
  * @param {Boolean} arg0.showTextWindowActions - A flag set when the text window actions should be set.
+ * @param {Boolean} arg0.collectionIsCSDA - A flag set when the collection is CSDA.
 */
 export const DownloadFilesPanel = ({
   accessMethodType,
@@ -26,7 +27,8 @@ export const DownloadFilesPanel = ({
   percentDoneDownloadLinks,
   retrievalId,
   eddLink,
-  showTextWindowActions
+  showTextWindowActions,
+  collectionIsCSDA
 }) => {
   const downloadFileName = `${retrievalId}-${accessMethodType}.txt`
 
@@ -58,6 +60,7 @@ export const DownloadFilesPanel = ({
         modalTitle="Download Files"
         disableCopy={!showTextWindowActions}
         disableSave={!showTextWindowActions}
+        disableEdd={collectionIsCSDA}
       >
         <ul className="download-links-panel__list">
           {
@@ -84,6 +87,7 @@ export const DownloadFilesPanel = ({
 DownloadFilesPanel.defaultProps = {
   percentDoneDownloadLinks: null,
   showTextWindowActions: true,
+  collectionIsCSDA: false,
   eddLink: null
 }
 
@@ -97,7 +101,8 @@ DownloadFilesPanel.propTypes = {
   granuleCount: PropTypes.number.isRequired,
   granuleLinksIsLoading: PropTypes.bool.isRequired,
   percentDoneDownloadLinks: PropTypes.string,
-  showTextWindowActions: PropTypes.bool
+  showTextWindowActions: PropTypes.bool,
+  collectionIsCSDA: PropTypes.bool
 }
 
 export default DownloadFilesPanel

--- a/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
@@ -79,5 +79,23 @@ describe('DownloadFilesPanel', () => {
       expect(windowActions.props().disableCopy).toEqual(true)
       expect(windowActions.props().disableSave).toEqual(true)
     })
+    test('hides the edd button', () => {
+      const enzymeWrapper = shallow(
+        <DownloadFilesPanel
+          accessMethodType="ESI"
+          earthdataEnvironment="prod"
+          downloadLinks={['http://search.earthdata.nasa.gov', 'http://cmr.earthdata.nasa.gov']}
+          retrievalCollection={{}}
+          retrievalId="1"
+          granuleCount={10}
+          granuleLinksIsLoading
+          showTextWindowActions
+          collectionIsCSDA
+        />
+      )
+
+      const windowActions = enzymeWrapper.find(TextWindowActions)
+      expect(windowActions.props().disableEdd).toEqual(true)
+    })
   })
 })

--- a/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
@@ -79,13 +79,12 @@ describe('DownloadFilesPanel', () => {
       expect(windowActions.props().disableCopy).toEqual(true)
       expect(windowActions.props().disableSave).toEqual(true)
     })
-    test('hides the edd button', () => {
+    test('hides the download button', () => {
       const enzymeWrapper = shallow(
         <DownloadFilesPanel
           accessMethodType="ESI"
           earthdataEnvironment="prod"
           downloadLinks={['http://search.earthdata.nasa.gov', 'http://cmr.earthdata.nasa.gov']}
-          retrievalCollection={{}}
           retrievalId="1"
           granuleCount={10}
           granuleLinksIsLoading

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -467,8 +467,15 @@ describe('OrderStatusItem', () => {
 
       enzymeWrapper.find('.order-status-item__button').simulate('click')
 
-      const message = enzymeWrapper.find('.order-status-item__note')
+      const body = enzymeWrapper.find('.order-status-item__body')
+      const tabs = body.find('EDSCTabs')
+      expect(tabs.children().length).toEqual(2)
 
+      const linksTab = tabs.childAt(0)
+      expect(linksTab.props().title).toEqual('Download Files')
+      expect(linksTab.childAt(0).props().collectionIsCSDA).toEqual(true)
+
+      const message = enzymeWrapper.find('.order-status-item__note')
       expect(message.text()).toContain('This collection is made available through the NASA Commercial Smallsat Data Acquisition (CSDA) Program')
     })
 

--- a/static/src/js/components/TextWindowActions/TextWindowActions.js
+++ b/static/src/js/components/TextWindowActions/TextWindowActions.js
@@ -33,6 +33,7 @@ import './TextWindowActions.scss'
  * @param {String} modalTitle - The title for the modal.
  * @param {Boolean} disableCopy - Disables the copy functionality.
  * @param {Boolean} disableSave - Disables the save functionality.
+ * @param {Boolean} disableEdd - Disables EDD button.
  */
 export const TextWindowActions = ({
   children,

--- a/static/src/js/components/TextWindowActions/__tests__/TextWindowActions.test.js
+++ b/static/src/js/components/TextWindowActions/__tests__/TextWindowActions.test.js
@@ -365,5 +365,26 @@ describe('TextWindowActions component', () => {
         })
       })
     })
+    describe('when disabling the edd button', () => {
+      const { enzymeWrapper } = setup({
+        disableEdd: true
+      })
+
+      test('hides the edd button', () => {
+        expect(enzymeWrapper.find('.text-window-actions__action--edd').length).toEqual(0)
+      })
+
+      describe('when the modal is open', () => {
+        const expandButton = enzymeWrapper.find('.text-window-actions__action--expand').filter(Button)
+        expandButton.simulate('click')
+
+        const linksModal = enzymeWrapper.find(EDSCModalContainer).at(0)
+        expect(linksModal.props().isOpen).toEqual(true)
+
+        test('hides the edd button', () => {
+          expect(enzymeWrapper.find('.text-window-actions__modal-action--edd').length).toEqual(0)
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
# Overview
CSDA collections have their own authentication that makes using EDD impossible

### What is the Solution?

We disable the EDD button on the download files panel when dealing with CSDA collections

### What areas of the application does this impact?

The order status page after the order has been submitted

# Testing

Try to order granules from a CSDA collection, verify EDD button doesn't exist on the download files panel.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
