### PR TITLE
EDSC-3910: Switching between access methods is not updating the variables displayed

### DIFF
--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -26,6 +26,7 @@ const setup = (overrideProps) => {
   const onSelectAccessMethod = jest.fn()
   const onSetActivePanel = jest.fn()
   const onUpdateAccessMethod = jest.fn()
+  const onTogglePanels = jest.fn()
 
   const props = {
     accessMethods: {},
@@ -39,6 +40,7 @@ const setup = (overrideProps) => {
     overrideTemporal: {},
     onSelectAccessMethod,
     onSetActivePanel,
+    onTogglePanels,
     onUpdateAccessMethod,
     selectedAccessMethod: '',
     ...overrideProps
@@ -49,7 +51,8 @@ const setup = (overrideProps) => {
   return {
     onSelectAccessMethod,
     onSetActivePanel,
-    onUpdateAccessMethod
+    onUpdateAccessMethod,
+    onTogglePanels
   }
 }
 
@@ -1138,6 +1141,60 @@ describe('AccessMethod component', () => {
           })
 
           expect(screen.getByText(/using the harmony-service-name/)).toBeInTheDocument()
+        })
+
+        test('edit variables button calls `onSetActivePanel` and `onTogglePanels`', async () => {
+          const user = userEvent.setup()
+          const collectionId = 'collectionId'
+          const serviceName = 'harmony-service-name'
+
+          const { onSetActivePanel, onTogglePanels } = setup({
+            selectedAccessMethod: 'harmony0',
+            accessMethods: {
+              harmony0: {
+                isValid: true,
+                type: 'Harmony',
+                name: serviceName,
+                supportsVariableSubsetting: true,
+                variables: {
+                  conceptId: 'V1200465315-CMR_ONLY',
+                  definition: 'sea surface subskin temperature in units of kelvin',
+                  longName: 'sea surface subskin temperature',
+                  name: 'sea_surface_temperature',
+                  nativeId: 'eds-test-var-EDSC-3817',
+                  scienceKeywords: [
+                    {
+                      category: 'EARTH SCIENCE',
+                      topic: 'SPECTRAL/ENGINEERING',
+                      term: 'MICROWAVE',
+                      variableLevel1: 'SEA SURFACE TEMPERATURE',
+                      variableLevel2: 'MAXIMUM/MINIMUM TEMPERATURE',
+                      variableLevel3: '24 HOUR MAXIMUM TEMPERATURE',
+                      detailedVariable: 'details_4385'
+                    },
+                    {
+                      category: 'EARTH SCIENCE',
+                      topic: 'SPECTRAL/ENGINEERING',
+                      term: 'MICROWAVE',
+                      variableLevel1: 'MICROWAVE IMAGERY'
+                    }
+                  ]
+                }
+              }
+            },
+            metadata: {
+              conceptId: collectionId
+            }
+          })
+
+          const editVariablesBtn = screen.getByRole('button', { name: 'Edit Variables' })
+          await user.click(editVariablesBtn)
+
+          expect(onSetActivePanel).toHaveBeenCalledTimes(1)
+          expect(onSetActivePanel).toHaveBeenCalledWith('0.0.1')
+
+          expect(onTogglePanels).toHaveBeenCalledTimes(1)
+          expect(onTogglePanels).toHaveBeenCalledWith(true)
         })
       })
 

