### PR TITLE
EDSC-3835: Display the Harmony service name more prominantly on the access methods list

### DIFF
--- a/static/src/css/modules/_tooltip.scss
+++ b/static/src/css/modules/_tooltip.scss
@@ -44,6 +44,12 @@
     padding-bottom: 0.325rem;
     border-bottom: 1px solid rgba($color__white, 0.15);
   }
+
+  &__secondary-text {
+    font-size: 0.675rem;
+    color: $color__black--300;
+    display: block;
+  }
 }
 
 /* Account for the addition of the 1px border on tooltip content */

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -219,7 +219,6 @@ export class AccessMethod extends Component {
       let subtitle = null
       let description = null
       let details = null
-      let serviceName = name
 
       switch (type) {
         case 'download': {
@@ -263,7 +262,6 @@ export class AccessMethod extends Component {
           subtitle = 'Harmony'
           description = 'Select options like variables, transformations, and output formats for in-region cloud access.'
           details = 'The requested data will be processed using the Harmony service and stored in the cloud for analysis.'
-          serviceName = name
           break
         }
         default:
@@ -278,7 +276,7 @@ export class AccessMethod extends Component {
             value={methodKey}
             title={title}
             subtitle={subtitle}
-            serviceName={serviceName}
+            serviceName={name}
             description={description}
             details={details}
           />

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -214,8 +214,6 @@ export class AccessMethod extends Component {
 
       const { type, name } = accessMethod
 
-      console.log('name', name)
-
       let id = null
       let title = null
       let subtitle = null

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -430,7 +430,7 @@ export class AccessMethod extends Component {
                 : (
                   <RadioList
                     defaultValue={selectedAccessMethod}
-                    onChange={(methodName) => { this.handleAccessMethodSelection(methodName) }}
+                    onChange={(methodName) => this.handleAccessMethodSelection(methodName)}
                   >
                     {radioList}
                   </RadioList>

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -214,6 +214,8 @@ export class AccessMethod extends Component {
 
       const { type, name } = accessMethod
 
+      console.log('name', name)
+
       let id = null
       let title = null
       let subtitle = null
@@ -261,7 +263,7 @@ export class AccessMethod extends Component {
           title = 'Customize'
           subtitle = 'Harmony'
           description = 'Select options like variables, transformations, and output formats for in-region cloud access.'
-          details = 'The requested data will be processed using the Harmony service and stored in the cloud for analysis.'
+          details = `The requested data will be processed using the ${name} service and stored in the cloud for analysis.`
           break
         }
         default:

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -352,7 +352,7 @@ export class AccessMethod extends Component {
 
     const echoFormFallback = (
       <div className="access-method__echoform-loading">
-        <Spinner className="access-method__echoform-spinner" size="tiny" type="dots" />
+        <Spinner className="access-method__echoform-spinner" dataTestId="access-method-echoform-spinner" size="tiny" type="dots" />
       </div>
     )
 
@@ -430,9 +430,7 @@ export class AccessMethod extends Component {
                 : (
                   <RadioList
                     defaultValue={selectedAccessMethod}
-                    onChange={(methodName) => {
-                      this.handleAccessMethodSelection(methodName)
-                    }}
+                    onChange={(methodName) => { this.handleAccessMethodSelection(methodName) }}
                   >
                     {radioList}
                   </RadioList>

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -430,7 +430,9 @@ export class AccessMethod extends Component {
                 : (
                   <RadioList
                     defaultValue={selectedAccessMethod}
-                    onChange={(methodName) => this.handleAccessMethodSelection(methodName)}
+                    onChange={(methodName) => {
+                      this.handleAccessMethodSelection(methodName)
+                    }}
                   >
                     {radioList}
                   </RadioList>
@@ -550,7 +552,7 @@ export class AccessMethod extends Component {
                       }
                       {
                         !selectedSpatialDisplay && (
-                          <p className="access-method__section-status mb-0" data-testId="no-area-selected">
+                          <p className="access-method__section-status mb-0">
                             { /* eslint-disable-next-line max-len */}
                             No spatial area selected. Make a spatial selection to enable spatial subsetting.
                           </p>
@@ -610,6 +612,7 @@ export class AccessMethod extends Component {
                         className="form-control form-control-sm"
                         onChange={this.handleOutputFormatSelection}
                         value={selectedOutputFormat}
+                        data-testid="access-methods__output-format-options"
                       >
                         {[
                           <option key="output-format-none" value="">None</option>,
@@ -631,6 +634,7 @@ export class AccessMethod extends Component {
                         className="form-control form-control-sm"
                         onChange={this.handleOutputProjectionSelection}
                         value={selectedOutputProjection}
+                        data-testid="access-methods__output-projection-options"
                       >
                         {[
                           <option key="output-projection-none" value="">None</option>,

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -219,6 +219,7 @@ export class AccessMethod extends Component {
       let subtitle = null
       let description = null
       let details = null
+      let serviceName = name
 
       switch (type) {
         case 'download': {
@@ -262,7 +263,7 @@ export class AccessMethod extends Component {
           subtitle = 'Harmony'
           description = 'Select options like variables, transformations, and output formats for in-region cloud access.'
           details = 'The requested data will be processed using the Harmony service and stored in the cloud for analysis.'
-
+          serviceName = name
           break
         }
         default:
@@ -277,7 +278,7 @@ export class AccessMethod extends Component {
             value={methodKey}
             title={title}
             subtitle={subtitle}
-            serviceName={name}
+            serviceName={serviceName}
             description={description}
             details={details}
           />

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -4,44 +4,17 @@ import {
   render, screen, waitFor
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-// import EDSCEchoform from '@edsc/echoforms'
 
 import '@testing-library/jest-dom'
 
 import { AccessMethod } from '../AccessMethod'
 
-// <mock-EchoForm data-testid="mock-echo-form">
-//   {children}
-// </mock-EchoForm>
-// jest.mock('../EchoForm', () => ({
-//   EchoForm: jest.fn().mockImplementation(() => ({
-//     default: jest.fn().then(() => (
-//       <div />
-//     ))
-//   }))
-// }))
-
-// function MockedOtherComponent() {
-//   return <div>mock echo-form</div>
-// }
-// TODO this has a shortcut
-const echoFormMock = jest.mock('../EchoForm', () => () => (
+// Mock the suspended component
+jest.mock('../EchoForm', () => () => (
   <div>
     mock echo-form
   </div>
 ))
-// const mockEchoForm = () => <div>mock echo-form</div>
-// jest.mock('../EchoForm', () => mockEchoForm)
-
-// jest.mock('@edsc/echoforms', () => ({
-//   EDSCEchoform: jest.fn(({ children }) => (
-//     <mock-EDSCEchoForm data-testid="mock-edsc-echo-form">
-//       {children}
-//     </mock-EDSCEchoForm>
-//   ))
-// }))
-
-// const echoFormMock = '<form xmlns="http://echo.nasa.gov/v9/echoforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> <model> <instance> <ecs:options xmlns:ecs="http://ecs.nasa.gov/options"> <!-- ECS distribution options example --> <ecs:distribution> <ecs:mediatype> <ecs:value>FtpPull</ecs:value> </ecs:mediatype> <ecs:mediaformat> <ecs:ftppull-format> <ecs:value>FILEFORMAT</ecs:value> </ecs:ftppull-format> </ecs:mediaformat> </ecs:distribution> <ecs:do-ancillaryprocessing>true</ecs:do-ancillaryprocessing> <ecs:ancillary> <ecs:orderQA/> <ecs:orderPH/> <ecs:orderBrowse/> </ecs:ancillary> </ecs:options> </instance> </model> <ui> <group id="mediaOptionsGroup" label="Media Options" ref="ecs:distribution"> <output id="MediaTypeOutput" label="Media Type:" relevant="ecs:mediatype/ecs:value =\'FtpPull\'" type="xsd:string" value="\'HTTPS Pull\'"/> <output id="FtpPullMediaFormatOutput" label="Media Format:" relevant="ecs:mediaformat/ecs:ftppull-format/ecs:value=\'FILEFORMAT\'" type="xsd:string" value="\'File\'"/> </group> <group id="checkancillaryoptions" label="Additional file options:" ref="ecs:ancillary" relevant="//ecs:do-ancillaryprocessing = \'true\'"> <input label="Include associated Browse file in order" ref="ecs:orderBrowse" type="xsd:boolean"/> <input label="Include associated Quality Assurance file in order" ref="ecs:orderQA" type="xsd:boolean"/> <input label="Include associated Production History file in order" ref="ecs:orderPH" type="xsd:boolean"/> </group> </ui> </form>'
 
 function setup(overrideProps) {
   const onSelectAccessMethod = jest.fn()
@@ -123,8 +96,7 @@ describe('AccessMethod component', () => {
       const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
       await user.click(directDownloadAccessMethodRadioButton)
       expect(onSelectAccessMethod).toHaveBeenCalledTimes(1)
-      // TODO comment why its esi0
-      // TODO find a collection to prove this
+
       // Multiple `ESI` services are possible for a collection
       expect(onSelectAccessMethod).toHaveBeenCalledWith({ collectionId, selectedAccessMethod: 'esi0' })
     })
@@ -141,7 +113,6 @@ describe('AccessMethod component', () => {
         }
       })
       const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
-      // TODO is there a more react-testing library way to do this
       expect(directDownloadAccessMethodRadioButton.value).toEqual('download')
     })
 
@@ -202,11 +173,9 @@ describe('AccessMethod component', () => {
   })
 
   describe('when the selected access method has an echoform', () => {
-    // TODO fix this
     test('lazy loads the echo-forms component and provides the correct fallback', async () => {
       const collectionId = 'collectionId'
       const form = 'mock-form'
-      // const form = 'this is a test form'
       setup({
         accessMethods: {
           echoOrder0: {
@@ -245,22 +214,8 @@ describe('AccessMethod component', () => {
         },
         selectedAccessMethod: 'echoOrder0'
       })
-      // screen.debug()
       const echoOrderInput = screen.getByRole('radio')
       expect(echoOrderInput.value).toEqual('echoOrder0')
-      // await user.click(echoOrderInput)
-      // enzymeWrapper.update()
-
-      // const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
-      // const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
-      // const suspenseComponent = echoFormWrapper.childAt(0)
-      // const echoForm = suspenseComponent.childAt(0)
-
-      // expect(echoForm.props().collectionId).toEqual(collectionId)
-      // expect(echoForm.props().form).toEqual(form)
-      // expect(echoForm.props().methodKey).toEqual('echoOrder0')
-      // expect(echoForm.props().rawModel).toEqual(null)
-      // expect(typeof echoForm.props().onUpdateAccessMethod).toEqual('function')
     })
 
     // TODO react-testing-library not meant to test props going into component
@@ -399,10 +354,8 @@ describe('AccessMethod component', () => {
           screen.getByTestId('access-methods__output-format-options'),
           screen.getByRole('option', { name: 'NETCDF-4' })
         )
-        // TODO I don't see NETCDF-3 on the DOM here?
         expect(screen.getByRole('option', { name: 'NETCDF-4' }).selected).toBe(true)
         expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
-        // tODO why is this selectedOutputFormat different
         expect(onUpdateAccessMethod).toHaveBeenCalledWith({
           collectionId: 'collectionId',
           method: {
@@ -411,19 +364,6 @@ describe('AccessMethod component', () => {
             }
           }
         })
-
-        // const outputFormat = enzymeWrapper.find('#input__output-format')
-        // outputFormat.simulate('change', { target: { value: 'nc4' } })
-
-        // expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
-        // expect(props.onUpdateAccessMethod).toBeCalledWith({
-        //   collectionId: 'collectionId',
-        //   method: {
-        //     harmony0: {
-        //       selectedOutputFormat: 'nc4'
-        //     }
-        //   }
-        // })
       })
     })
 
@@ -748,7 +688,7 @@ describe('AccessMethod component', () => {
       })
 
       describe('when enableTemporalSubsetting is not set', () => {
-        test.only('defaults the checkbox checked', () => {
+        test('defaults the checkbox checked', () => {
           const collectionId = 'collectionId'
           setup({
             accessMethods: {

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -1,15 +1,19 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+
+import {
+  render, screen
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '@testing-library/jest-dom'
 
 import { AccessMethod } from '../AccessMethod'
-import AccessMethodRadio from '../../FormFields/AccessMethodRadio/AccessMethodRadio'
-import RadioList from '../../FormFields/RadioList/RadioList'
-import ProjectPanelSection from '../../ProjectPanels/ProjectPanelSection'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 function setup(overrideProps) {
+  const onSelectAccessMethod = jest.fn()
+  const onSetActivePanel = jest.fn()
+  const onUpdateAccessMethod = jest.fn()
+
   const props = {
     accessMethods: {},
     index: 0,
@@ -20,34 +24,34 @@ function setup(overrideProps) {
     temporal: {},
     ursProfile: {},
     overrideTemporal: {},
-    onSelectAccessMethod: jest.fn(),
-    onSetActivePanel: jest.fn(),
-    onUpdateAccessMethod: jest.fn(),
+    onSelectAccessMethod,
+    onSetActivePanel,
+    onUpdateAccessMethod,
     selectedAccessMethod: '',
     ...overrideProps
   }
 
-  const enzymeWrapper = shallow(<AccessMethod {...props} />)
+  render(<AccessMethod {...props} />)
 
   return {
-    enzymeWrapper,
-    props
+    onSelectAccessMethod,
+    onSetActivePanel,
+    onUpdateAccessMethod
   }
 }
 
 describe('AccessMethod component', () => {
-  test('should render self', () => {
-    const { enzymeWrapper } = setup()
+  // test('should render self', () => {
+  //   const { enzymeWrapper } = setup()
 
-    expect(enzymeWrapper.exists()).toBeTruthy()
-  })
+  //   expect(enzymeWrapper.exists()).toBeTruthy()
+  // })
 
   describe('handleAccessMethodSelection', () => {
-    test('updates the selected access method', () => {
-      const { enzymeWrapper, props } = setup()
-
+    test('updates the selected access method', async () => {
+      const user = userEvent.setup()
       const collectionId = 'collectionId'
-      enzymeWrapper.setProps({
+      const { onSelectAccessMethod } = setup({
         accessMethods: {
           download: {
             isValid: true,
@@ -62,22 +66,26 @@ describe('AccessMethod component', () => {
           hits: 3800
         }
       })
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      await user.click(directDownloadAccessMethodRadioButton)
 
-      const radioList = enzymeWrapper.find(RadioList)
-      radioList.props().onChange('download')
+      expect(onSelectAccessMethod).toHaveBeenCalledTimes(1)
+      expect(onSelectAccessMethod).toHaveBeenCalledWith({ collectionId, selectedAccessMethod: 'download' })
 
-      expect(props.onSelectAccessMethod.mock.calls.length).toBe(1)
-      expect(props.onSelectAccessMethod.mock.calls[0]).toEqual([{
-        collectionId,
-        selectedAccessMethod: 'download'
-      }])
+      // const radioList = enzymeWrapper.find(RadioList)
+      // radioList.props().onChange('download')
+
+      // expect(props.onSelectAccessMethod.mock.calls.length).toBe(1)
+      // expect(props.onSelectAccessMethod.mock.calls[0]).toEqual([{
+      //   collectionId,
+      //   selectedAccessMethod: 'download'
+      // }])
     })
 
-    test('updates the selected access method when type is orderable', () => {
-      const { enzymeWrapper, props } = setup()
-
+    test('updates the selected access method when type is orderable', async () => {
+      const user = userEvent.setup()
       const collectionId = 'collectionId'
-      enzymeWrapper.setProps({
+      const { onSelectAccessMethod } = setup({
         accessMethods: {
           esi0: {
             isValid: true,
@@ -93,22 +101,19 @@ describe('AccessMethod component', () => {
         }
       })
 
-      const radioList = enzymeWrapper.find(RadioList)
-      radioList.props().onChange('esi0')
-
-      expect(props.onSelectAccessMethod.mock.calls.length).toBe(1)
-      expect(props.onSelectAccessMethod.mock.calls[0]).toEqual([{
-        collectionId,
-        selectedAccessMethod: 'esi0'
-      }])
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      await user.click(directDownloadAccessMethodRadioButton)
+      expect(onSelectAccessMethod).toHaveBeenCalledTimes(1)
+      // TODO comment why its esi0
+      // TODO find a collection to prove this
+      // Multiple `ESI` services are possible for a collection
+      expect(onSelectAccessMethod).toHaveBeenCalledWith({ collectionId, selectedAccessMethod: 'esi0' })
     })
   })
 
   describe('radio button display', () => {
     test('renders a radio button for download', () => {
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
+      setup({
         accessMethods: {
           download: {
             isValid: true,
@@ -116,14 +121,13 @@ describe('AccessMethod component', () => {
           }
         }
       })
-
-      expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('download')
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      // TODO is there a more react-testing library way to do this
+      expect(directDownloadAccessMethodRadioButton.value).toEqual('download')
     })
 
     test('renders a radio button for echo orders', () => {
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
+      setup({
         accessMethods: {
           echoOrder0: {
             isValid: true,
@@ -132,13 +136,12 @@ describe('AccessMethod component', () => {
         }
       })
 
-      expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('echoOrder0')
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      expect(directDownloadAccessMethodRadioButton.value).toEqual('echoOrder0')
     })
 
     test('renders a radio button for esi', () => {
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
+      setup({
         accessMethods: {
           esi: {
             isValid: true,
@@ -147,13 +150,14 @@ describe('AccessMethod component', () => {
         }
       })
 
-      expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('esi')
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      expect(directDownloadAccessMethodRadioButton.value).toEqual('esi')
+
+      // expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('esi')
     })
 
     test('renders a radio button for opendap', () => {
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
+      setup({
         accessMethods: {
           opendap: {
             isValid: true,
@@ -161,14 +165,12 @@ describe('AccessMethod component', () => {
           }
         }
       })
-
-      expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('opendap')
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      expect(directDownloadAccessMethodRadioButton.value).toEqual('opendap')
     })
 
     test('renders a radio button for harmony', () => {
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
+      setup({
         accessMethods: {
           harmony0: {
             isValid: true,
@@ -176,119 +178,115 @@ describe('AccessMethod component', () => {
           }
         }
       })
-
-      expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('harmony0')
+      const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
+      // Multiple `Harmony` services are possible for a collection
+      expect(directDownloadAccessMethodRadioButton.value).toEqual('harmony0')
+      // expect(enzymeWrapper.find(AccessMethodRadio).props().value).toEqual('harmony0')
     })
   })
 
-  describe('when the selected access method has an echoform', () => {
-    test('lazy loads the echoforms component and provides the correct fallback', () => {
-      const collectionId = 'collectionId'
-      const form = 'echo form here'
+  // describe('when the selected access method has an echoform', () => {
+  //   // TODO fix thsi
+  //   test.skip('lazy loads the echoforms component and provides the correct fallback', () => {
+  //     const collectionId = 'collectionId'
+  //     const form = 'echo form here'
+  //     setup({
+  //       accessMethods: {
+  //         echoOrder0: {
+  //           isValid: true,
+  //           type: 'ECHO ORDERS',
+  //           form
+  //         }
+  //       },
+  //       metadata: {
+  //         conceptId: collectionId
+  //       },
+  //       selectedAccessMethod: 'echoOrder0'
+  //     })
 
-      const { enzymeWrapper } = setup()
+  //     // enzymeWrapper.update()
 
-      enzymeWrapper.setProps({
-        accessMethods: {
-          echoOrder0: {
-            isValid: true,
-            type: 'ECHO ORDERS',
-            form
-          }
-        },
-        metadata: {
-          conceptId: collectionId
-        },
-        selectedAccessMethod: 'echoOrder0'
-      })
+  //     // const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
+  //     // const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
+  //     // const suspenseComponent = echoFormWrapper.childAt(0)
+  //     // const echoForm = suspenseComponent.childAt(0)
 
-      enzymeWrapper.update()
+  //     // expect(echoFormWrapper.childAt(0).props().fallback.props.className).toEqual('access-method__echoform-loading')
+  //     // expect(echoForm.props().form).toEqual(form)
+  //   })
 
-      const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
-      const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
-      const suspenseComponent = echoFormWrapper.childAt(0)
-      const echoForm = suspenseComponent.childAt(0)
+  //   test('renders an echoform', () => {
+  //     const collectionId = 'collectionId'
+  //     const form = 'echo form here'
 
-      expect(echoFormWrapper.childAt(0).props().fallback.props.className).toEqual('access-method__echoform-loading')
-      expect(echoForm.props().form).toEqual(form)
-    })
+  //     setup({
+  //       accessMethods: {
+  //         echoOrder0: {
+  //           isValid: true,
+  //           type: 'ECHO ORDERS',
+  //           form
+  //         }
+  //       },
+  //       metadata: {
+  //         conceptId: collectionId
+  //       },
+  //       selectedAccessMethod: 'echoOrder0'
+  //     })
 
-    test('renders an echoform', () => {
-      const collectionId = 'collectionId'
-      const form = 'echo form here'
+  //     // enzymeWrapper.update()
 
-      const { enzymeWrapper } = setup()
+  //     // const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
+  //     // const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
+  //     // const suspenseComponent = echoFormWrapper.childAt(0)
+  //     // const echoForm = suspenseComponent.childAt(0)
 
-      enzymeWrapper.setProps({
-        accessMethods: {
-          echoOrder0: {
-            isValid: true,
-            type: 'ECHO ORDERS',
-            form
-          }
-        },
-        metadata: {
-          conceptId: collectionId
-        },
-        selectedAccessMethod: 'echoOrder0'
-      })
+  //     // expect(echoForm.props().collectionId).toEqual(collectionId)
+  //     // expect(echoForm.props().form).toEqual(form)
+  //     // expect(echoForm.props().methodKey).toEqual('echoOrder0')
+  //     // expect(echoForm.props().rawModel).toEqual(null)
+  //     // expect(typeof echoForm.props().onUpdateAccessMethod).toEqual('function')
+  //   })
 
-      enzymeWrapper.update()
+  //   test('renders an echoform with saved fields', () => {
+  //     const collectionId = 'collectionId'
+  //     const form = 'echo form here'
+  //     const rawModel = 'saved fields'
 
-      const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
-      const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
-      const suspenseComponent = echoFormWrapper.childAt(0)
-      const echoForm = suspenseComponent.childAt(0)
+  //     const { enzymeWrapper } = setup()
 
-      expect(echoForm.props().collectionId).toEqual(collectionId)
-      expect(echoForm.props().form).toEqual(form)
-      expect(echoForm.props().methodKey).toEqual('echoOrder0')
-      expect(echoForm.props().rawModel).toEqual(null)
-      expect(typeof echoForm.props().onUpdateAccessMethod).toEqual('function')
-    })
+  //     enzymeWrapper.setProps({
+  //       accessMethods: {
+  //         echoOrder0: {
+  //           isValid: true,
+  //           type: 'ECHO ORDERS',
+  //           form,
+  //           rawModel
+  //         }
+  //       },
+  //       metadata: {
+  //         conceptId: collectionId
+  //       },
+  //       selectedAccessMethod: 'echoOrder0'
+  //     })
 
-    test('renders an echoform with saved fields', () => {
-      const collectionId = 'collectionId'
-      const form = 'echo form here'
-      const rawModel = 'saved fields'
+  //     const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
+  //     const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
+  //     const suspenseComponent = echoFormWrapper.childAt(0)
+  //     const echoForm = suspenseComponent.childAt(0)
 
-      const { enzymeWrapper } = setup()
-
-      enzymeWrapper.setProps({
-        accessMethods: {
-          echoOrder0: {
-            isValid: true,
-            type: 'ECHO ORDERS',
-            form,
-            rawModel
-          }
-        },
-        metadata: {
-          conceptId: collectionId
-        },
-        selectedAccessMethod: 'echoOrder0'
-      })
-
-      const customizationSection = enzymeWrapper.find(ProjectPanelSection).at(1)
-      const echoFormWrapper = customizationSection.find(ProjectPanelSection).at(1)
-      const suspenseComponent = echoFormWrapper.childAt(0)
-      const echoForm = suspenseComponent.childAt(0)
-
-      expect(echoForm.props().collectionId).toEqual(collectionId)
-      expect(echoForm.props().form).toEqual(form)
-      expect(echoForm.props().methodKey).toEqual('echoOrder0')
-      expect(echoForm.props().rawModel).toEqual(rawModel)
-      expect(typeof echoForm.props().onUpdateAccessMethod).toEqual('function')
-    })
-  })
+  //     expect(echoForm.props().collectionId).toEqual(collectionId)
+  //     expect(echoForm.props().form).toEqual(form)
+  //     expect(echoForm.props().methodKey).toEqual('echoOrder0')
+  //     expect(echoForm.props().rawModel).toEqual(rawModel)
+  //     expect(typeof echoForm.props().onUpdateAccessMethod).toEqual('function')
+  //   })
+  // })
 
   describe('when the selected access method is opendap', () => {
-    test('selecting a output format calls onUpdateAccessMethod', () => {
-      const { enzymeWrapper, props } = setup()
-
+    test('selecting a output format calls onUpdateAccessMethod', async () => {
+      const user = userEvent.setup()
       const collectionId = 'collectionId'
-
-      enzymeWrapper.setProps({
+      const { onUpdateAccessMethod } = setup({
         accessMethods: {
           opendap: {
             isValid: true,
@@ -302,11 +300,15 @@ describe('AccessMethod component', () => {
         selectedAccessMethod: 'opendap'
       })
 
-      const outputFormat = enzymeWrapper.find('#input__output-format')
-      outputFormat.simulate('change', { target: { value: 'nc4' } })
+      // `screen.getByRole('combobox')` was not finding the `select` element
+      await user.selectOptions(
+        screen.getByTestId('access-methods__output-format-options'),
+        screen.getByRole('option', { name: 'NETCDF-4' })
+      )
 
-      expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
-      expect(props.onUpdateAccessMethod).toBeCalledWith({
+      expect(screen.getByRole('option', { name: 'NETCDF-4' }).selected).toBe(true)
+      expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+      expect(onUpdateAccessMethod).toHaveBeenCalledWith({
         collectionId: 'collectionId',
         method: {
           opendap: {
@@ -314,17 +316,32 @@ describe('AccessMethod component', () => {
           }
         }
       })
+
+      // await user.click(selectionDropDown)
+      // const netcdf4option = screen.getByText('NETCDF-4')
+      // await user.click(netcdf4option)
+      // expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+
+      // const outputFormat = enzymeWrapper.find('#input__output-format')
+      // outputFormat.simulate('change', { target: { value: 'nc4' } })
+
+      // expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
+      // expect(props.onUpdateAccessMethod).toBeCalledWith({
+      //   collectionId: 'collectionId',
+      //   method: {
+      //     opendap: {
+      //       selectedOutputFormat: 'nc4'
+      //     }
+      //   }
+      // })
     })
   })
 
   describe('when the selected access method is harmony', () => {
     describe('when supportedOutputFormats does not exist', () => {
-      test('displays outputFormat field', () => {
-        const { enzymeWrapper } = setup()
-
+      test('does not display outputFormat field', () => {
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -336,18 +353,15 @@ describe('AccessMethod component', () => {
           },
           selectedAccessMethod: 'harmony0'
         })
-
-        expect(enzymeWrapper.find('#input__output-format').exists()).toBeFalsy()
+        expect(screen.getByText('No customization options are available for the selected access method.')).toBeInTheDocument()
+        expect(screen.queryByTestId('access-methods__output-format-options')).toBeNull()
       })
     })
 
     describe('when supportedOutputFormats exist', () => {
       test('displays outputFormat field', () => {
-        const { enzymeWrapper } = setup()
-
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -360,16 +374,14 @@ describe('AccessMethod component', () => {
           },
           selectedAccessMethod: 'harmony0'
         })
-
-        expect(enzymeWrapper.find('#input__output-format').exists()).toBeTruthy()
+        expect(screen.getByText('Choose from output format options like GeoTIFF, NETCDF, and other file types.')).toBeInTheDocument()
+        expect(screen.queryByTestId('access-methods__output-format-options')).toBeInTheDocument()
       })
 
-      test('selecting a output format calls onUpdateAccessMethod', () => {
-        const { enzymeWrapper, props } = setup()
-
+      test('selecting a output format calls onUpdateAccessMethod', async () => {
+        const user = userEvent.setup()
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        const { onUpdateAccessMethod } = setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -382,29 +394,43 @@ describe('AccessMethod component', () => {
           },
           selectedAccessMethod: 'harmony0'
         })
-
-        const outputFormat = enzymeWrapper.find('#input__output-format')
-        outputFormat.simulate('change', { target: { value: 'nc4' } })
-
-        expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
-        expect(props.onUpdateAccessMethod).toBeCalledWith({
+        // `screen.getByRole('combobox')` was not finding the `select` element
+        await user.selectOptions(
+          screen.getByTestId('access-methods__output-format-options'),
+          screen.getByRole('option', { name: 'NETCDF-4' })
+        )
+        // TODO I don't see NETCDF-3 on the DOM here?
+        expect(screen.getByRole('option', { name: 'NETCDF-4' }).selected).toBe(true)
+        expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+        // tODO why is this selectedOutputFormat different
+        expect(onUpdateAccessMethod).toHaveBeenCalledWith({
           collectionId: 'collectionId',
           method: {
             harmony0: {
-              selectedOutputFormat: 'nc4'
+              selectedOutputFormat: 'application/x-netcdf4'
             }
           }
         })
+
+        // const outputFormat = enzymeWrapper.find('#input__output-format')
+        // outputFormat.simulate('change', { target: { value: 'nc4' } })
+
+        // expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
+        // expect(props.onUpdateAccessMethod).toBeCalledWith({
+        //   collectionId: 'collectionId',
+        //   method: {
+        //     harmony0: {
+        //       selectedOutputFormat: 'nc4'
+        //     }
+        //   }
+        // })
       })
     })
 
-    describe('when supportedOutputProjections does not exist', () => {
-      test('displays outputFormat field', () => {
-        const { enzymeWrapper } = setup()
-
+    describe('when supportedOutputProjections do not exist', () => {
+      test('does not display outputFormat field', () => {
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -417,17 +443,15 @@ describe('AccessMethod component', () => {
           selectedAccessMethod: 'harmony0'
         })
 
-        expect(enzymeWrapper.find('#input__output-projection').exists()).toBeFalsy()
+        expect(screen.getByText('No customization options are available for the selected access method.')).toBeInTheDocument()
+        expect(screen.queryByTestId('access-methods__output-projection-options')).toBeNull()
       })
     })
 
     describe('when supportedOutputProjections exist', () => {
       test('displays outputProjection field', () => {
-        const { enzymeWrapper } = setup()
-
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -441,15 +465,14 @@ describe('AccessMethod component', () => {
           selectedAccessMethod: 'harmony0'
         })
 
-        expect(enzymeWrapper.find('#input__output-projection').exists()).toBeTruthy()
+        expect(screen.getByText('Choose a desired output projection from supported EPSG Codes.')).toBeInTheDocument()
+        expect(screen.queryByTestId('access-methods__output-projection-options')).toBeInTheDocument()
       })
 
-      test('selecting a output projection calls onUpdateAccessMethod', () => {
-        const { enzymeWrapper, props } = setup()
-
+      test('selecting a output projection calls onUpdateAccessMethod', async () => {
+        const user = userEvent.setup()
         const collectionId = 'collectionId'
-
-        enzymeWrapper.setProps({
+        const { onUpdateAccessMethod } = setup({
           accessMethods: {
             harmony0: {
               isValid: true,
@@ -463,11 +486,16 @@ describe('AccessMethod component', () => {
           selectedAccessMethod: 'harmony0'
         })
 
-        const outputFormat = enzymeWrapper.find('#input__output-projection')
-        outputFormat.simulate('change', { target: { value: 'EPSG:4326' } })
+        await user.selectOptions(
+          screen.getByTestId('access-methods__output-projection-options'),
+          screen.getByRole('option', { name: 'EPSG:4326' })
+        )
 
-        expect(props.onUpdateAccessMethod).toBeCalledTimes(1)
-        expect(props.onUpdateAccessMethod).toBeCalledWith({
+        // TODO I don't see NETCDF-3 on the DOM here?
+        expect(screen.getByRole('option', { name: 'EPSG:4326' }).selected).toBe(true)
+        expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+        // tODO why is this selectedOutputFormat different
+        expect(onUpdateAccessMethod).toHaveBeenCalledWith({
           collectionId: 'collectionId',
           method: {
             harmony0: {
@@ -481,11 +509,8 @@ describe('AccessMethod component', () => {
     describe('when temporal subsetting is not supported', () => {
       describe('when a temporal range is not set', () => {
         test('does not display the temporal subsetting input', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -498,18 +523,16 @@ describe('AccessMethod component', () => {
             },
             selectedAccessMethod: 'harmony0'
           })
-
-          expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
+          // tODO is this equal
+          expect(screen.queryByText('Temporal')).toBeNull()
+          // expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
         })
       })
 
       describe('when a temporal range is set', () => {
         test('does not display the temporal subsetting input', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -528,7 +551,9 @@ describe('AccessMethod component', () => {
             }
           })
 
-          expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
+          expect(screen.queryByText('Temporal')).toBeNull()
+
+          // expect(enzymeWrapper.find('#input__temporal-subsetting').exists()).not.toBeTruthy()
         })
       })
     })
@@ -536,11 +561,8 @@ describe('AccessMethod component', () => {
     describe('when temporal subsetting is supported', () => {
       describe('when a temporal range is not set', () => {
         test('displays a message about temporal subsetting', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -553,18 +575,14 @@ describe('AccessMethod component', () => {
             },
             selectedAccessMethod: 'harmony0'
           })
-
-          expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('No temporal range selected.')
+          expect(screen.getByText('No temporal range selected. Make a temporal selection to enable temporal subsetting.')).toBeInTheDocument()
         })
       })
 
       describe('when a temporal range is set', () => {
         test('displays a checkbox input', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -582,16 +600,13 @@ describe('AccessMethod component', () => {
               isRecurring: false
             }
           })
-
-          expect(enzymeWrapper.find('#input__temporal-subsetting').length).toEqual(1)
+          // One single temporal subsetting selection
+          expect(screen.getAllByRole('checkbox').length).toEqual(1)
         })
 
         test('displays the correct selected temporal range', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -609,17 +624,13 @@ describe('AccessMethod component', () => {
               isRecurring: false
             }
           })
-
-          expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:2008-06-27 00:00:00 to 2021-08-01 23:59:59')
+          expect(screen.getByText('Selected Range:2008-06-27 00:00:00 to 2021-08-01 23:59:59')).toBeInTheDocument()
         })
 
         describe('when only an start date is set', () => {
           test('displays the correct selected temporal range', () => {
-            const { enzymeWrapper } = setup()
-
             const collectionId = 'collectionId'
-
-            enzymeWrapper.setProps({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -636,17 +647,13 @@ describe('AccessMethod component', () => {
                 isRecurring: false
               }
             })
-
-            expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:2008-06-27 00:00:00 ongoing')
+            expect(screen.getByText('Selected Range:2008-06-27 00:00:00 ongoing')).toBeInTheDocument()
           })
 
           describe('when only an end date is set', () => {
             test('displays the correct selected temporal range', () => {
-              const { enzymeWrapper } = setup()
-
               const collectionId = 'collectionId'
-
-              enzymeWrapper.setProps({
+              setup({
                 accessMethods: {
                   harmony0: {
                     isValid: true,
@@ -663,8 +670,7 @@ describe('AccessMethod component', () => {
                   isRecurring: false
                 }
               })
-
-              expect(enzymeWrapper.find('.access-method__section-status').text()).toContain('Selected Range:Up to 2008-06-27 00:00:00')
+              expect(screen.getByText('Selected Range:Up to 2008-06-27 00:00:00')).toBeInTheDocument()
             })
           })
         })
@@ -672,7 +678,8 @@ describe('AccessMethod component', () => {
 
       describe('when the temporal selection is recurring', () => {
         test('sets the checkbox unchecked', () => {
-          const { enzymeWrapper } = setup({
+          const collectionId = 'collectionId'
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -681,7 +688,7 @@ describe('AccessMethod component', () => {
               }
             },
             metadata: {
-              conceptId: 'collectionId'
+              conceptId: collectionId
             },
             selectedAccessMethod: 'harmony0',
             temporal: {
@@ -692,12 +699,14 @@ describe('AccessMethod component', () => {
               isRecurring: true
             }
           })
+          expect(screen.getByRole('checkbox').checked).toEqual(false)
 
-          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
+          // expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
         })
 
         test('sets the checkbox disabled', () => {
-          const { enzymeWrapper } = setup({
+          const collectionId = 'collectionId'
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -706,7 +715,7 @@ describe('AccessMethod component', () => {
               }
             },
             metadata: {
-              conceptId: 'collectionId'
+              conceptId: collectionId
             },
             selectedAccessMethod: 'harmony0',
             temporal: {
@@ -717,12 +726,12 @@ describe('AccessMethod component', () => {
               isRecurring: true
             }
           })
-
-          expect(enzymeWrapper.find('#input__temporal-subsetting').props().disabled).toEqual(true)
+          expect(screen.getByRole('checkbox').disabled).toEqual(true)
+          // expect(enzymeWrapper.find('#input__temporal-subsetting').props().disabled).toEqual(true)
         })
 
         test('sets a warning in the section', () => {
-          const { enzymeWrapper } = setup({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -742,18 +751,15 @@ describe('AccessMethod component', () => {
               isRecurring: true
             }
           })
-
-          expect(enzymeWrapper.find(ProjectPanelSection).at(1).childAt(0).props().warning).toEqual('To prevent unexpected results, temporal subsetting is not supported for recurring dates.')
+          expect(screen.getByText('To prevent unexpected results, temporal subsetting is not supported for recurring dates.')).toBeInTheDocument()
+          // expect(enzymeWrapper.find(ProjectPanelSection).at(1).childAt(0).props().warning).toEqual('To prevent unexpected results, temporal subsetting is not supported for recurring dates.')
         })
       })
 
       describe('when enableTemporalSubsetting is not set', () => {
         test('defaults the checkbox checked', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -771,18 +777,15 @@ describe('AccessMethod component', () => {
               isRecurring: false
             }
           })
-
-          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+          // TODO can we specify the checkbox further by name or some other prop
+          expect(screen.getByRole('checkbox').checked).toEqual(true)
         })
       })
 
       describe('when enableTemporalSubsetting is set to true', () => {
         test('sets the checkbox checked', () => {
-          const { enzymeWrapper } = setup()
-
           const collectionId = 'collectionId'
-
-          enzymeWrapper.setProps({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -801,17 +804,46 @@ describe('AccessMethod component', () => {
               isRecurring: false
             }
           })
-
-          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+          expect(screen.getByRole('checkbox').checked).toEqual(true)
         })
 
         describe('when the user clicks the checkbox', () => {
-          test('sets the checkbox checked', () => {
-            const { enzymeWrapper } = setup()
-
+          test('sets the checkbox checked', async () => {
+            const user = userEvent.setup()
             const collectionId = 'collectionId'
+            // `enableTemporalSubsetting` must be set to false here to prevent `checked` form being true
+            setup({
+              accessMethods: {
+                harmony0: {
+                  isValid: true,
+                  type: 'Harmony',
+                  supportsTemporalSubsetting: true,
+                  enableTemporalSubsetting: false
+                }
+              },
+              metadata: {
+                conceptId: collectionId
+              },
+              selectedAccessMethod: 'harmony0',
+              temporal: {
+                startDate: '2008-06-27T00:00:00.979Z',
+                endDate: '2021-08-01T23:59:59.048Z',
+                isRecurring: false
+              }
+            })
+            const checkbox = screen.getByRole('checkbox')
 
-            enzymeWrapper.setProps({
+            // Ensure `checkbox` is false first
+            expect(checkbox.checked).toEqual(false)
+
+            await user.click(checkbox)
+            expect(checkbox.checked).toEqual(true)
+          })
+
+          test('calls onUpdateAccessMethod', async () => {
+            const collectionId = 'collectionId'
+            const user = userEvent.setup()
+            const { onUpdateAccessMethod } = setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -831,51 +863,18 @@ describe('AccessMethod component', () => {
               }
             })
 
-            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+            const checkbox = screen.getByRole('checkbox')
 
-            checkbox.simulate('change', { target: { checked: false } })
-
-            enzymeWrapper.update()
-
-            expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
-          })
-
-          test('calls onUpdateAccessMethod', () => {
-            const { enzymeWrapper, props } = setup({
-              accessMethods: {
-                harmony0: {
-                  isValid: true,
-                  type: 'Harmony',
-                  supportsTemporalSubsetting: true,
-                  enableTemporalSubsetting: true
-                }
-              },
-              metadata: {
-                conceptId: 'collectionId'
-              },
-              selectedAccessMethod: 'harmony0',
-              temporal: {
-                startDate: '2008-06-27T00:00:00.979Z',
-                endDate: '2021-08-01T23:59:59.048Z',
-                isRecurring: false
-              }
-            })
-
-            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
-
-            checkbox.simulate('change', { target: { checked: false } })
-
-            enzymeWrapper.update()
-
-            expect(props.onUpdateAccessMethod).toHaveBeenCalledTimes(1)
-            expect(props.onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: false } } })
+            await user.click(checkbox)
+            expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+            expect(onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: false } } })
           })
         })
       })
 
       describe('when enableTemporalSubsetting is set to false', () => {
         test('sets the checkbox unchecked', () => {
-          const { enzymeWrapper } = setup({
+          setup({
             accessMethods: {
               harmony0: {
                 isValid: true,
@@ -894,13 +893,14 @@ describe('AccessMethod component', () => {
               isRecurring: false
             }
           })
+          expect(screen.getByRole('checkbox').checked).toEqual(false)
 
-          expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
+          // expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(false)
         })
 
         describe('when enableSpatialSubsetting is set to false', () => {
           test('sets the checkbox unchecked for boundingBox', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -917,11 +917,13 @@ describe('AccessMethod component', () => {
                 boundingBox: ['-18.28125,-25.8845,-10.40625,-14.07468']
               }
             })
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
-            expect(enzymeWrapper.find('.access-method__section-status[data-testId="no-area-selected"]').exists()).toEqual(false)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
+
+            // expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
+            // expect(enzymeWrapper.find('.access-method__section-status[data-testId="no-area-selected"]').exists()).toEqual(false)
           })
           test('no area selected shows up when not passing in a spatial value', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -936,10 +938,12 @@ describe('AccessMethod component', () => {
               selectedAccessMethod: 'harmony0',
               spatial: {}
             })
-            expect(enzymeWrapper.find('.access-method__section-status[data-testId="no-area-selected"]').props().children).toEqual('No spatial area selected. Make a spatial selection to enable spatial subsetting.')
+            // expect(screen.getByTestId('no-area-selected'))
+            expect(screen.getByText('No spatial area selected. Make a spatial selection to enable spatial subsetting.')).toBeInTheDocument()
+            // expect(enzymeWrapper.find('.access-method__section-status[data-testId="no-area-selected"]').props().children).toEqual('No spatial area selected. Make a spatial selection to enable spatial subsetting.')
           })
           test('sets the checkbox unchecked for circle', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -956,10 +960,10 @@ describe('AccessMethod component', () => {
                 circle: ['64.125,7.8161,983270-18.28125']
               }
             })
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
           })
           test('sets the checkbox unchecked for point', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -976,10 +980,11 @@ describe('AccessMethod component', () => {
                 point: ['82.6875,-18.61541']
               }
             })
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
+            // expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
           })
           test('sets the checkbox unchecked for line', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -996,10 +1001,11 @@ describe('AccessMethod component', () => {
                 line: ['82.6875,-18.61541,83.1231, -16.11311']
               }
             })
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
+            // expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
           })
           test('sets the checkbox unchecked for shapefile', () => {
-            const { enzymeWrapper } = setup({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -1017,17 +1023,16 @@ describe('AccessMethod component', () => {
                 polygon: ['104.625,-10.6875,103.11328,-10.89844,103.57031,-12.19922,105.32813,-13.11328,106.38281,-11.70703,105.75,-10.33594,104.625,-10.6875']
               }
             })
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
+            // expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(false)
           })
         })
 
         describe('when the user clicks the checkbox', () => {
-          test('sets the checkbox for temporal unchecked', () => {
-            const { enzymeWrapper } = setup()
-
+          test('sets the checkbox for temporal unchecked', async () => {
+            const user = userEvent.setup()
             const collectionId = 'collectionId'
-
-            enzymeWrapper.setProps({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -1046,22 +1051,24 @@ describe('AccessMethod component', () => {
                 isRecurring: false
               }
             })
+            const checkbox = screen.getByRole('checkbox')
+            expect(checkbox.checked).toEqual(true)
+            await user.click(checkbox)
+            expect(screen.getByRole('checkbox').checked).toEqual(false)
 
-            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
+            // const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
 
-            checkbox.simulate('change', { target: { checked: true } })
+            // checkbox.simulate('change', { target: { checked: true } })
 
-            enzymeWrapper.update()
+            // enzymeWrapper.update()
 
-            expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
+            // expect(enzymeWrapper.find('#input__temporal-subsetting').props().checked).toEqual(true)
           })
 
-          test('sets the checkbox for spatial unchecked', () => {
-            const { enzymeWrapper } = setup()
-
+          test('sets the checkbox for spatial checked', async () => {
+            const user = userEvent.setup()
             const collectionId = 'collectionId'
-
-            enzymeWrapper.setProps({
+            setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -1078,22 +1085,23 @@ describe('AccessMethod component', () => {
                 boundingBox: ['-18.28125,-25.8845,-10.40625,-14.07468']
               }
             })
+            const checkbox = screen.getByRole('checkbox')
+            await user.click(checkbox)
+            expect(screen.getByRole('checkbox').checked).toEqual(true)
 
-            const checkbox = enzymeWrapper.find('#input__spatial-subsetting')
+            // const checkbox = enzymeWrapper.find('#input__spatial-subsetting')
 
-            checkbox.simulate('change', { target: { checked: true } })
+            // checkbox.simulate('change', { target: { checked: true } })
 
-            enzymeWrapper.update()
+            // enzymeWrapper.update()
 
-            expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(true)
+            // expect(enzymeWrapper.find('#input__spatial-subsetting').props().checked).toEqual(true)
           })
 
-          test('calls onUpdateAccessMethod', () => {
-            const { enzymeWrapper, props } = setup()
-
+          test('calls onUpdateAccessMethod', async () => {
+            const user = userEvent.setup()
             const collectionId = 'collectionId'
-
-            enzymeWrapper.setProps({
+            const { onUpdateAccessMethod } = setup({
               accessMethods: {
                 harmony0: {
                   isValid: true,
@@ -1112,17 +1120,31 @@ describe('AccessMethod component', () => {
                 isRecurring: false
               }
             })
-
-            const checkbox = enzymeWrapper.find('#input__temporal-subsetting')
-
-            checkbox.simulate('change', { target: { checked: true } })
-
-            enzymeWrapper.update()
-
-            expect(props.onUpdateAccessMethod).toHaveBeenCalledTimes(1)
-            expect(props.onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: true } } })
+            const checkbox = screen.getByRole('checkbox')
+            await user.click(checkbox)
+            expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
+            expect(onUpdateAccessMethod).toHaveBeenCalledWith({ collectionId: 'collectionId', method: { harmony0: { enableTemporalSubsetting: false } } })
           })
         })
+      })
+    })
+    describe('when a service name is passed in', () => {
+      test('the service name is display on the panel without needing to click `More Info`', () => {
+        const collectionId = 'collectionId'
+        const serviceName = 'harmony-service-name'
+        setup({
+          accessMethods: {
+            harmony0: {
+              isValid: true,
+              type: 'Harmony',
+              name: serviceName
+            }
+          },
+          metadata: {
+            conceptId: collectionId
+          }
+        })
+        expect(screen.getByText('Service: harmony-service-name')).toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -1073,7 +1073,7 @@ describe('AccessMethod component', () => {
             }
           })
 
-          expect(screen.getByText('OPeNDAP (opendap-service-name)')).toBeInTheDocument()
+          expect(screen.getByText('opendap-service-name')).toBeInTheDocument()
         })
       })
       describe('when the service type is `Harmony`', () => {
@@ -1092,7 +1092,7 @@ describe('AccessMethod component', () => {
               conceptId: collectionId
             }
           })
-          expect(screen.getByText('Harmony (harmony-service-name)')).toBeInTheDocument()
+          expect(screen.getByText('harmony-service-name')).toBeInTheDocument()
         })
       })
     })

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -193,7 +193,7 @@ describe('AccessMethod component', () => {
       // Spinner up before the lazy loaded component has completed loading
       expect(screen.getByTestId('access-method-echoform-spinner')).toBeInTheDocument()
 
-      // Wait for the lazy loaded component to load
+      // Wait for the lazy loaded component to load with the mocked implementation
       await waitFor(() => expect(screen.getByText('mock echo-form')).toBeInTheDocument())
     })
 

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.js
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.js
@@ -404,7 +404,7 @@ export const CollectionResultsItem = forwardRef(({
                             className="collection-results-item__tooltip collection-results-item__tooltip--csda"
                           >
                             Commercial Smallsat Data Acquisition Program
-                            <span className="collection-results-item__tooltip-secondary">
+                            <span className="tooltip__secondary-text">
                               (Additional authentication required)
                             </span>
                           </Tooltip>

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.scss
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.scss
@@ -361,12 +361,6 @@
     color: $color__black--300;
   }
 
-  &__tooltip-secondary {
-    font-size: 0.675rem;
-    color: $color__black--300;
-    display: block;
-  }
-
   &__popover {
     display: flex;
     flex-direction: column;

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -63,14 +63,17 @@ export const AccessMethodRadio = ({
                 {subtitle}
               </span>
             </span>
-            { serviceName
-           && (
-           <span className="access-method-radio__primary-service-name">
-             {serviceName}
-           </span>
-           )}
+            {
+              serviceName && (
+                <div className="access-method-radio__header-secondary">
+                  <span className="access-method-radio__primary-service-name" title={`Service: ${serviceName}`}>
+                    {serviceName}
+                  </span>
+                </div>
+              )
+            }
           </div>
-          <div className="access-method-radio__header-secondary">
+          <div className="access-method-radio__header-content">
             <span className="access-method-radio__description">
               {description}
             </span>
@@ -96,14 +99,6 @@ export const AccessMethodRadio = ({
           <span className="access-method-radio__details">
             {details}
           </span>
-          {
-            serviceName && (
-              <span className="access-method-radio__service-name">
-                {'Service: '}
-                {serviceName}
-              </span>
-            )
-          }
         </div>
       </CSSTransition>
     </label>

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { CSSTransition } from 'react-transition-group'
 import { FaCheck } from 'react-icons/fa'
 
@@ -65,11 +67,22 @@ export const AccessMethodRadio = ({
             </span>
             {
               serviceName && (
-                <div className="access-method-radio__header-secondary">
-                  <span className="access-method-radio__primary-service-name" title={`Service: ${serviceName}`}>
-                    {serviceName}
-                  </span>
-                </div>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={(
+                    <Tooltip>
+                      Service:
+                      {' '}
+                      {serviceName}
+                    </Tooltip>
+                )}
+                >
+                  <div className="access-method-radio__header-secondary">
+                    <span className="access-method-radio__primary-service-name">
+                      {serviceName}
+                    </span>
+                  </div>
+                </OverlayTrigger>
               )
             }
           </div>

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -71,8 +71,7 @@ export const AccessMethodRadio = ({
                   placement="top"
                   overlay={(
                     <Tooltip>
-                      Service:
-                      {' '}
+                      <span className="tooltip__secondary-text">Service</span>
                       {serviceName}
                     </Tooltip>
                 )}

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -55,12 +55,20 @@ export const AccessMethodRadio = ({
       <div className="access-method-radio__content">
         <header className="access-method-radio__header">
           <div className="access-method-radio__header-primary">
-            <h4 className="access-method-radio__title">
-              {title}
-            </h4>
-            <span className="access-method-radio__subtitle">
-              {serviceName && subtitle ? (`${subtitle} (${serviceName})`) : subtitle }
+            <span className="access-method-radio__primary-titles">
+              <h4 className="access-method-radio__title">
+                {title}
+              </h4>
+              <span className="access-method-radio__subtitle">
+                {subtitle}
+              </span>
             </span>
+            { serviceName
+           && (
+           <span className="access-method-radio__primary-service-name">
+             {serviceName}
+           </span>
+           )}
           </div>
           <div className="access-method-radio__header-secondary">
             <span className="access-method-radio__description">

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -59,20 +59,12 @@ export const AccessMethodRadio = ({
               {title}
             </h4>
             <span className="access-method-radio__subtitle">
-              {subtitle}
+              {serviceName && subtitle ? (`${subtitle} (${serviceName})`) : subtitle }
             </span>
           </div>
           <div className="access-method-radio__header-secondary">
             <span className="access-method-radio__description">
               {description}
-              {
-            serviceName && subtitle === 'Harmony' && (
-              <span className="access-method-radio__service-name">
-                {'Service: '}
-                {serviceName}
-              </span>
-            )
-          }
             </span>
           </div>
           <div className="access-method-radio__header-tertiary">
@@ -97,7 +89,7 @@ export const AccessMethodRadio = ({
             {details}
           </span>
           {
-            serviceName && subtitle !== 'Harmony' && (
+            serviceName && (
               <span className="access-method-radio__service-name">
                 {'Service: '}
                 {serviceName}

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.js
@@ -65,6 +65,14 @@ export const AccessMethodRadio = ({
           <div className="access-method-radio__header-secondary">
             <span className="access-method-radio__description">
               {description}
+              {
+            serviceName && subtitle === 'Harmony' && (
+              <span className="access-method-radio__service-name">
+                {'Service: '}
+                {serviceName}
+              </span>
+            )
+          }
             </span>
           </div>
           <div className="access-method-radio__header-tertiary">
@@ -89,7 +97,7 @@ export const AccessMethodRadio = ({
             {details}
           </span>
           {
-            serviceName && (
+            serviceName && subtitle !== 'Harmony' && (
               <span className="access-method-radio__service-name">
                 {'Service: '}
                 {serviceName}

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -66,11 +66,26 @@
   &__header-primary {
     vertical-align: baseline;
     margin-bottom: 0.25rem;
-    white-space: nowrap;
     display: flex;
+    flex-direction: row;
+    align-items: baseline;
   }
 
   &__header-secondary {
+    display: flex;
+    justify-content: flex-end;
+    align-items: baseline;
+    width: 17rem;
+    background: $color__black--200;
+    color: $color__black--900;
+    border-radius: 1rem;
+    font-size: 0.625rem;
+    font-weight: 700;
+    margin-left: 0.25rem;
+    padding: 0.075rem 0.5rem;
+  }
+
+  &__header-content {
     margin-bottom: 0.325rem;
   }
 
@@ -102,15 +117,21 @@
   }
 
   &__primary-titles {
+    display: flex;
+    align-items: baseline;
     flex-grow: 1;
   }
 
 
   &__primary-service-name {
-    padding-left: 10px;
+    display: block;
+    padding: 0 0.125rem;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
     color: $color__black--500;
   }
-  
+
 
   &__description {
     margin: 0;
@@ -211,11 +232,12 @@
   &__details {
     display: block;
     font-size: 0.825rem;
+    word-break: break-word;
   }
 
   &__service-name {
     display: block;
-    margin-top: 0.75rem;
     font-size: 0.825rem;
+    word-break: break-all;
   }
 }

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -16,6 +16,8 @@
     border: 1px solid darken($color__black--200, 10);
     background-color: $color__black--100;
     color: $color__black--800;
+    overflow-x: scroll;
+    overflow-y: hidden;
   }
 
   &__input {
@@ -66,6 +68,7 @@
   &__header-primary {
     vertical-align: baseline;
     margin-bottom: 0.25rem;
+    white-space: nowrap;
   }
 
   &__header-secondary {

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -61,6 +61,7 @@
     margin-bottom: 0.875*$spacer;
     margin-right: $spacer;
     margin-left: 2.5*$spacer;
+    overflow: hidden;
   }
 
   &__header-primary {
@@ -72,17 +73,21 @@
   }
 
   &__header-secondary {
+    position: relative;
+    top: -0.125rem;
     display: flex;
     justify-content: center;
-    align-items: baseline;
-    width: 9rem;
+    align-items: center;
     background: $color__black--200;
     color: $color__black--900;
     border-radius: 1rem;
     font-size: 0.625rem;
     font-weight: 700;
-    margin-left: 0.25rem;
+    margin-left: 1rem;
     padding: 0.075rem 0.5rem;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   &__header-content {

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -73,9 +73,9 @@
 
   &__header-secondary {
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: baseline;
-    width: 17rem;
+    width: 9rem;
     background: $color__black--200;
     color: $color__black--900;
     border-radius: 1rem;

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.scss
@@ -16,8 +16,6 @@
     border: 1px solid darken($color__black--200, 10);
     background-color: $color__black--100;
     color: $color__black--800;
-    overflow-x: scroll;
-    overflow-y: hidden;
   }
 
   &__input {
@@ -69,6 +67,7 @@
     vertical-align: baseline;
     margin-bottom: 0.25rem;
     white-space: nowrap;
+    display: flex;
   }
 
   &__header-secondary {
@@ -101,6 +100,17 @@
     color: $color__black--500;
     font-size: 0.825rem;
   }
+
+  &__primary-titles {
+    flex-grow: 1;
+  }
+
+
+  &__primary-service-name {
+    padding-left: 10px;
+    color: $color__black--500;
+  }
+  
 
   &__description {
     margin: 0;

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import {
-  render, screen
+  act, render, screen
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -47,7 +47,6 @@ describe('AccessMethodRadio component', () => {
 
   test('adds an htmlFor prop using the id', () => {
     setup()
-    screen.debug()
     const label = screen.getByTestId('test-id')
     expect(label.htmlFor).toEqual('test-id')
   })
@@ -162,9 +161,10 @@ describe('AccessMethodRadio component', () => {
     })
 
     test('displays the service name', () => {
-      setup({ serviceName: 'test service name' })
-      // The service name appears on the document under the More-Info-block
-      const renderedServiceNames = screen.getAllByText('Service: test service name')
+      const harmonyDetails = 'details: The service-name-is-passed-as-prop'
+      setup({ serviceName: 'test service name', details: harmonyDetails })
+      // The service name is passed in through the `details` prop
+      const renderedServiceNames = screen.getAllByText(harmonyDetails)
       // renders in the `More-Info` section
       expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__more-info')
       expect(renderedServiceNames.length).toEqual(1)
@@ -174,8 +174,18 @@ describe('AccessMethodRadio component', () => {
         setup({ serviceName: 'test service name', subtitle: 'Harmony' })
         const renderedServiceNames = screen.getAllByText('test service name')
         // renders in the `access-method-content` section
-        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
+        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-secondary')
         expect(renderedServiceNames.length).toEqual(1)
+      })
+
+      test('Hovering over the service name opens a tooltip', async () => {
+        const user = userEvent.setup()
+        setup({ serviceName: 'test service name', subtitle: 'Harmony' })
+        const renderedServiceName = screen.getByText('test service name')
+        await act(async () => {
+          await user.hover(renderedServiceName)
+        })
+        expect(screen.getByText('Service: test service name')).toBeInTheDocument()
       })
     })
     describe('when the `subtitle` is `OPeNDAP`', () => {
@@ -183,8 +193,18 @@ describe('AccessMethodRadio component', () => {
         setup({ serviceName: 'test service name', subtitle: 'OPeNDAP' })
         const renderedServiceNames = screen.getAllByText('test service name')
         // renders in the `access-method-content` section
-        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
+        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-secondary')
         expect(renderedServiceNames.length).toEqual(1)
+      })
+
+      test('Hovering over the service name opens a tooltip', async () => {
+        const user = userEvent.setup()
+        setup({ serviceName: 'test service name', subtitle: 'OPeNDAP' })
+        const renderedServiceName = screen.getByText('test service name')
+        await act(async () => {
+          await user.hover(renderedServiceName)
+        })
+        expect(screen.getByText('Service: test service name')).toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -1,153 +1,173 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+
+import {
+  render, screen
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import '@testing-library/jest-dom'
+
 import AccessMethodRadio from '../AccessMethodRadio'
 
-Enzyme.configure({ adapter: new Adapter() })
-
-function setup(overrideProps) {
+const setup = (overrideProps) => {
+  const onChange = jest.fn()
+  const onClick = jest.fn()
   const props = {
     id: 'test-id',
     description: 'test description',
     details: 'test details',
     value: 'test value',
     checked: false,
-    onChange: jest.fn(),
-    onClick: jest.fn(),
+    onChange,
+    onClick,
     title: 'test title',
     subtitle: 'test subtitle',
     ...overrideProps
   }
 
-  const enzymeWrapper = shallow(<AccessMethodRadio {...props} />)
+  render(<AccessMethodRadio {...props} />)
 
   return {
-    enzymeWrapper,
-    props
+    onChange,
+    onClick
   }
 }
 
-describe('AccessMethodRadio component', () => {
-  const { enzymeWrapper, props } = setup()
+// Setup DOM elements before each test
+// beforeEach(() => {
+//   const { onChange, onClick } = setup()
+// })
 
-  test('renders as a label', () => {
-    expect(enzymeWrapper.type()).toBe('label')
+describe('AccessMethodRadio component', () => {
+  // TODO I can som test these two with `querySelector`
+
+  test.skip('renders as a label', () => {
+    expect(screen.getByLabelText())
   })
 
   test('has a test id', () => {
-    expect(enzymeWrapper.props()['data-testid']).toBe('test-id')
+    setup()
+    expect(screen.getByTestId('test-id')).toBeInTheDocument()
   })
 
-  test('adds an htmlFor prop using the id', () => {
-    expect(enzymeWrapper.props().htmlFor).toBe('test-id')
-  })
+  // test('adds an htmlFor prop using the id', () => {
+  //   expect(enzymeWrapper.props().htmlFor).toBe('test-id')
+  // })
 
-  test('does not add the is-selected classname modifier', () => {
-    expect(enzymeWrapper.props().className).not.toContain('access-method-radio--is-selected')
-  })
+  // test('does not add the is-selected classname modifier', () => {
+  //   expect(enzymeWrapper.props().className).not.toContain('access-method-radio--is-selected')
+  // })
 
   test('displays the title', () => {
-    expect(enzymeWrapper.find('.access-method-radio__title').text()).toBe('test title')
+    setup()
+    expect(screen.getByText('test title')).toBeInTheDocument()
   })
 
   test('displays the subtitle', () => {
-    expect(enzymeWrapper.find('.access-method-radio__subtitle').text()).toBe('test subtitle')
+    setup()
+    expect(screen.getByText('test subtitle')).toBeInTheDocument()
   })
 
   test('displays the description', () => {
-    expect(enzymeWrapper.find('.access-method-radio__description').text()).toBe('test description')
+    setup()
+    expect(screen.getByText('test description')).toBeInTheDocument()
   })
 
   test('displays the details', () => {
-    expect(enzymeWrapper.find('.access-method-radio__details').text()).toBe('test details')
+    setup()
+    expect(screen.getByText('test details')).toBeInTheDocument()
+    // expect(enzymeWrapper.find('.access-method-radio__details').text()).toBe('test details')
   })
 
-  test('does not display the service name section', () => {
-    expect(enzymeWrapper.find('.access-method-radio__service-name').length).toBe(0)
+  test('does not display the service name section since this is not a `Harmony` service', () => {
+    setup()
+    expect(screen.queryAllByText('Service:').length).toBe(0)
+    // expect(enzymeWrapper.find('.access-method-radio__service-name').length).toBe(0)
   })
 
   describe('input element', () => {
     test('has a name property', () => {
-      expect(enzymeWrapper.find('input').props().name).toBe('test-id')
+      // https://stackoverflow.com/questions/66633103/how-to-test-radio-button-in-react-testing-libraryuser-can-select-other-radio-bu
+      // expect(enzymeWrapper.find('input').props().name).toBe('test-id')
+      // There is a single radio button
+      setup()
+      expect(screen.getByRole('radio', { value: 'test value' })).toBeInTheDocument()
+    })
+    // TODO is false the same as empty string here
+    test.skip('sets the checked property', () => {
+      // expect(enzymeWrapper.find('input').props().checked).toBe('')
+      setup()
+      const radioButton = screen.getByRole('radio', { value: 'test value' })
+      expect(radioButton.checked).toEqual('')
     })
 
-    test('has a value property', () => {
-      expect(enzymeWrapper.find('input').props().value).toBe('test value')
-    })
-
-    test('sets the checked property', () => {
-      expect(enzymeWrapper.find('input').props().checked).toBe('')
-    })
-
-    test('fires the onChange callback', () => {
-      enzymeWrapper.find('input').simulate('change')
-
-      const { onChange } = props
-
+    test('fires the onChange callback', async () => {
+      // enzymeWrapper.find('input').simulate('change')
+      const { onChange } = setup()
+      const user = userEvent.setup()
+      const radioButton = screen.getByRole('radio', { value: 'test value' })
+      await user.click(radioButton)
       expect(onChange).toHaveBeenCalledTimes(1)
     })
 
-    test('fires the onClick callback', () => {
-      enzymeWrapper.find('input').simulate('click')
-
-      const { onClick } = props
-
+    test('fires the onClick callback', async () => {
+      const { onClick } = setup()
+      const user = userEvent.setup()
+      const radioButton = screen.getByRole('radio', { value: 'test value' })
+      await user.click(radioButton)
       expect(onClick).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('fake input element', () => {
     test('does not display an icon', () => {
-      expect(enzymeWrapper.find('.access-method-radio__radio-icon').length).toBe(0)
+      expect()
+      // expect(enzymeWrapper.find('.access-method-radio__radio-icon').length).toBe(0)
     })
   })
 
   describe('more info section', () => {
     test('does not display by default', () => {
-      expect(enzymeWrapper.find('CSSTransition').props().in).toBe(false)
+      setup()
+      expect(screen.getByText('More Info')).toBeInTheDocument()
     })
 
-    test('displays when the more info button is clicked', () => {
-      const stopPropagationMock = jest.fn()
+    test('displays when the more info button is clicked', async () => {
+      const { onClick } = setup()
+      const user = userEvent.setup()
+      const moreInfoButton = screen.getByRole('button')
+      await user.click(moreInfoButton)
+      expect(screen.getByText('Less Info')).toBeInTheDocument()
 
-      enzymeWrapper.find('button').simulate('click', {
-        stopPropagation: stopPropagationMock
-      })
-
-      expect(enzymeWrapper.find('CSSTransition').props().in).toBe(true)
-      expect(stopPropagationMock).toHaveBeenCalledTimes(1)
+      // Ensure outer `onClick` is not being called
+      expect(onClick).toHaveBeenCalledTimes(0)
     })
   })
 
   describe('when the access method is checked', () => {
-    const { enzymeWrapper } = setup({
-      checked: true
-    })
-
-    test('adds the is-selected classname modifier', () => {
-      expect(enzymeWrapper.props().className).toContain('access-method-radio--is-selected')
-    })
+    // test('adds the is-selected classname modifier', () => {
+    //   expect(enzymeWrapper.props().className).toContain('access-method-radio--is-selected')
+    // })
 
     describe('input element', () => {
       test('sets the checked property', () => {
-        expect(enzymeWrapper.find('input').props().checked).toBe('checked')
-      })
-    })
-
-    describe('fake input element', () => {
-      test('displays an icon', () => {
-        expect(enzymeWrapper.find('.access-method-radio__radio-icon').length).toBe(1)
+        setup({ checked: true })
+        // expect(enzymeWrapper.find('input').props().checked).toBe('checked')
+        const radioButton = screen.getByRole('radio', { value: 'test value' })
+        // TODO why are these different values????
+        // expect(radioButton.checked).toEqual('checked')
+        expect(radioButton.checked).toEqual(true)
+        expect(screen.getByTestId('edsc-icon')).toBeInTheDocument()
       })
     })
   })
 
   describe('when a service name is provided', () => {
-    const { enzymeWrapper } = setup({
-      serviceName: 'test service name'
-    })
-
     test('does not display an icon', () => {
-      expect(enzymeWrapper.find('.access-method-radio__service-name').text()).toBe('Service: test service name')
+      setup({ serviceName: 'test service name' })
+      expect(screen.getByText('Service: test service name')).toBeInTheDocument()
+      // The icon does not render
+      expect(screen.queryByTestId('edsc-icon')).toBeNull()
     })
   })
 })

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -172,9 +172,18 @@ describe('AccessMethodRadio component', () => {
     describe('when the `subtitle` is `Harmony`', () => {
       test('service name appears on on customizable option does not appear in the more-info section', () => {
         setup({ serviceName: 'test service name', subtitle: 'Harmony' })
-        const renderedServiceNames = screen.getAllByText('Service: test service name')
+        const renderedServiceNames = screen.getAllByText('Harmony (test service name)')
         // renders in the `access-method-content` section
-        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-secondary')
+        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
+        expect(renderedServiceNames.length).toEqual(1)
+      })
+    })
+    describe('when the `subtitle` is `OPeNDAP`', () => {
+      test('service name appears on on customizable option does not appear in the more-info section', () => {
+        setup({ serviceName: 'test service name', subtitle: 'OPeNDAP' })
+        const renderedServiceNames = screen.getAllByText('OPeNDAP (test service name)')
+        // renders in the `access-method-content` section
+        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
         expect(renderedServiceNames.length).toEqual(1)
       })
     })

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -50,15 +50,17 @@ describe('AccessMethodRadio component', () => {
     expect(screen.getByTestId('test-id')).toBeInTheDocument()
   })
 
-  // TODO I can test this with `querySelector`
-  // test('adds an htmlFor prop using the id', () => {
-  //   expect(enzymeWrapper.props().htmlFor).toBe('test-id')
-  // })
+  test('adds an htmlFor prop using the id', () => {
+    setup()
+    screen.debug()
+    const label = screen.getByTestId('test-id')
+    expect(label.htmlFor).toEqual('test-id')
+  })
 
   test('does not add the is-selected classname modifier', () => {
     setup()
-    const input = screen.getByTestId('test-id')
-    expect(input.className).not.toContain('access-method-radio--is-selected')
+    const label = screen.getByTestId('test-id')
+    expect(label.className).not.toContain('access-method-radio--is-selected')
   })
 
   test('displays the title', () => {
@@ -88,14 +90,12 @@ describe('AccessMethodRadio component', () => {
 
   describe('input element', () => {
     test('has a name property', () => {
-      // https://stackoverflow.com/questions/66633103/how-to-test-radio-button-in-react-testing-libraryuser-can-select-other-radio-bu
-      // expect(enzymeWrapper.find('input').props().name).toBe('test-id')
-      // There is a single radio button
       setup()
-      expect(screen.getByRole('radio', { value: 'test value' })).toBeInTheDocument()
+      const input = screen.getByRole('radio', { value: 'test value' })
+      expect(input.name).toEqual('test-id')
     })
-    // TODO is false the same as empty string here
     test('sets the checked property', () => {
+      // TODO is false the same as empty string here
       // expect(enzymeWrapper.find('input').props().checked).toBe('')
       setup()
       const radioButton = screen.getByRole('radio', { value: 'test value' })
@@ -147,8 +147,8 @@ describe('AccessMethodRadio component', () => {
   describe('when the access method is checked', () => {
     test('adds the is-selected classname modifier', () => {
       setup({ checked: true })
-      const input = screen.getByTestId('test-id')
-      expect(input.className).toContain('access-method-radio--is-selected')
+      const label = screen.getByTestId('test-id')
+      expect(label.className).toContain('access-method-radio--is-selected')
     })
 
     describe('input element', () => {

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -167,6 +167,7 @@ describe('AccessMethodRadio component', () => {
       // The icon does not render
       expect(screen.queryByTestId('edsc-icon')).toBeNull()
     })
+
     test('displays the service name', () => {
       setup({ serviceName: 'test service name' })
       // The service name appears on the document under the More-Info-block

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -185,7 +185,9 @@ describe('AccessMethodRadio component', () => {
         await act(async () => {
           await user.hover(renderedServiceName)
         })
-        expect(screen.getByText('Service: test service name')).toBeInTheDocument()
+        // Tooltip is being styled and rendered
+        const tooltipMessage = screen.getByText('Service')
+        expect(tooltipMessage.className).toEqual('tooltip__secondary-text')
       })
     })
     describe('when the `subtitle` is `OPeNDAP`', () => {
@@ -204,7 +206,9 @@ describe('AccessMethodRadio component', () => {
         await act(async () => {
           await user.hover(renderedServiceName)
         })
-        expect(screen.getByText('Service: test service name')).toBeInTheDocument()
+        // Tooltip is being styled and rendered
+        const tooltipMessage = screen.getByText('Service')
+        expect(tooltipMessage.className).toEqual('tooltip__secondary-text')
       })
     })
   })

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -34,16 +34,11 @@ const setup = (overrideProps) => {
 }
 
 describe('AccessMethodRadio component', () => {
-  // TODO this is technically an implementation detail by react-test-library but, I could
-  // TODO: retrieve using query selector
-  // test.only('renders as a label', () => {
-  //   setup()
-  // const label = screen.getByTestId('test-id')
-  //   expect(screen.getByRole('menu'))
-  //   screen.debug()
-  // expect(screen.getByTestId('test-id')).toBeInTheDocument()
-  // expect(screen.getByLabelText())
-  // })
+  test('renders as a label', () => {
+    setup()
+    const label = screen.getByTestId('test-id')
+    expect(label.nodeName).toEqual('LABEL')
+  })
 
   test('has a test id', () => {
     setup()
@@ -95,8 +90,6 @@ describe('AccessMethodRadio component', () => {
       expect(input.name).toEqual('test-id')
     })
     test('sets the checked property', () => {
-      // TODO is false the same as empty string here
-      // expect(enzymeWrapper.find('input').props().checked).toBe('')
       setup()
       const radioButton = screen.getByRole('radio', { value: 'test value' })
       expect(radioButton.checked).toEqual(false)

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -33,30 +33,33 @@ const setup = (overrideProps) => {
   }
 }
 
-// Setup DOM elements before each test
-// beforeEach(() => {
-//   const { onChange, onClick } = setup()
-// })
-
 describe('AccessMethodRadio component', () => {
-  // TODO I can som test these two with `querySelector`
-
-  test.skip('renders as a label', () => {
-    expect(screen.getByLabelText())
-  })
+  // TODO this is technically an implementation detail by react-test-library but, I could
+  // TODO: retrieve using query selector
+  // test.only('renders as a label', () => {
+  //   setup()
+  // const label = screen.getByTestId('test-id')
+  //   expect(screen.getByRole('menu'))
+  //   screen.debug()
+  // expect(screen.getByTestId('test-id')).toBeInTheDocument()
+  // expect(screen.getByLabelText())
+  // })
 
   test('has a test id', () => {
     setup()
     expect(screen.getByTestId('test-id')).toBeInTheDocument()
   })
 
+  // TODO I can test this with `querySelector`
   // test('adds an htmlFor prop using the id', () => {
   //   expect(enzymeWrapper.props().htmlFor).toBe('test-id')
   // })
 
-  // test('does not add the is-selected classname modifier', () => {
-  //   expect(enzymeWrapper.props().className).not.toContain('access-method-radio--is-selected')
-  // })
+  test('does not add the is-selected classname modifier', () => {
+    setup()
+    const input = screen.getByTestId('test-id')
+    expect(input.className).not.toContain('access-method-radio--is-selected')
+  })
 
   test('displays the title', () => {
     setup()
@@ -76,13 +79,11 @@ describe('AccessMethodRadio component', () => {
   test('displays the details', () => {
     setup()
     expect(screen.getByText('test details')).toBeInTheDocument()
-    // expect(enzymeWrapper.find('.access-method-radio__details').text()).toBe('test details')
   })
 
-  test('does not display the service name section since this is not a `Harmony` service', () => {
+  test('does not display the service name', () => {
     setup()
     expect(screen.queryAllByText('Service:').length).toBe(0)
-    // expect(enzymeWrapper.find('.access-method-radio__service-name').length).toBe(0)
   })
 
   describe('input element', () => {
@@ -94,15 +95,14 @@ describe('AccessMethodRadio component', () => {
       expect(screen.getByRole('radio', { value: 'test value' })).toBeInTheDocument()
     })
     // TODO is false the same as empty string here
-    test.skip('sets the checked property', () => {
+    test('sets the checked property', () => {
       // expect(enzymeWrapper.find('input').props().checked).toBe('')
       setup()
       const radioButton = screen.getByRole('radio', { value: 'test value' })
-      expect(radioButton.checked).toEqual('')
+      expect(radioButton.checked).toEqual(false)
     })
 
     test('fires the onChange callback', async () => {
-      // enzymeWrapper.find('input').simulate('change')
       const { onChange } = setup()
       const user = userEvent.setup()
       const radioButton = screen.getByRole('radio', { value: 'test value' })
@@ -121,8 +121,8 @@ describe('AccessMethodRadio component', () => {
 
   describe('fake input element', () => {
     test('does not display an icon', () => {
-      expect()
-      // expect(enzymeWrapper.find('.access-method-radio__radio-icon').length).toBe(0)
+      setup()
+      expect(screen.queryByTestId('edsc-icon')).toBeNull()
     })
   })
 
@@ -145,17 +145,16 @@ describe('AccessMethodRadio component', () => {
   })
 
   describe('when the access method is checked', () => {
-    // test('adds the is-selected classname modifier', () => {
-    //   expect(enzymeWrapper.props().className).toContain('access-method-radio--is-selected')
-    // })
+    test('adds the is-selected classname modifier', () => {
+      setup({ checked: true })
+      const input = screen.getByTestId('test-id')
+      expect(input.className).toContain('access-method-radio--is-selected')
+    })
 
     describe('input element', () => {
       test('sets the checked property', () => {
         setup({ checked: true })
-        // expect(enzymeWrapper.find('input').props().checked).toBe('checked')
         const radioButton = screen.getByRole('radio', { value: 'test value' })
-        // TODO why are these different values????
-        // expect(radioButton.checked).toEqual('checked')
         expect(radioButton.checked).toEqual(true)
         expect(screen.getByTestId('edsc-icon')).toBeInTheDocument()
       })
@@ -165,9 +164,25 @@ describe('AccessMethodRadio component', () => {
   describe('when a service name is provided', () => {
     test('does not display an icon', () => {
       setup({ serviceName: 'test service name' })
-      expect(screen.getByText('Service: test service name')).toBeInTheDocument()
       // The icon does not render
       expect(screen.queryByTestId('edsc-icon')).toBeNull()
+    })
+    test('displays the service name', () => {
+      setup({ serviceName: 'test service name' })
+      // The service name appears on the document under the More-Info-block
+      const renderedServiceNames = screen.getAllByText('Service: test service name')
+      // renders in the `More-Info` section
+      expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__more-info')
+      expect(renderedServiceNames.length).toEqual(1)
+    })
+    describe('when the `subtitle` is `Harmony`', () => {
+      test('service name appears on on customizable option does not appear in the more-info section', () => {
+        setup({ serviceName: 'test service name', subtitle: 'Harmony' })
+        const renderedServiceNames = screen.getAllByText('Service: test service name')
+        // renders in the `access-method-content` section
+        expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-secondary')
+        expect(renderedServiceNames.length).toEqual(1)
+      })
     })
   })
 })

--- a/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
+++ b/static/src/js/components/FormFields/AccessMethodRadio/__tests__/AccessMethodRadio.test.js
@@ -170,18 +170,18 @@ describe('AccessMethodRadio component', () => {
       expect(renderedServiceNames.length).toEqual(1)
     })
     describe('when the `subtitle` is `Harmony`', () => {
-      test('service name appears on on customizable option does not appear in the more-info section', () => {
+      test('service name appears on on customizable option primary title', () => {
         setup({ serviceName: 'test service name', subtitle: 'Harmony' })
-        const renderedServiceNames = screen.getAllByText('Harmony (test service name)')
+        const renderedServiceNames = screen.getAllByText('test service name')
         // renders in the `access-method-content` section
         expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
         expect(renderedServiceNames.length).toEqual(1)
       })
     })
     describe('when the `subtitle` is `OPeNDAP`', () => {
-      test('service name appears on on customizable option does not appear in the more-info section', () => {
+      test('service name appears on on customizable option primary title', () => {
         setup({ serviceName: 'test service name', subtitle: 'OPeNDAP' })
-        const renderedServiceNames = screen.getAllByText('OPeNDAP (test service name)')
+        const renderedServiceNames = screen.getAllByText('test service name')
         // renders in the `access-method-content` section
         expect(renderedServiceNames[0].closest('div').className).toEqual('access-method-radio__header-primary')
         expect(renderedServiceNames.length).toEqual(1)


### PR DESCRIPTION
# Overview

### What is the feature?

Moving the service name for `Harmony` customizable collection to the customize panel so user does not need to click on the `More Info` box. Rewriting tests that were using `Enzyme` to `react-testing-library`

### What is the Solution?

Small change to render the service name on the customizable option instead of under the `More Info` block

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Find a collection with `customizable` harmony service. Add the collection to your project go to the project page and hit customize

### Attachments
![image](https://github.com/nasa/earthdata-search/assets/34591886/a701cccd-6361-40d0-a759-4469c2f75394)

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
