### PR TITLE
EDSC-3869: Fixing projection switching between Antarctic and Arctic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Earthdata Search uses PostgreSQL in production on AWS RDS. If you don't already 
     brew install postgresql
 
 Start the PostgreSQL server:
-    
+
     # If you have never used brew services before:
     brew tap homebrew/services
     

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.js
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.js
@@ -18,7 +18,6 @@ import './TemporalSelectionDropdown.scss'
 
 /**
  * Component representing the temporal selection dropdown
- * @extends PureComponent
  */
 const TemporalSelectionDropdown = ({
   allowRecurring,

--- a/static/src/js/containers/MapContainer/MapEvents.js
+++ b/static/src/js/containers/MapContainer/MapEvents.js
@@ -28,8 +28,16 @@ const MapEvents = (props) => {
 
   useEffect(() => {
     const { latitude = 0, longitude = 0, zoom = 4 } = mapProps
+    let newLatitude = latitude
 
-    if (mapProps) map.setView([latitude, longitude], zoom)
+    // Fix problems where 90 and -90 degrees cause page crashes when South Polar <-> North Polar projection switch
+    if (latitude === 90) {
+      newLatitude = 89.999
+    } else if (latitude === -90) {
+      newLatitude = -89.999
+    }
+
+    if (mapProps) map.setView([newLatitude, longitude], zoom)
   }, [mapProps])
 
   const handleOverlayChange = (event) => {

--- a/static/src/js/containers/MapContainer/MapEvents.js
+++ b/static/src/js/containers/MapContainer/MapEvents.js
@@ -1,11 +1,10 @@
-import { useEffect, useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useMap, useMapEvents } from 'react-leaflet'
 
 const MapEvents = (props) => {
   const map = useMap()
   const {
-    mapProps,
     overlays = {},
     onChangeMap,
     onMetricsMap
@@ -25,20 +24,6 @@ const MapEvents = (props) => {
       layersControl.appendChild(attributionElement)
     }
   })
-
-  useEffect(() => {
-    const { latitude = 0, longitude = 0, zoom = 4 } = mapProps
-    let newLatitude = latitude
-
-    // Fix problems where 90 and -90 degrees cause page crashes when South Polar <-> North Polar projection switch
-    if (latitude === 90) {
-      newLatitude = 89.999
-    } else if (latitude === -90) {
-      newLatitude = -89.999
-    }
-
-    if (mapProps) map.setView([newLatitude, longitude], zoom)
-  }, [mapProps])
 
   const handleOverlayChange = (event) => {
     const enabled = event.type === 'overlayadd'
@@ -99,11 +84,6 @@ MapEvents.defaultProps = {
 }
 
 MapEvents.propTypes = {
-  mapProps: PropTypes.shape({
-    latitude: PropTypes.number,
-    longitude: PropTypes.number,
-    zoom: PropTypes.number
-  }).isRequired,
   overlays: PropTypes.shape({}).isRequired,
   onChangeMap: PropTypes.func,
   onMetricsMap: PropTypes.func

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1028,7 +1028,7 @@ test.describe('Map interactions', () => {
         await expect(page).toHaveURL('search?polygon[0]=42.1875%2C-76.46517%2C42.1875%2C-82.40647%2C56.25%2C-76.46517%2C42.1875%2C-76.46517&sf=1&sfs[0]=0&lat=-90&projection=EPSG%3A3031&zoom=0')
 
         // Draws a polygon on the map
-        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 343L821 284L850 318L768 343z')
+        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 342L821 283L850 317L768 342z')
         await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 284L768 343L850 318L821 284z')
         await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
         await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1028,7 +1028,7 @@ test.describe('Map interactions', () => {
         await expect(page).toHaveURL('search?polygon[0]=42.1875%2C-76.46517%2C42.1875%2C-82.40647%2C56.25%2C-76.46517%2C42.1875%2C-76.46517&sf=1&sfs[0]=0&lat=-90&projection=EPSG%3A3031&zoom=0')
 
         // Draws a polygon on the map
-        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 342L821 283L850 317L768 342z')
+        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 343L821 284L850 318L768 343z')
         await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 284L768 343L850 318L821 284z')
         await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
         await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1151,6 +1151,32 @@ test.describe('Map interactions', () => {
         await expect(page.locator('img.leaflet-tile').first()).toHaveAttribute('src', /epsg3031/)
       })
     })
+
+    test.describe('When switching from the North Polar Stereographic projection to the South Polar Stereographic projection', () => {
+      test('updates the URL with the new map parameter and updates the src of tile images', async ({ page }) => {
+        await interceptUnauthenticatedCollections({
+          page,
+          body: commonBody,
+          headers: commonHeaders
+        })
+
+        await page.goto('/')
+
+        // Change the projection to North Polar
+        await page.getByTestId('projection-switcher__arctic').click()
+
+        await expect(page).toHaveURL('search?lat=90&projection=EPSG%3A3413&zoom=0')
+
+        await expect(page.locator('img.leaflet-tile').first()).toHaveAttribute('src', /epsg3413/)
+
+        // Change the projection to South Polar
+        await page.getByTestId('projection-switcher__antarctic').click()
+
+        await expect(page).toHaveURL('search?lat=-90&projection=EPSG%3A3031&zoom=0')
+
+        await expect(page.locator('img.leaflet-tile').first()).toHaveAttribute('src', /epsg3031/)
+      })
+    })
   })
 
   test.describe('When changing the map layers', () => {

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1028,10 +1028,10 @@ test.describe('Map interactions', () => {
         await expect(page).toHaveURL('search?polygon[0]=42.1875%2C-76.46517%2C42.1875%2C-82.40647%2C56.25%2C-76.46517%2C42.1875%2C-76.46517&sf=1&sfs[0]=0&lat=-90&projection=EPSG%3A3031&zoom=0')
 
         // Draws a polygon on the map
-        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 343L821 284L850 318L768 343z')
-        await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 284L768 343L850 318L821 284z')
-        await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
-        await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
+        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 342L821 283L850 317L768 342z')
+        await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 283L768 342L850 317L821 283z')
+        await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 283L850 317L768 342L821 283z')
+        await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 283L850 317L768 342L821 283z')
 
         // Populates the spatial display field
         await expect(

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1028,10 +1028,10 @@ test.describe('Map interactions', () => {
         await expect(page).toHaveURL('search?polygon[0]=42.1875%2C-76.46517%2C42.1875%2C-82.40647%2C56.25%2C-76.46517%2C42.1875%2C-76.46517&sf=1&sfs[0]=0&lat=-90&projection=EPSG%3A3031&zoom=0')
 
         // Draws a polygon on the map
-        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 342L821 283L850 317L768 342z')
-        await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 283L768 342L850 317L821 283z')
-        await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 283L850 317L768 342L821 283z')
-        await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 283L850 317L768 342L821 283z')
+        await expect(page.locator('.geojson-svg.leaflet-interactive')).toHaveAttribute('d', 'M768 343L821 284L850 318L768 343z')
+        await expect(page.locator('.leaflet-interactive').nth(0)).toHaveAttribute('d', 'M821 284L768 343L850 318L821 284z')
+        await expect(page.locator('.leaflet-interactive').nth(2)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
+        await expect(page.locator('.leaflet-interactive').nth(3)).toHaveAttribute('d', 'M821 284L850 318L768 343L821 284z')
 
         // Populates the spatial display field
         await expect(


### PR DESCRIPTION
# Overview

### What is the feature?

There is an issue on EDSC where if you switch from south polar to north polar projects or vice versa the webpage will no longer function. This is to correct that error by preventing the Arithmetic operation that causes this from occurring

### What is the Solution?

Removing the function that is setting the center of the map. This value is being passed into leaflet's `setView` function. It seems to be holding onto the `lastCenter` field so when it tries to parse that value on the opposite polar projection it cannot find the coordinate. This is propagating as our web application crashing. We can remove this part of the code as it is not changing the view from what it is being set to when we already switch projections 

### What areas of the application does this impact?

EDSC Map and projection switching

# Testing

### Reproduction steps

Switch from the south polar projection to the north polar projection and vice versa. Ensure the EDSC is still functioning after that as expected

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