--- a/static/src/js/components/ProjectPanels/VariableTreePanel.js
+++ b/static/src/js/components/ProjectPanels/VariableTreePanel.js
@@ -24,6 +24,7 @@ export const VariableTreePanel = (props) => {
 
   const selectedMethod = accessMethods[selectedAccessMethod]
   const {
+    id: selectedAccessMethodServiceConceptId = '',
     keywordMappings = [],
     hierarchyMappings = [],
     selectedVariables = [],
@@ -81,7 +82,7 @@ export const VariableTreePanel = (props) => {
     <ProjectPanelSection heading="Variable Selection">
       {keywordMappings.length > 0 && hierarchyMappings.length > 0 && browseBy}
       <Tree
-        key={treeView}
+        key={`${selectedAccessMethodServiceConceptId}_${treeView}`}
         collectionId={collectionId}
         index={index}
         items={items}

--- a/static/src/js/components/Tree/Tree.js
+++ b/static/src/js/components/Tree/Tree.js
@@ -49,7 +49,7 @@ export const Tree = ({
       variables,
       onUpdateFinished: forceUpdate
     })
-  }, [variables]) // Update TreeModel when the list of variables changes
+  }, []) // Only execute this useEffect once on initial render
 
   /**
    * Update the treeModel with new values

--- a/static/src/js/components/Tree/Tree.js
+++ b/static/src/js/components/Tree/Tree.js
@@ -49,7 +49,7 @@ export const Tree = ({
       variables,
       onUpdateFinished: forceUpdate
     })
-  }, []) // Only execute this useEffect once on initial render
+  }, [variables]) // Update TreeModel when the list of variables changes
 
   /**
    * Update the treeModel with new values

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -536,7 +536,7 @@ describe('buildAccessMethods', () => {
     })
   })
 
-  describe('when the collection contains variables associated to its services and variables directly associated to the collection', () => {
+  describe('when the collection contains both variables associated to its services and variables directly associated to the collection', () => {
     test('variables on the service are returned instead of variables directly associated to the collection', () => {
       const collectionMetadata = {
         services: {
@@ -919,6 +919,8 @@ describe('buildAccessMethods', () => {
           }
         },
         harmony1: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
           enableTemporalSubsetting: true,
           enableSpatialSubsetting: true,
           hierarchyMappings: [
@@ -948,6 +950,7 @@ describe('buildAccessMethods', () => {
           ],
           supportedOutputProjections: [],
           supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
           supportsShapefileSubsetting: false,
           supportsTemporalSubsetting: false,
           supportsVariableSubsetting: true,
@@ -990,6 +993,8 @@ describe('buildAccessMethods', () => {
         },
         // Harmony2 contains the default variables in the coll -> var association
         harmony2: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
           enableTemporalSubsetting: true,
           enableSpatialSubsetting: true,
           hierarchyMappings: [
@@ -1016,6 +1021,7 @@ describe('buildAccessMethods', () => {
           ],
           supportedOutputProjections: [],
           supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
           supportsShapefileSubsetting: false,
           supportsTemporalSubsetting: false,
           supportsVariableSubsetting: true,

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -537,7 +537,7 @@ describe('buildAccessMethods', () => {
   })
 
   describe('when the collection contains variables associated to its services and variables directly associated to the collection', () => {
-    test('variables on the collections service are returned instead of directly associated variables', () => {
+    test('variables on the service are returned instead of variables directly associated to the collection', () => {
       const collectionMetadata = {
         services: {
           items: [{
@@ -641,6 +641,177 @@ describe('buildAccessMethods', () => {
                 scienceKeywords: null
               }]
             }
+          }, {
+            conceptId: 'S100001-EDSC',
+            longName: 'Mock Service Name 2',
+            name: 'mock-name 2',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example2.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 4,
+              items: [{
+                conceptId: 'V100006-EDSC',
+                definition: 'Alpha channel value',
+                longName: 'Alpha channel ',
+                name: 'alpha_var',
+                nativeId: 'mmt_variable_3973',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100007-EDSC',
+                definition: 'Blue channel value',
+                longName: 'Blue channel',
+                name: 'blue_var',
+                nativeId: 'mmt_variable_3974',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100008-EDSC',
+                definition: 'Green channel value',
+                longName: 'Green channel',
+                name: 'green_var',
+                nativeId: 'mmt_variable_3975',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100009-EDSC',
+                definition: 'Red channel value',
+                longName: 'Red Channel',
+                name: 'red_var',
+                nativeId: 'mmt_variable_3966',
+                scienceKeywords: null
+              }]
+            }
+          },
+          {
+            conceptId: 'S100002-EDSC',
+            longName: 'Mock Service Name 3',
+            name: 'mock-name 3',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example3.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }]
           }]
         },
         variables: {
@@ -743,6 +914,135 @@ describe('buildAccessMethods', () => {
               longName: 'Red Channel',
               name: 'red_var',
               nativeId: 'mmt_variable_3969',
+              scienceKeywords: null
+            }
+          }
+        },
+        harmony1: {
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100006-EDSC'
+            },
+            {
+              id: 'V100007-EDSC'
+            },
+            {
+              id: 'V100008-EDSC'
+            },
+            {
+              id: 'V100009-EDSC'
+            }
+          ],
+          id: 'S100001-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 2',
+          name: 'mock-name 2',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example2.com',
+          variables: {
+            'V100006-EDSC': {
+              conceptId: 'V100006-EDSC',
+              definition: 'Alpha channel value',
+              longName: 'Alpha channel ',
+              name: 'alpha_var',
+              nativeId: 'mmt_variable_3973',
+              scienceKeywords: null
+            },
+            'V100007-EDSC': {
+              conceptId: 'V100007-EDSC',
+              definition: 'Blue channel value',
+              longName: 'Blue channel',
+              name: 'blue_var',
+              nativeId: 'mmt_variable_3974',
+              scienceKeywords: null
+            },
+            'V100008-EDSC': {
+              conceptId: 'V100008-EDSC',
+              definition: 'Green channel value',
+              longName: 'Green channel',
+              name: 'green_var',
+              nativeId: 'mmt_variable_3975',
+              scienceKeywords: null
+            },
+            'V100009-EDSC': {
+              conceptId: 'V100009-EDSC',
+              definition: 'Red channel value',
+              longName: 'Red Channel',
+              name: 'red_var',
+              nativeId: 'mmt_variable_3966',
+              scienceKeywords: null
+            }
+          }
+        },
+        harmony2: {
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100002-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 3',
+          name: 'mock-name 3',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example3.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
               scienceKeywords: null
             }
           }

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -988,6 +988,7 @@ describe('buildAccessMethods', () => {
             }
           }
         },
+        // Harmony2 contains the default variables in the coll -> var association
         harmony2: {
           enableTemporalSubsetting: true,
           enableSpatialSubsetting: true,

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -25,11 +25,11 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
 
   const accessMethods = {}
   let harmonyIndex = 0
-  let associatedVariables = collectionAssociatedVariables
   const { items: serviceItems = null } = services
 
   if (serviceItems !== null) {
     serviceItems.forEach((serviceItem) => {
+      let associatedVariables = collectionAssociatedVariables
       const {
         conceptId: serviceConceptId,
         orderOptions,

--- a/static/src/js/util/tree/TreeNode.js
+++ b/static/src/js/util/tree/TreeNode.js
@@ -141,7 +141,7 @@ export class TreeNode {
   }
 
   /**
-   * Seralizes the selected items into an array of the fullValues
+   * Serializes the selected items into an array of the fullValues
    */
   seralize() {
     const checked = []


### PR DESCRIPTION
# Overview

### What is the feature?

Fixing an issue where selecting a service then selecting from the variables on that service the Tree panel is not updating so we are seeing the variables associated to another service. In the default case should be that the variables which appear are the variable directly associated to the collection in the project, however if the service has variables associated to it we want those to show up instead of the ones on the direct-collection association (even if they are just a subset of those)

### What is the Solution?

Update the key prop in the render of the Tree component so that it has a reference to the `selectedAccessMethodServiceConceptId` such that when we change services this component is going to be re-rendered.

### What areas of the application does this impact?

List impacted areas.

Project page and the variables tree view

### Reproduction steps

Find a collection with different sets of variables such as `C1200196166-SCIOPS` in the SIT env in this collection some of the services if selected should have the default set of `variables` and some should have those associated to the service. If we select one of those sets of variables and then switch to another then the variables on the later are going to be seen on the variable Tree view

We can quickly see these associations from `graphql` 
https://studio.apollographql.com/sandbox/explorer?endpoint=https%3A%2F%2Fgraphql.uat.earthdata.nasa.gov%2Fapi&explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABABQAkADgIZ5VwDO6RAwhADZsJQoCWES9AJJIKMFAEoiwADpIiRKO07c%2BAktVoMmlGnXqSZc%2BUR4oEDKbOPHFSKAgopBYK9aIA3GjyoAjTvUsjNwUIGFRXYNNzAMNg6yQ6BAi423tHZ2TghN53BAygtwBfTKJigvl6fHceexiS%2BSiLWLj5VIcnF3K3FAIKJK7rTzxvPwQ6gbdFMJR6t0bxlqzE2eC29M7F4zLN7bjd633S1zLCkAAaECGR-wwQGRANPWkMZtdntY7n9GfmAEYAJgADIDfgBOABsv3B4IAtABlZiCADyAAU4c9ZIVToUgA

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
