### PR TITLE
EDSC-3909: Fix showing direct collection -> variable associations

### DIFF
--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -180,7 +180,11 @@ describe('buildAccessMethods', () => {
               'TIFF',
               'NETCDF-4'
             ]
-          }]
+          }],
+          variables: {
+            count: 0,
+            items: null
+          }
         }]
       },
       variables: {

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -180,39 +180,39 @@ describe('buildAccessMethods', () => {
               'TIFF',
               'NETCDF-4'
             ]
-          }],
-          variables: {
-            count: 4,
-            items: [{
-              conceptId: 'V100000-EDSC',
-              definition: 'Alpha channel value',
-              longName: 'Alpha channel ',
-              name: 'alpha_var',
-              nativeId: 'mmt_variable_3972',
-              scienceKeywords: null
-            }, {
-              conceptId: 'V100001-EDSC',
-              definition: 'Blue channel value',
-              longName: 'Blue channel',
-              name: 'blue_var',
-              nativeId: 'mmt_variable_3971',
-              scienceKeywords: null
-            }, {
-              conceptId: 'V100002-EDSC',
-              definition: 'Green channel value',
-              longName: 'Green channel',
-              name: 'green_var',
-              nativeId: 'mmt_variable_3970',
-              scienceKeywords: null
-            }, {
-              conceptId: 'V100003-EDSC',
-              definition: 'Red channel value',
-              longName: 'Red Channel',
-              name: 'red_var',
-              nativeId: 'mmt_variable_3969',
-              scienceKeywords: null
-            }]
-          }
+          }]
+        }]
+      },
+      variables: {
+        count: 4,
+        items: [{
+          conceptId: 'V100000-EDSC',
+          definition: 'Alpha channel value',
+          longName: 'Alpha channel ',
+          name: 'alpha_var',
+          nativeId: 'mmt_variable_3972',
+          scienceKeywords: null
+        }, {
+          conceptId: 'V100001-EDSC',
+          definition: 'Blue channel value',
+          longName: 'Blue channel',
+          name: 'blue_var',
+          nativeId: 'mmt_variable_3971',
+          scienceKeywords: null
+        }, {
+          conceptId: 'V100002-EDSC',
+          definition: 'Green channel value',
+          longName: 'Green channel',
+          name: 'green_var',
+          nativeId: 'mmt_variable_3970',
+          scienceKeywords: null
+        }, {
+          conceptId: 'V100003-EDSC',
+          definition: 'Red channel value',
+          longName: 'Red Channel',
+          name: 'red_var',
+          nativeId: 'mmt_variable_3969',
+          scienceKeywords: null
         }]
       }
     }
@@ -521,6 +521,218 @@ describe('buildAccessMethods', () => {
           }
         }
       }
+    })
+  })
+
+  describe('when the collection contains variables associated to its services and variables directly associated to the collection', () => {
+    test('variables on the collections service are returned instead of directly associated variables', () => {
+      const collectionMetadata = {
+        services: {
+          items: [{
+            conceptId: 'S100000-EDSC',
+            longName: 'Mock Service Name',
+            name: 'mock-name',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 4,
+              items: [{
+                conceptId: 'V100000-EDSC',
+                definition: 'Alpha channel value',
+                longName: 'Alpha channel ',
+                name: 'alpha_var',
+                nativeId: 'mmt_variable_3972',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100001-EDSC',
+                definition: 'Blue channel value',
+                longName: 'Blue channel',
+                name: 'blue_var',
+                nativeId: 'mmt_variable_3971',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100002-EDSC',
+                definition: 'Green channel value',
+                longName: 'Green channel',
+                name: 'green_var',
+                nativeId: 'mmt_variable_3970',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100003-EDSC',
+                definition: 'Red channel value',
+                longName: 'Red Channel',
+                name: 'red_var',
+                nativeId: 'mmt_variable_3969',
+                scienceKeywords: null
+              }]
+            }
+          }]
+        },
+        variables: {
+          count: 3,
+          items: [{
+            conceptId: 'V100003-EDSC',
+            definition: 'Beta channel value',
+            longName: 'Beta channel ',
+            name: 'beta_var',
+            nativeId: 'mmt_variable_4972',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100004-EDSC',
+            definition: 'Orange channel value',
+            longName: 'Orange channel',
+            name: 'orange_var',
+            nativeId: 'mmt_variable_4971',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100005-EDSC',
+            definition: 'Purple channel value',
+            longName: 'Purple channel',
+            name: 'purple_var',
+            nativeId: 'mmt_variable_4970',
+            scienceKeywords: null
+          }]
+        }
+      }
+      const isOpenSearch = false
+
+      const methods = buildAccessMethods(collectionMetadata, isOpenSearch)
+
+      expect(methods).toEqual({
+        harmony0: {
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100000-EDSC'
+            },
+            {
+              id: 'V100001-EDSC'
+            },
+            {
+              id: 'V100002-EDSC'
+            },
+            {
+              id: 'V100003-EDSC'
+            }
+          ],
+          id: 'S100000-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name',
+          name: 'mock-name',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example.com',
+          variables: {
+            'V100000-EDSC': {
+              conceptId: 'V100000-EDSC',
+              definition: 'Alpha channel value',
+              longName: 'Alpha channel ',
+              name: 'alpha_var',
+              nativeId: 'mmt_variable_3972',
+              scienceKeywords: null
+            },
+            'V100001-EDSC': {
+              conceptId: 'V100001-EDSC',
+              definition: 'Blue channel value',
+              longName: 'Blue channel',
+              name: 'blue_var',
+              nativeId: 'mmt_variable_3971',
+              scienceKeywords: null
+            },
+            'V100002-EDSC': {
+              conceptId: 'V100002-EDSC',
+              definition: 'Green channel value',
+              longName: 'Green channel',
+              name: 'green_var',
+              nativeId: 'mmt_variable_3970',
+              scienceKeywords: null
+            },
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Red channel value',
+              longName: 'Red Channel',
+              name: 'red_var',
+              nativeId: 'mmt_variable_3969',
+              scienceKeywords: null
+            }
+          }
+        }
+      })
     })
   })
 })

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -40,7 +40,7 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
         variables: serviceAssociatedVariables = {}
       } = serviceItem
 
