### PR TITLE
EDSC-3861: Fixes bug when viewing a focused collection's map imagery

### DIFF
--- a/static/src/js/components/Map/GranuleGridLayerExtended.js
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.js
@@ -303,7 +303,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
     //   return null
     // }
 
-    if (!matched) { return false }
+    if (!matched) { return null }
 
     this.options.time = date
     if (this.options.granule) {
@@ -882,15 +882,16 @@ export class GranuleGridLayerExtended extends L.GridLayer {
     )
 
     const {
+      addedGranuleIds,
+      collectionId,
       color,
       drawingNewLayer,
-      lightColor,
       focusedCollectionId,
       focusedGranuleId,
-      collectionId,
-      addedGranuleIds,
-      removedGranuleIds,
-      isProjectPage
+      isProjectPage,
+      lightColor,
+      projection,
+      removedGranuleIds
     } = this
 
     return this.setResults({
@@ -903,6 +904,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       granules,
       isProjectPage,
       lightColor,
+      projection,
       removedGranuleIds
     })
   }

--- a/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
+++ b/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
@@ -309,6 +309,7 @@ describe('GranuleGridLayerExtended class', () => {
           granules: updateProps.granules,
           isProjectPage: false,
           lightColor: 'rgb(46, 204, 113, 0.5)',
+          projection: 'epsg4326',
           removedGranuleIds: []
         })
       })
@@ -337,6 +338,7 @@ describe('GranuleGridLayerExtended class', () => {
           granules: updateProps.granules,
           isProjectPage: false,
           lightColor: 'rgb(46, 204, 113, 0.5)',
+          projection: 'epsg4326',
           removedGranuleIds: []
         })
       })
@@ -364,6 +366,7 @@ describe('GranuleGridLayerExtended class', () => {
           granules: updateProps.granules,
           isProjectPage: false,
           lightColor: 'rgb(46, 204, 113, 0.5)',
+          projection: 'epsg4326',
           removedGranuleIds: []
         })
       })


### PR DESCRIPTION
# Overview

### What is the feature?

When switching between a focused collection with map imagery, back to the collection search results, and then back into the same collection, the map imagery is not being displayed for the focused collection.

### What is the Solution?

The projection check for map imagery was failing because the projection was not passed in to `setResults` in `GranuleGridLayerExtended`, when being called from `loadResults`. Adding `projection` keeps the value from being set to undefined, and the imagery is loaded as expected.

### What areas of the application does this impact?

Map imagery

# Testing

### Reproduction steps

In SIT, search for `C1200269573-E2E_18_3` (or any collection with map imagery will work)

Click into the collection to view granules and map imagery, ensure that the map imagery loads. 
Click `Search Results` to go back to the collection results.
Click back into the collection again to view granules and map imagery, ensure that the map imagery loads.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
