### PR TITLE
CMR-9569: Update the dataCenter to keyword for generating proper organization facets.

### DIFF
--- a/portals/ghrc/config.json
+++ b/portals/ghrc/config.json
@@ -4,7 +4,7 @@
   "parentConfig": "edsc",
   "portalBrowser": true,
   "query": {
-    "dataCenter": "NASA/MSFC/GHRC",
+    "keyword": "NASA/MSFC/GHRC",
     "hasGranulesOrCwic": null
   },
   "title": {

--- a/portals/obdaac/config.json
+++ b/portals/obdaac/config.json
@@ -27,7 +27,7 @@
   "parentConfig": "edsc",
   "portalBrowser": true,
   "query": {
-    "dataCenter": "NASA/GSFC/SED/ESD/GCDC/OB.DAAC"
+    "keyword": "NASA/GSFC/SED/ESD/GCDC/OB.DAAC"
   },
   "title": {
     "primary": "OBDAAC",

--- a/portals/ornldaac/config.json
+++ b/portals/ornldaac/config.json
@@ -4,7 +4,7 @@
   "parentConfig": "edsc",
   "portalBrowser": true,
   "query": {
-    "dataCenter": "ORNL_DAAC",
+    "keyword": "ORNL_DAAC",
     "hasGranulesOrCwic": null
   },
   "title": {

--- a/portals/podaac/config.json
+++ b/portals/podaac/config.json
@@ -4,7 +4,7 @@
   "parentConfig": "edsc",
   "portalBrowser": true,
   "query": {
-    "dataCenter": "NASA/JPL/PODAAC",
+    "keyword": "NASA/JPL/PODAAC",
     "hasGranulesOrCwic": null
   },
   "title": {

--- a/portals/seabass/config.json
+++ b/portals/seabass/config.json
@@ -23,7 +23,7 @@
     "parentConfig": "edsc",
     "portalBrowser": true,
     "query": {
-      "dataCenter": "NASA/GSFC/SED/ESD/GCDC/SeaBASS"
+      "keyword": "NASA/GSFC/SED/ESD/GCDC/SeaBASS"
     },
     "title": {
       "primary": "SeaBASS",


### PR DESCRIPTION
# Overview
The the query metric we currently used failed to be processed by the CMR due dataCenter itself not resolving to attribute.
Changed the query to use portal config value as a keyword search instead. This works and generates the correct organizations. (To me 😬) 

### What is the feature?
Update the way we query ES for portal collection data. 

### What is the Solution?
Using the keyword value over the dataCenter value.

### What areas of the application does this impact?

All portals that had their config changed. 

# Testing

### Reproduction steps

- Using a dev environment with changes applied and pointed at PROD and a second browser with PROD open
- Compare the results of the portals
- Ensure Organization has facet options available and selecting any one will filter to the correct collections

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
