### PR TITLE
EDSC-3884: Set latitude check to Ant/arctic circle

### DIFF
--- a/static/src/js/components/Map/ShapefileLayer.js
+++ b/static/src/js/components/Map/ShapefileLayer.js
@@ -215,8 +215,8 @@ class ShapefileLayerExtended extends L.Layer {
           featureLatLngs = featureLayer.getLatLngs().flat()
         }
 
-        allLatsArctic = featureLatLngs.every((latlng) => latlng.lat > 45)
-        allLatsAntarctic = featureLatLngs.every((latlng) => latlng.lat < -45)
+        allLatsArctic = featureLatLngs.every((latlng) => latlng.lat > 66.5)
+        allLatsAntarctic = featureLatLngs.every((latlng) => latlng.lat < -66.5)
 
         const addIconClasses = (layer) => {
           const { options = {} } = layer


### PR DESCRIPTION
# Overview

### What is the feature?

When a geoJSON file is uploaded, EDSC would change to one of the polar basemaps if all of the coordinates were above 45° north or south. However, the polar basemaps don't actually extend that far towards the equator, so the uploaded shape is in an unexpected location over a black background. Users also wouldn't expect the basemap to change unless the region of interest is much closer to the poles.

### What is the Solution?

This fix updates the latitude check to 66.5°, the approximate latitude of the Arctic and Antarctic Circles.

### What areas of the application does this impact?

Display of uploaded geospatial files. 

# Testing

### Reproduction steps

1. Download [georgia_straight_vancouver.geojson.zip](https://github.com/nasa/earthdata-search/files/13746212/georgia_straight_vancouver.geojson.zip)
2. Unzip the file
3. Click the upload file button as shown:
<img width="300" alt="image" src="https://github.com/nasa/earthdata-search/assets/10775395/8ee2c44e-733c-4d94-b8de-f0c09e75997d">

4. Upload the unzipped geoJSON file
5. Verify that the basemap stays on the default Geographic/Equirectangular projection and does not switch to the north polar projection. The uploaded geoJSON file should be plotted as shown:
<img width="1350" alt="image" src="https://github.com/nasa/earthdata-search/assets/10775395/d21700ba-e876-42b3-826b-ef43f416e433">

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
