### PR TITLE
EDSC-3900: Ensure browse image links are https links

### DIFF
--- a/static/src/js/util/request/__tests__/granuleRequest.test.js
+++ b/static/src/js/util/request/__tests__/granuleRequest.test.js
@@ -277,6 +277,73 @@ describe('GranuleRequest#transformResponse', () => {
 
       expect(result).toEqual(expectedResult)
     })
+
+    test('when the granule has multiple browse image link protocols it uses the first https URL', () => {
+      jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({ cmrHost: 'https://cmr.earthdata.nasa.gov' }))
+
+      const request = new GranuleRequest(undefined, 'prod')
+
+      const data = {
+        feed: {
+          id: 'https://cmr.earthdata.nasa.gov:443/search/granules.json?echo_collection_id=C123456-MOCK&page_num=2&page_size=20&sort_key=-start_date',
+          title: 'ECHO granule metadata',
+          updated: '2019-05-21T01:08:02.143Z',
+          entry: [{
+            id: 'granuleId',
+            time_end: '2000-01-31T00:00:00.000Z',
+            time_start: '2000-01-01T00:00:00.000Z',
+            links: [
+              {
+                rel: '#data',
+                href: 'https://test.com/data.json'
+              },
+              {
+                rel: '#browse',
+                href: 's3://test.com/browse/image/first_url.jpg'
+              },
+              {
+                rel: '#browse',
+                href: 'https://test.com/browse/image/second_url.jpg'
+              }
+            ]
+          }]
+        }
+      }
+
+      const result = request.transformResponse(data)
+
+      const expectedResult = {
+        feed: {
+          entry: [
+            {
+              id: 'granuleId',
+              browse_url: 'https://test.com/browse/image/second_url.jpg',
+              time_end: '2000-01-31T00:00:00.000Z',
+              time_start: '2000-01-01T00:00:00.000Z',
+              thumbnail: 'https://cmr.earthdata.nasa.gov/browse-scaler/browse_images/granules/granuleId?h=85&w=85',
+              formatted_temporal: ['2000-01-01 00:00:00', '2000-01-31 00:00:00'],
+              isOpenSearch: false,
+              links: [
+                {
+                  rel: '#data',
+                  href: 'https://test.com/data.json'
+                },
+                {
+                  rel: '#browse',
+                  href: 's3://test.com/browse/image/first_url.jpg'
+                },
+                {
+                  rel: '#browse',
+                  href: 'https://test.com/browse/image/second_url.jpg'
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
   })
 
   test('returns data if response is not successful', () => {

--- a/static/src/js/util/request/granuleRequest.js
+++ b/static/src/js/util/request/granuleRequest.js
@@ -47,31 +47,42 @@ export default class GranuleRequest extends CmrRequest {
     const { entry = [] } = feed
 
     entry.map((granule) => {
+      const {
+        id,
+        time_start: timeStart,
+        time_end: timeEnd,
+        links
+      } = granule
+
       const updatedGranule = granule
 
       updatedGranule.isOpenSearch = false
 
-      const formattedTemporal = getTemporal(granule.time_start, granule.time_end)
+      const formattedTemporal = getTemporal(timeStart, timeEnd)
 
       if (formattedTemporal.filter(Boolean).length > 0) {
         updatedGranule.formatted_temporal = formattedTemporal
       }
 
-      const h = getApplicationConfig().thumbnailSize.height
-      const w = getApplicationConfig().thumbnailSize.width
+      const { thumbnailSize } = getApplicationConfig()
+      const { height, width } = thumbnailSize
 
-      if (granule.id) {
-        // eslint-disable-next-line
-        updatedGranule.thumbnail = `${getEarthdataConfig(this.earthdataEnvironment).cmrHost}/browse-scaler/browse_images/granules/${granule.id}?h=${h}&w=${w}`
+      if (id) {
+        updatedGranule.thumbnail = `${getEarthdataConfig(this.earthdataEnvironment).cmrHost}/browse-scaler/browse_images/granules/${id}?h=${height}&w=${width}`
       }
 
-      if (granule.links && granule.links.length > 0) {
+      if (links && links.length > 0) {
         let browseUrl
 
         // Pick the first 'browse' link to use as the browseUrl
-        granule.links.some((link) => {
-          if (link.rel.indexOf('browse') > -1) {
-            browseUrl = link.href
+        links.some((link) => {
+          const {
+            href,
+            rel
+          } = link
+
+          if (rel.indexOf('browse') > -1 && href.startsWith('https://')) {
+            browseUrl = href
 
             return true
           }


### PR DESCRIPTION
# Overview

### What is the feature?

When EDSC retrieves granule metadata, we parse the links on each granule and look for one that is a browse type to use as the browse url (when a user clicks on the browse thumbnail). If that browse link is an s3 protocol link it doesn't work when clicking on it. 

### What is the Solution?

Only look for links that start with `https://` to populate the browse link

### What areas of the application does this impact?

Clicking on granule browse images

# Testing

### Reproduction steps

In UAT, the collection this was reported in is `C1259974840-ASF`, but I think they have fixed the metadata to ensure the https links come first, therefore get selected. I'm still trying to find an example of this in the wild to use for testing

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
