### PR TITLE
EDSC-3819: Fixing `variables` object  in submitHarmonyOrder

### DIFF
--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderUrl.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderUrl.test.js
@@ -4,15 +4,8 @@ describe('constructOrderUrl', () => {
   describe('when variables are selected', () => {
     test('url uses selected variable names in the url for variables', () => {
       const response = constructOrderUrl('C100000-EDSC', {
-        selectedVariables: [
-          {
-            conceptId: 'V100000-EDSC',
-            name: 'test_var'
-          },
-          {
-            conceptId: 'V100002-EDSC',
-            name: 'test_var_2'
-          }
+        selectedVariableNames: [
+          'test_var', 'test_var_2'
         ],
         url: 'https://harmony.earthdata.nasa.gov'
       })

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderUrl.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderUrl.test.js
@@ -5,27 +5,16 @@ describe('constructOrderUrl', () => {
     test('url uses selected variable names in the url for variables', () => {
       const response = constructOrderUrl('C100000-EDSC', {
         selectedVariables: [
-          'V100000-EDSC',
-          'V100002-EDSC'
-        ],
-        url: 'https://harmony.earthdata.nasa.gov',
-        variables: {
-          'V100000-EDSC': {
-            name: 'test_var',
-            longName: 'Test Variable',
-            conceptId: 'V100000-EDSC'
+          {
+            conceptId: 'V100000-EDSC',
+            name: 'test_var'
           },
-          'V100001-EDSC': {
-            name: 'test_var_1',
-            longName: 'Test Variable 1',
-            conceptId: 'V100001-EDSC'
-          },
-          'V100002-EDSC': {
-            name: 'test_var_2',
-            longName: 'Test Variable 2',
-            conceptId: 'V100002-EDSC'
+          {
+            conceptId: 'V100002-EDSC',
+            name: 'test_var_2'
           }
-        }
+        ],
+        url: 'https://harmony.earthdata.nasa.gov'
       })
 
       expect(response).toEqual('https://harmony.earthdata.nasa.gov/C100000-EDSC/ogc-api-coverages/1.0.0/collections/test_var%2Ctest_var_2/coverage/rangeset')
@@ -35,24 +24,7 @@ describe('constructOrderUrl', () => {
   describe('when no variables are selected', () => {
     test('url uses \'all\' in the url for variables', () => {
       const response = constructOrderUrl('C100000-EDSC', {
-        url: 'https://harmony.earthdata.nasa.gov',
-        variables: {
-          'V100000-EDSC': {
-            name: 'test_var',
-            longName: 'Test Variable',
-            conceptId: 'V100000-EDSC'
-          },
-          'V100001-EDSC': {
-            name: 'test_var_1',
-            longName: 'Test Variable 1',
-            conceptId: 'V100001-EDSC'
-          },
-          'V100002-EDSC': {
-            name: 'test_var_2',
-            longName: 'Test Variable 2',
-            conceptId: 'V100002-EDSC'
-          }
-        }
+        url: 'https://harmony.earthdata.nasa.gov'
       })
 
       expect(response).toEqual('https://harmony.earthdata.nasa.gov/C100000-EDSC/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset')

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -96,16 +96,8 @@ describe('submitHarmonyOrder', () => {
             enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
-            selectedVariables: [
-              {
-                name: 'test_var',
-                conceptId: 'V100000-EDSC'
-              },
-              {
-                name: 'test_var_2',
-                conceptId: 'V100002-EDSC'
-              }
-            ],
+            selectedVariables: ['V100000-EDSC', 'V100002-EDSC'],
+            selectedVariableNames: ['test_var', 'test_var_2'],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}
@@ -182,16 +174,8 @@ describe('submitHarmonyOrder', () => {
             enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
-            selectedVariables: [
-              {
-                conceptId: 'V100000-EDSC',
-                name: 'test_var'
-              },
-              {
-                conceptId: 'V100002-EDSC',
-                name: 'test_var_2'
-              }
-            ],
+            selectedVariables: ['V100000-EDSC', 'V100002-EDSC'],
+            selectedVariableNames: ['test_var', 'test_var_2'],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}
@@ -269,16 +253,8 @@ describe('submitHarmonyOrder', () => {
             enableTemporalSubsetting: true,
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
-            selectedVariables: [
-              {
-                conceptId: 'V100000-EDSC',
-                name: 'test_var'
-              },
-              {
-                conceptId: 'V100002-EDSC',
-                name: 'test_var_2'
-              }
-            ],
+            selectedVariables: ['V100000-EDSC', 'V100002-EDSC'],
+            selectedVariableNames: ['test_var', 'test_var_2'],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -97,26 +97,15 @@ describe('submitHarmonyOrder', () => {
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [
-              'V100000-EDSC',
-              'V100002-EDSC'
-            ],
-            variables: {
-              'V100000-EDSC': {
+              {
                 name: 'test_var',
-                longName: 'Test Variable',
                 conceptId: 'V100000-EDSC'
               },
-              'V100001-EDSC': {
-                name: 'test_var_1',
-                longName: 'Test Variable 1',
-                conceptId: 'V100001-EDSC'
-              },
-              'V100002-EDSC': {
+              {
                 name: 'test_var_2',
-                longName: 'Test Variable 2',
                 conceptId: 'V100002-EDSC'
               }
-            },
+            ],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}
@@ -194,26 +183,15 @@ describe('submitHarmonyOrder', () => {
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [
-              'V100000-EDSC',
-              'V100002-EDSC'
-            ],
-            variables: {
-              'V100000-EDSC': {
-                name: 'test_var',
-                longName: 'Test Variable',
-                conceptId: 'V100000-EDSC'
+              {
+                conceptId: 'V100000-EDSC',
+                name: 'test_var'
               },
-              'V100001-EDSC': {
-                name: 'test_var_1',
-                longName: 'Test Variable 1',
-                conceptId: 'V100001-EDSC'
-              },
-              'V100002-EDSC': {
-                name: 'test_var_2',
-                longName: 'Test Variable 2',
-                conceptId: 'V100002-EDSC'
+              {
+                conceptId: 'V100002-EDSC',
+                name: 'test_var_2'
               }
-            },
+            ],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}
@@ -292,26 +270,15 @@ describe('submitHarmonyOrder', () => {
             type: 'Harmony',
             selectedOutputFormat: 'NetCDF-4',
             selectedVariables: [
-              'V100000-EDSC',
-              'V100002-EDSC'
-            ],
-            variables: {
-              'V100000-EDSC': {
-                name: 'test_var',
-                longName: 'Test Variable',
-                conceptId: 'V100000-EDSC'
+              {
+                conceptId: 'V100000-EDSC',
+                name: 'test_var'
               },
-              'V100001-EDSC': {
-                name: 'test_var_1',
-                longName: 'Test Variable 1',
-                conceptId: 'V100001-EDSC'
-              },
-              'V100002-EDSC': {
-                name: 'test_var_2',
-                longName: 'Test Variable 2',
-                conceptId: 'V100002-EDSC'
+              {
+                conceptId: 'V100002-EDSC',
+                name: 'test_var_2'
               }
-            },
+            ],
             url: 'https://harmony.earthdata.nasa.gov'
           },
           granule_params: {}

--- a/serverless/src/submitHarmonyOrder/constructOrderUrl.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderUrl.js
@@ -4,21 +4,16 @@
  * @param {Object} accessMethod The selected access method from the project page
  */
 export const constructOrderUrl = (collectionId, accessMethod) => {
-  console.log('Got to parsing name in constructOrderUrl ')
   const {
     selectedVariables,
     url
   } = accessMethod
-  console.log('🚀 ~ file: constructOrderUrl.js:13 ~ constructOrderUrl ~ selectedVariables:', selectedVariables)
 
   const selectedVariableNames = []
 
   if (selectedVariables) {
     selectedVariables.forEach((variable) => {
-      console.log('🚀 ~ file: constructOrderUrl.js:18 ~ selectedVariables.forEach ~ variable:', variable)
-      // Const { [variable]: variableObject } = variable
       const { name } = variable
-      console.log('🚀 ~ file: constructOrderUrl.js:19 ~ selectedVariables.forEach ~ name:', name)
 
       selectedVariableNames.push(name)
     })
@@ -26,7 +21,6 @@ export const constructOrderUrl = (collectionId, accessMethod) => {
 
   let variableParameter = 'all'
   if (selectedVariableNames.length > 0) {
-    console.log('🚀 ~ file: constructOrderUrl.js:28 ~ constructOrderUrl ~ variableParameter:', variableParameter)
     variableParameter = encodeURIComponent(selectedVariableNames.join(','))
   }
 
@@ -38,7 +32,6 @@ export const constructOrderUrl = (collectionId, accessMethod) => {
     `collections/${variableParameter}`,
     'coverage/rangeset'
   ]
-  console.log('🚀 ~ file: constructOrderUrl.js:39 ~ constructOrderUrl ~ harmonyPathParts:', harmonyPathParts)
 
   return harmonyPathParts.join('/')
 }

--- a/serverless/src/submitHarmonyOrder/constructOrderUrl.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderUrl.js
@@ -5,19 +5,9 @@
  */
 export const constructOrderUrl = (collectionId, accessMethod) => {
   const {
-    selectedVariables,
+    selectedVariableNames = [],
     url
   } = accessMethod
-
-  const selectedVariableNames = []
-
-  if (selectedVariables) {
-    selectedVariables.forEach((variable) => {
-      const { name } = variable
-
-      selectedVariableNames.push(name)
-    })
-  }
 
   let variableParameter = 'all'
   if (selectedVariableNames.length > 0) {

--- a/serverless/src/submitHarmonyOrder/constructOrderUrl.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderUrl.js
@@ -4,18 +4,21 @@
  * @param {Object} accessMethod The selected access method from the project page
  */
 export const constructOrderUrl = (collectionId, accessMethod) => {
+  console.log('Got to parsing name in constructOrderUrl ')
   const {
     selectedVariables,
-    url,
-    variables
+    url
   } = accessMethod
+  console.log('🚀 ~ file: constructOrderUrl.js:13 ~ constructOrderUrl ~ selectedVariables:', selectedVariables)
 
   const selectedVariableNames = []
 
   if (selectedVariables) {
     selectedVariables.forEach((variable) => {
-      const { [variable]: variableObject } = variables
-      const { name } = variableObject
+      console.log('🚀 ~ file: constructOrderUrl.js:18 ~ selectedVariables.forEach ~ variable:', variable)
+      // Const { [variable]: variableObject } = variable
+      const { name } = variable
+      console.log('🚀 ~ file: constructOrderUrl.js:19 ~ selectedVariables.forEach ~ name:', name)
 
       selectedVariableNames.push(name)
     })
@@ -23,6 +26,7 @@ export const constructOrderUrl = (collectionId, accessMethod) => {
 
   let variableParameter = 'all'
   if (selectedVariableNames.length > 0) {
+    console.log('🚀 ~ file: constructOrderUrl.js:28 ~ constructOrderUrl ~ variableParameter:', variableParameter)
     variableParameter = encodeURIComponent(selectedVariableNames.join(','))
   }
 
@@ -34,6 +38,7 @@ export const constructOrderUrl = (collectionId, accessMethod) => {
     `collections/${variableParameter}`,
     'coverage/rangeset'
   ]
+  console.log('🚀 ~ file: constructOrderUrl.js:39 ~ constructOrderUrl ~ harmonyPathParts:', harmonyPathParts)
 
   return harmonyPathParts.join('/')
 }

--- a/static/src/js/util/__tests__/retrievals.test.js
+++ b/static/src/js/util/__tests__/retrievals.test.js
@@ -42,7 +42,22 @@ describe('retrievals', () => {
                     'EPSG:4326'
                   ],
                   type: 'Harmony',
-                  url: 'https://harmony.sit.earthdata.nasa.gov'
+                  url: 'https://harmony.sit.earthdata.nasa.gov',
+                  variables: {
+                    'V100000-EDSC': {
+                      conceptId: 'V100000-EDSC',
+                      definition: 'Alpha channel value',
+                      longName: 'Alpha channel ',
+                      name: 'alpha_var',
+                      scienceKeywords: [
+                        {
+                          category: 'EARTH SCIENCE',
+                          topic: 'ATMOSPHERE',
+                          term: 'ATMOSPHERIC PRESSURE'
+                        }
+                      ]
+                    }
+                  }
                 }
               },
               granules: {

--- a/static/src/js/util/__tests__/retrievals.test.js
+++ b/static/src/js/util/__tests__/retrievals.test.js
@@ -42,22 +42,7 @@ describe('retrievals', () => {
                     'EPSG:4326'
                   ],
                   type: 'Harmony',
-                  url: 'https://harmony.sit.earthdata.nasa.gov',
-                  variables: {
-                    'V100000-EDSC': {
-                      conceptId: 'V100000-EDSC',
-                      definition: 'Alpha channel value',
-                      longName: 'Alpha channel ',
-                      name: 'alpha_var',
-                      scienceKeywords: [
-                        {
-                          category: 'EARTH SCIENCE',
-                          topic: 'ATMOSPHERE',
-                          term: 'ATMOSPHERIC PRESSURE'
-                        }
-                      ]
-                    }
-                  }
+                  url: 'https://harmony.sit.earthdata.nasa.gov'
                 }
               },
               granules: {
@@ -115,22 +100,7 @@ describe('retrievals', () => {
           },
           selectedOutputProjection: 'EPSG:4326',
           type: 'Harmony',
-          url: 'https://harmony.sit.earthdata.nasa.gov',
-          variables: {
-            'V100000-EDSC': {
-              conceptId: 'V100000-EDSC',
-              definition: 'Alpha channel value',
-              longName: 'Alpha channel ',
-              name: 'alpha_var',
-              scienceKeywords: [
-                {
-                  category: 'EARTH SCIENCE',
-                  topic: 'ATMOSPHERE',
-                  term: 'ATMOSPHERIC PRESSURE'
-                }
-              ]
-            }
-          }
+          url: 'https://harmony.sit.earthdata.nasa.gov'
         },
         collection_metadata: {
           conceptId: 'C100000-EDSC',
@@ -277,22 +247,7 @@ describe('retrievals', () => {
           },
           selectedOutputProjection: 'EPSG:4326',
           type: 'Harmony',
-          url: 'https://harmony.sit.earthdata.nasa.gov',
-          variables: {
-            'V100000-EDSC': {
-              conceptId: 'V100000-EDSC',
-              definition: 'Alpha channel value',
-              longName: 'Alpha channel ',
-              name: 'alpha_var',
-              scienceKeywords: [
-                {
-                  category: 'EARTH SCIENCE',
-                  topic: 'ATMOSPHERE',
-                  term: 'ATMOSPHERIC PRESSURE'
-                }
-              ]
-            }
-          }
+          url: 'https://harmony.sit.earthdata.nasa.gov'
         },
         collection_metadata: {
           conceptId: 'C100000-EDSC',

--- a/static/src/js/util/__tests__/retrievals.test.js
+++ b/static/src/js/util/__tests__/retrievals.test.js
@@ -115,7 +115,22 @@ describe('retrievals', () => {
           },
           selectedOutputProjection: 'EPSG:4326',
           type: 'Harmony',
-          url: 'https://harmony.sit.earthdata.nasa.gov'
+          url: 'https://harmony.sit.earthdata.nasa.gov',
+          variables: {
+            'V100000-EDSC': {
+              conceptId: 'V100000-EDSC',
+              definition: 'Alpha channel value',
+              longName: 'Alpha channel ',
+              name: 'alpha_var',
+              scienceKeywords: [
+                {
+                  category: 'EARTH SCIENCE',
+                  topic: 'ATMOSPHERE',
+                  term: 'ATMOSPHERIC PRESSURE'
+                }
+              ]
+            }
+          }
         },
         collection_metadata: {
           conceptId: 'C100000-EDSC',
@@ -262,7 +277,22 @@ describe('retrievals', () => {
           },
           selectedOutputProjection: 'EPSG:4326',
           type: 'Harmony',
-          url: 'https://harmony.sit.earthdata.nasa.gov'
+          url: 'https://harmony.sit.earthdata.nasa.gov',
+          variables: {
+            'V100000-EDSC': {
+              conceptId: 'V100000-EDSC',
+              definition: 'Alpha channel value',
+              longName: 'Alpha channel ',
+              name: 'alpha_var',
+              scienceKeywords: [
+                {
+                  category: 'EARTH SCIENCE',
+                  topic: 'ATMOSPHERE',
+                  term: 'ATMOSPHERIC PRESSURE'
+                }
+              ]
+            }
+          }
         },
         collection_metadata: {
           conceptId: 'C100000-EDSC',

--- a/static/src/js/util/createSpatialDisplay.js
+++ b/static/src/js/util/createSpatialDisplay.js
@@ -63,7 +63,6 @@ export const createSpatialDisplay = (spatial) => {
   if (selectedShape) {
     if (boundingBox) {
       const splitStr = transformBoundingBoxCoordinates(selectedShape[0])
-      console.log(splitStr)
 
       return `SW: (${splitStr[0]}) NE: (${splitStr[1]})`
     }

--- a/static/src/js/util/retrievals.js
+++ b/static/src/js/util/retrievals.js
@@ -42,8 +42,7 @@ const permittedAccessMethodFields = [
   'supportsBoundingBoxSubsetting',
   'supportsShapefileSubsetting',
   'type',
-  'url',
-  'variables'
+  'url'
 ]
 
 /**
@@ -109,12 +108,42 @@ export const prepareRetrievalParams = (state) => {
 
     const params = buildGranuleSearchParams(preparedParams)
 
+    const allVariables = accessMethods[selectedAccessMethod].variables
+
+    console.log('🚀 ~ file: retrievals.js:113 ~ projectCollectionsIds.forEach ~ allVariables:', allVariables)
+
     returnValue.granule_params = params
     returnValue.access_method = pick(
       accessMethods[selectedAccessMethod],
       permittedAccessMethodFields
     )
 
+    // ReturnValue.access_method.merge({'variables':})
+    // TODO Add a parse to just get the variable name
+
+    console.log('🚀 ~ file: retrievals.js:118 ~ projectCollectionsIds.forEach ~ returnValue.access_method.selectedVariables:', returnValue.access_method)
+    if (returnValue.access_method.selectedVariables) {
+      console.log('🚀 ~ file: retrievals.js:112 ~ projectCollectionsIds.forEach ~ returnValue.access_method:', returnValue.access_method)
+      const variableObjects = []
+      returnValue.access_method.selectedVariables.forEach((variableKey) => {
+        console.log('🚀 ~ file: retrievals.js:119 ~ returnValue.access_method.selectedVariables.forEach ~ variableKey:', variableKey)
+        // Only pull in the `name` field of the variables object
+        const newVarObj = {
+          conceptId: variableKey,
+          name: allVariables[variableKey].name
+        }
+
+        console.log('🚀 ~ file: retrievals.js:128 ~ returnValue.access_method.selectedVariables.forEach ~ newVarObj:', newVarObj)
+        variableObjects.push(newVarObj)
+      })
+
+      if (variableObjects) {
+        console.log('🚀 ~ file: retrievals.js:124 ~ projectCollectionsIds.forEach ~ variableObjects:', variableObjects)
+        returnValue.access_method.selectedVariables = variableObjects
+      }
+    }
+
+    console.log('✅ ~ file: retrievals.js:141 ~ projectCollectionsIds.forEach ~ returnValue.access_method:', returnValue.access_method)
     const {
       boundingBox = [],
       circle = [],
@@ -151,6 +180,7 @@ export const prepareRetrievalParams = (state) => {
     }
 
     retrievalCollections.push(returnValue)
+    console.log('🚀 ~ file: retrievals.js:181 ~ projectCollectionsIds.forEach ~ retrievalCollections:', retrievalCollections)
   })
 
   const { search } = router.location

--- a/static/src/js/util/retrievals.js
+++ b/static/src/js/util/retrievals.js
@@ -110,40 +110,29 @@ export const prepareRetrievalParams = (state) => {
 
     const allVariables = accessMethods[selectedAccessMethod].variables
 
-    console.log('🚀 ~ file: retrievals.js:113 ~ projectCollectionsIds.forEach ~ allVariables:', allVariables)
-
     returnValue.granule_params = params
     returnValue.access_method = pick(
       accessMethods[selectedAccessMethod],
       permittedAccessMethodFields
     )
 
-    // ReturnValue.access_method.merge({'variables':})
-    // TODO Add a parse to just get the variable name
-
-    console.log('🚀 ~ file: retrievals.js:118 ~ projectCollectionsIds.forEach ~ returnValue.access_method.selectedVariables:', returnValue.access_method)
     if (returnValue.access_method.selectedVariables) {
-      console.log('🚀 ~ file: retrievals.js:112 ~ projectCollectionsIds.forEach ~ returnValue.access_method:', returnValue.access_method)
       const variableObjects = []
       returnValue.access_method.selectedVariables.forEach((variableKey) => {
-        console.log('🚀 ~ file: retrievals.js:119 ~ returnValue.access_method.selectedVariables.forEach ~ variableKey:', variableKey)
         // Only pull in the `name` field of the variables object
         const newVarObj = {
           conceptId: variableKey,
           name: allVariables[variableKey].name
         }
 
-        console.log('🚀 ~ file: retrievals.js:128 ~ returnValue.access_method.selectedVariables.forEach ~ newVarObj:', newVarObj)
         variableObjects.push(newVarObj)
       })
 
       if (variableObjects) {
-        console.log('🚀 ~ file: retrievals.js:124 ~ projectCollectionsIds.forEach ~ variableObjects:', variableObjects)
         returnValue.access_method.selectedVariables = variableObjects
       }
     }
 
-    console.log('✅ ~ file: retrievals.js:141 ~ projectCollectionsIds.forEach ~ returnValue.access_method:', returnValue.access_method)
     const {
       boundingBox = [],
       circle = [],
@@ -180,7 +169,6 @@ export const prepareRetrievalParams = (state) => {
     }
 
     retrievalCollections.push(returnValue)
-    console.log('🚀 ~ file: retrievals.js:181 ~ projectCollectionsIds.forEach ~ retrievalCollections:', retrievalCollections)
   })
 
   const { search } = router.location

--- a/static/src/js/util/retrievals.js
+++ b/static/src/js/util/retrievals.js
@@ -42,7 +42,8 @@ const permittedAccessMethodFields = [
   'supportsBoundingBoxSubsetting',
   'supportsShapefileSubsetting',
   'type',
-  'url'
+  'url',
+  'variables'
 ]
 
 /**

--- a/static/src/js/util/retrievals.js
+++ b/static/src/js/util/retrievals.js
@@ -108,7 +108,7 @@ export const prepareRetrievalParams = (state) => {
 
     const params = buildGranuleSearchParams(preparedParams)
 
-    const allVariables = accessMethods[selectedAccessMethod].variables
+    const { variables, selectedVariables } = accessMethods[selectedAccessMethod]
 
     returnValue.granule_params = params
     returnValue.access_method = pick(
@@ -116,20 +116,17 @@ export const prepareRetrievalParams = (state) => {
       permittedAccessMethodFields
     )
 
-    if (returnValue.access_method.selectedVariables) {
-      const variableObjects = []
-      returnValue.access_method.selectedVariables.forEach((variableKey) => {
-        // Only pull in the `name` field of the variables object
-        const newVarObj = {
-          conceptId: variableKey,
-          name: allVariables[variableKey].name
-        }
+    // Adding `selectedVariableNames` which is a derived field not included in `selectedAccessMethod`
+    if (selectedVariables) {
+      const variableNames = selectedVariables.map((variableKey) => {
+        const { [variableKey]: variableObject } = variables
+        const { name: variableName } = variableObject
 
-        variableObjects.push(newVarObj)
+        return variableName
       })
 
-      if (variableObjects) {
-        returnValue.access_method.selectedVariables = variableObjects
+      if (variableNames) {
+        returnValue.access_method.selectedVariableNames = variableNames
       }
     }
 


### PR DESCRIPTION
# Overview
Bug fix for Harmony based orders handling variables
### What is the feature?
We add variables to the permittedAccessMethodFields so that it is available for the build url function farther down
### What is the Solution?
We add variables to the permittedAccessMethodFields so that it is available for the build url function farther down
### What areas of the application does this impact?
Harmony Orders completing correctly
# Testing
The ticket includes example orders in uat and prod that can be re-ordered for testing.
# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
