### PR TITLE
EDSC-3601: Fixed up Children usage in RadioList.js

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -64,10 +64,10 @@ export class AccessMethod extends Component {
     const {
       enableSpatialSubsetting = !(
         boundingBox === undefined
-         && circle === undefined
-         && line === undefined
-         && point === undefined
-         && polygon === undefined
+        && circle === undefined
+        && line === undefined
+        && point === undefined
+        && polygon === undefined
       )
     } = selectedMethod || {}
 
@@ -179,6 +179,33 @@ export class AccessMethod extends Component {
     })
   }
 
+  renderRadioItem(radioItem, onPropsChange, selected) {
+    const {
+      id,
+      methodKey,
+      title,
+      subtitle,
+      name,
+      description,
+      details
+    } = radioItem
+
+    return (
+      <AccessMethodRadio
+        key={id}
+        id={id}
+        value={methodKey}
+        title={title}
+        subtitle={subtitle}
+        serviceName={name}
+        description={description}
+        details={details}
+        onChange={onPropsChange}
+        checked={selected === methodKey}
+      />
+    )
+  }
+
   render() {
     const {
       enableTemporalSubsetting,
@@ -276,16 +303,15 @@ export class AccessMethod extends Component {
 
       if (type) {
         accessMethodsByType[type].push(
-          <AccessMethodRadio
-            key={id}
-            id={id}
-            value={methodKey}
-            title={title}
-            subtitle={subtitle}
-            serviceName={name}
-            description={description}
-            details={details}
-          />
+          {
+            id,
+            methodKey,
+            title,
+            subtitle,
+            name,
+            description,
+            details
+          }
         )
       }
     })
@@ -435,9 +461,9 @@ export class AccessMethod extends Component {
                   <RadioList
                     defaultValue={selectedAccessMethod}
                     onChange={(methodName) => this.handleAccessMethodSelection(methodName)}
-                  >
-                    {radioList}
-                  </RadioList>
+                    radioList={radioList}
+                    renderRadio={this.renderRadioItem}
+                  />
                 )
             }
           </div>

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -1137,7 +1137,7 @@ describe('AccessMethod component', () => {
             }
           })
 
-          expect(screen.getByText('harmony-service-name')).toBeInTheDocument()
+          expect(screen.getByText(/using the harmony-service-name/)).toBeInTheDocument()
         })
       })
     })

--- a/static/src/js/components/FormFields/RadioList/RadioList.js
+++ b/static/src/js/components/FormFields/RadioList/RadioList.js
@@ -1,17 +1,11 @@
-import React, {
-  Children,
-  useState,
-  useEffect
-} from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-
-import Radio from '../Radio/Radio'
-import AccessMethodRadio from '../AccessMethodRadio/AccessMethodRadio'
 
 export const RadioList = ({
   defaultValue,
   onChange,
-  children
+  radioList,
+  renderRadio
 }) => {
   const [selected, setSelected] = useState(defaultValue)
 
@@ -30,24 +24,7 @@ export const RadioList = ({
 
   return (
     <div className="radio-list">
-      {
-        Children.map(children, (child) => {
-          const { props, type } = child
-
-          if (type !== Radio && type !== AccessMethodRadio) return null
-
-          return React.cloneElement(
-            child,
-            {
-              onChange: onPropsChange,
-              // Disabling the rule, but we shouldn't be using Children
-              // https://react.dev/reference/react/Children
-              // eslint-disable-next-line react/prop-types
-              checked: selected === props.value
-            }
-          )
-        })
-      }
+      {radioList.map((radio) => renderRadio(radio, onPropsChange, selected))}
     </div>
   )
 }
@@ -58,7 +35,8 @@ RadioList.defaultProps = {
 }
 
 RadioList.propTypes = {
-  children: PropTypes.node.isRequired,
+  radioList: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  renderRadio: PropTypes.func.isRequired,
   defaultValue: PropTypes.string,
   onChange: PropTypes.func
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Fixed up the issue the @macrouch brought up.

### What is the Solution?

Send to RadioList an array of the objects and a function to render the Radio component and then call them in RadioList.

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
UAT
- **Collection to test with:**
MetOp-C ASCAT Level 2 25.0km Ocean Surface Wind Vectors in Full Orbit Swath

1. type in _MetOp-C ASCAT Level 2 25.0km Ocean Surface Wind Vectors in Full Orbit Swath_ into the search bar
2. press enter and click on the first granule that loads
3. click download all
4. click on the different Radio Buttons and ensure everything renders as expected.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
