### PR TITLE
EDSC-3905: Create a Lambda to export logging in EDD to EDSC CloudWatch

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -328,6 +328,15 @@
           cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
           path: relevancy_logger
 
+  eddLogger:
+    handler: serverless/src/eddLogger/handler.default
+    timeout: ${env:LAMBDA_TIMEOUT, '30'}
+    events:
+      - http:
+          method: post
+          cors: ${file(./serverless-configs/${self:provider.name}-cors-configuration.yml)}
+          path: edd_logger
+
   edlOptionalAuthorizer:
     handler: serverless/src/edlOptionalAuthorizer/handler.default
     timeout: ${env:LAMBDA_TIMEOUT, '30'}

--- a/serverless/src/eddLogger/__tests__/handler.test.js
+++ b/serverless/src/eddLogger/__tests__/handler.test.js
@@ -1,0 +1,42 @@
+import MockDate from 'mockdate'
+
+import eddLogger from '../handler'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('eddLogger', () => {
+  beforeEach(() => {
+    // Mock the date so the timestamp log is predictable
+    MockDate.set(Date.now())
+  })
+
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  test('logs the event body', async () => {
+    const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
+
+    const event = {
+      body: JSON.stringify({
+        params: {
+          eventType: 'downloadComplete',
+          data: {
+            fileCount: 10,
+            fileSize: 512,
+            failedFiles: 0,
+            downloadDuration: 123456
+          }
+        }
+      })
+    }
+
+    const response = await eddLogger(event)
+
+    expect(response.statusCode).toBe(200)
+    expect(consoleMock).toBeCalledTimes(1)
+    expect(consoleMock).toBeCalledWith(`[metrics] {"event":"downloadComplete","fileCount":10,"fileSize":512,"failedFiles":0,"downloadDuration":123456,"timestamp":${Date.now()}}`)
+  })
+})

--- a/serverless/src/eddLogger/handler.js
+++ b/serverless/src/eddLogger/handler.js
@@ -8,8 +8,7 @@ const eddLogger = async (event) => {
 
   const { body } = event
   const { params = {} } = JSON.parse(body)
-  const { data = {} } = params
-  const { eventType } = params
+  const { data = {}, eventType } = params
 
   const eventData = {
     event: eventType,

--- a/serverless/src/eddLogger/handler.js
+++ b/serverless/src/eddLogger/handler.js
@@ -1,0 +1,28 @@
+import { getApplicationConfig } from '../../../sharedUtils/config'
+/**
+ * Logs an error reported by a client
+ * @param {Object} event Details about the HTTP request that it received
+ */
+const eddLogger = async (event) => {
+  const { defaultResponseHeaders } = getApplicationConfig()
+
+  const { body } = event
+  const { params = {} } = JSON.parse(body)
+  const { data = {} } = params
+  const { eventType } = params
+
+  const eventData = {
+    event: eventType,
+    ...data,
+    timestamp: Date.now()
+  }
+
+  console.log(`[metrics] ${JSON.stringify(eventData)}`)
+
+  return {
+    statusCode: 200,
+    headers: defaultResponseHeaders
+  }
+}
+
+export default eddLogger


### PR DESCRIPTION
# Overview

### What is the feature?

Adding a Lambda that will export log messages to CloudWatch sent from EDD.

### What areas of the application does this impact?

EDSC


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