-      if (serviceAssociatedVariables.count > 0) {
+      if (serviceAssociatedVariables.items) {
         associatedVariables = serviceAssociatedVariables
       }
 

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -18,12 +18,12 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
   const {
     granules = {},
     services = {},
-    variables: collAssociatedVars = {}
+    variables: collectionAssociatedVariables = {}
   } = collectionMetadata
 
   const accessMethods = {}
   let harmonyIndex = 0
-  let associatedVariables = collAssociatedVars
+  let associatedVariables = collectionAssociatedVariables
   const { items: serviceItems = null } = services
 
   if (serviceItems !== null) {
@@ -37,11 +37,11 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
         maxItemsPerOrder,
         name,
         supportedReformattings,
-        variables: serviceAssocVars = {}
+        variables: serviceAssociatedVariables = {}
       } = serviceItem
 
-      if (serviceAssocVars.count > 0) {
-        associatedVariables = serviceAssocVars
+      if (serviceAssociatedVariables.count > 0) {
+        associatedVariables = serviceAssociatedVariables
       }
 
       // Only process service types that EDSC supports

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -17,11 +17,13 @@ import { supportsVariableSubsetting } from './supportsVariableSubsetting'
 export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
   const {
     granules = {},
-    services = {}
+    services = {},
+    variables: collAssociatedVars = {}
   } = collectionMetadata
+
   const accessMethods = {}
   let harmonyIndex = 0
-
+  let associatedVariables = collAssociatedVars
   const { items: serviceItems = null } = services
 
   if (serviceItems !== null) {
@@ -35,8 +37,13 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
         maxItemsPerOrder,
         name,
         supportedReformattings,
-        variables: associatedVariables
+        variables: serviceAssocVars = {}
       } = serviceItem
+
+      if (serviceAssocVars.count > 0) {
+        associatedVariables = serviceAssocVars
+      }
+
       // Only process service types that EDSC supports
       const supportedServiceTypes = ['esi', 'echo orders', 'opendap', 'harmony']
       if (!supportedServiceTypes.includes(serviceType.toLowerCase())) return

--- a/static/src/js/util/accessMethods/getVariables.js
+++ b/static/src/js/util/accessMethods/getVariables.js
@@ -20,8 +20,7 @@ const computeVariables = (items) => {
 
 /**
  * Fetches the variable metadata for the provided variableIds
- * @param {Array} variableIds An array of variable Concept Ids
- * @param {String} jwtToken JWT returned from edlAuthorizer
+ * @param {Object} data variable object response from CMR
  */
 export const getVariables = (data) => {
   const { count } = data


### PR DESCRIPTION
# Overview

### What is the feature?

There was a user requested fix to showing the variables associated to the collection in a project utilizing `Harmony` or `OpenDap` services. In `EDSC-3817` a change was made to include only variables associated to the services of a collection. Instead this ticket updates this business logic to show the variables associated directly to the collection **unless** there exists variables associated to a service of the collection.

### What is the Solution?

Tweak business logic in modules for building the access method component

### What areas of the application does this impact?

Access methods

# Testing

Add a collection to your project which implements `opendap` and or `harmony` services. Ensure that on the variables page (select `Edit Variables` on the Configure data customization options) we get a view of all of the variables associated to that collection if there exists no services on that collection which have variable associations.

Secondly ensure that for a collection which does contain variables associated to the services those variables are instead shown

This query from gaphql
```
query ($params: CollectionsInput) {
  collections(params: $params) {
    items {
      conceptId
      variables {
        count
        items {
          name
          conceptId
        }
      }
      services {
        items {
          variables {
            count
            items {
              name
              conceptId
            }
          }
        }
      }
    }
  }
}
```

along with the concept-id as a parameter can be used to validate that the metadata for the collection `does/does not `have either type of association.

### Attachments

Using `C1996881146-POCLOUD` in the production envs
![image](https://github.com/nasa/earthdata-search/assets/34591886/bcf9b8bd-955e-42da-8b39-08ca9e4cbfe7)

Using `C1200277763-E2E_18_4` in the SIT env
![image](https://github.com/nasa/earthdata-search/assets/34591886/7957190c-13b7-4cba-aaa4-4f1dc17732d6)


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
