### PR TITLE
EDSC-3981: Fixing Timeline display for focused collection

### DIFF
--- a/static/src/js/components/Timeline/Timeline.js
+++ b/static/src/js/components/Timeline/Timeline.js
@@ -245,32 +245,34 @@ export const Timeline = ({
     const data = []
 
     // Render the Collection Timelines in the same order they were added
-    projectCollectionsIds.forEach((conceptId, index) => {
-      if (!intervals[conceptId]) return
+    if (isProjectPage) {
+      projectCollectionsIds.forEach((conceptId, index) => {
+        if (!intervals[conceptId]) return
 
-      const values = intervals[conceptId]
-      const metadata = collectionMetadata[conceptId] || {}
+        const values = intervals[conceptId]
+        const metadata = collectionMetadata[conceptId] || {}
 
-      const dataValue = {}
-      dataValue.id = conceptId
-      dataValue.color = getColorByIndex(index)
-      const { title = '' } = metadata
-      dataValue.title = title
+        const dataValue = {}
+        dataValue.id = conceptId
+        dataValue.color = getColorByIndex(index)
+        const { title = '' } = metadata
+        dataValue.title = title
 
-      dataValue.intervals = values.map((value) => {
-        const [start, end] = value
+        dataValue.intervals = values.map((value) => {
+          const [start, end] = value
 
-        // TODO: Change the format of the intervals to an object at some point
-        return [start * 1000, end * 1000]
+          // TODO: Change the format of the intervals to an object at some point
+          return [start * 1000, end * 1000]
+        })
+
+        data.push(dataValue)
       })
-
-      data.push(dataValue)
-    })
+    }
 
     // Ensure we render the Timeline on the focused collection view, even if it has not been added to the project
     if (!isProjectPage) {
       Object.keys(intervals).forEach((conceptId, index) => {
-        if (!collectionMetadata[conceptId] || projectCollectionsIds.includes(conceptId)) return
+        if (!collectionMetadata[conceptId]) return
 
         const values = intervals[conceptId]
         const metadata = collectionMetadata[conceptId] || {}

--- a/static/src/js/components/Timeline/Timeline.js
+++ b/static/src/js/components/Timeline/Timeline.js
@@ -266,26 +266,28 @@ export const Timeline = ({
       data.push(dataValue)
     })
 
-    Object.keys(intervals).forEach((conceptId, index) => {
-      if (!collectionMetadata[conceptId] || projectCollectionsIds.includes(conceptId)) return
+    if (!isProjectPage) {
+      Object.keys(intervals).forEach((conceptId, index) => {
+        if (!collectionMetadata[conceptId] || projectCollectionsIds.includes(conceptId)) return
 
-      const values = intervals[conceptId]
-      const metadata = collectionMetadata[conceptId] || {}
+        const values = intervals[conceptId]
+        const metadata = collectionMetadata[conceptId] || {}
 
-      const dataValue = {}
-      dataValue.id = conceptId
-      dataValue.color = getColorByIndex(index)
-      const { title = '' } = metadata
-      dataValue.title = title
+        const dataValue = {}
+        dataValue.id = conceptId
+        dataValue.color = getColorByIndex(index)
+        const { title = '' } = metadata
+        dataValue.title = title
 
-      dataValue.intervals = values.map((value) => {
-        const [start, end] = value
+        dataValue.intervals = values.map((value) => {
+          const [start, end] = value
 
-        return [start * 1000, end * 1000]
+          return [start * 1000, end * 1000]
+        })
+
+        data.push(dataValue)
       })
-
-      data.push(dataValue)
-    })
+    }
 
     return data
   }

--- a/static/src/js/components/Timeline/Timeline.js
+++ b/static/src/js/components/Timeline/Timeline.js
@@ -244,6 +244,7 @@ export const Timeline = ({
   const setupData = ({ intervals }) => {
     const data = []
 
+    // Render the Collection Timelines in the same order they were added
     projectCollectionsIds.forEach((conceptId, index) => {
       if (!intervals[conceptId]) return
 
@@ -266,6 +267,7 @@ export const Timeline = ({
       data.push(dataValue)
     })
 
+    // Ensure we render the Timeline on the focused collection view, even if it has not been added to the project
     if (!isProjectPage) {
       Object.keys(intervals).forEach((conceptId, index) => {
         if (!collectionMetadata[conceptId] || projectCollectionsIds.includes(conceptId)) return

--- a/static/src/js/components/Timeline/Timeline.js
+++ b/static/src/js/components/Timeline/Timeline.js
@@ -28,7 +28,6 @@ export const Timeline = ({
   onToggleOverrideTemporalModal,
   onToggleTimeline,
   pathname,
-  projectCollectionsIds,
   showOverrideModal,
   temporalSearch,
   timeline
@@ -244,8 +243,8 @@ export const Timeline = ({
   const setupData = ({ intervals }) => {
     const data = []
 
-    projectCollectionsIds.forEach((conceptId, index) => {
-      if (!intervals[conceptId]) return
+    Object.keys(intervals).forEach((conceptId, index) => {
+      if (!collectionMetadata[conceptId]) return
 
       const values = intervals[conceptId]
       const metadata = collectionMetadata[conceptId] || {}
@@ -385,7 +384,6 @@ Timeline.propTypes = {
   onToggleOverrideTemporalModal: PropTypes.func.isRequired,
   onToggleTimeline: PropTypes.func.isRequired,
   pathname: PropTypes.string.isRequired,
-  projectCollectionsIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   showOverrideModal: PropTypes.bool.isRequired,
   temporalSearch: PropTypes.shape({
     endDate: PropTypes.string,

--- a/static/src/js/components/Timeline/Timeline.js
+++ b/static/src/js/components/Timeline/Timeline.js
@@ -28,6 +28,7 @@ export const Timeline = ({
   onToggleOverrideTemporalModal,
   onToggleTimeline,
   pathname,
+  projectCollectionsIds,
   showOverrideModal,
   temporalSearch,
   timeline
@@ -243,8 +244,8 @@ export const Timeline = ({
   const setupData = ({ intervals }) => {
     const data = []
 
-    Object.keys(intervals).forEach((conceptId, index) => {
-      if (!collectionMetadata[conceptId]) return
+    projectCollectionsIds.forEach((conceptId, index) => {
+      if (!intervals[conceptId]) return
 
       const values = intervals[conceptId]
       const metadata = collectionMetadata[conceptId] || {}
@@ -259,6 +260,27 @@ export const Timeline = ({
         const [start, end] = value
 
         // TODO: Change the format of the intervals to an object at some point
+        return [start * 1000, end * 1000]
+      })
+
+      data.push(dataValue)
+    })
+
+    Object.keys(intervals).forEach((conceptId, index) => {
+      if (!collectionMetadata[conceptId] || projectCollectionsIds.includes(conceptId)) return
+
+      const values = intervals[conceptId]
+      const metadata = collectionMetadata[conceptId] || {}
+
+      const dataValue = {}
+      dataValue.id = conceptId
+      dataValue.color = getColorByIndex(index)
+      const { title = '' } = metadata
+      dataValue.title = title
+
+      dataValue.intervals = values.map((value) => {
+        const [start, end] = value
+
         return [start * 1000, end * 1000]
       })
 
@@ -384,6 +406,7 @@ Timeline.propTypes = {
   onToggleOverrideTemporalModal: PropTypes.func.isRequired,
   onToggleTimeline: PropTypes.func.isRequired,
   pathname: PropTypes.string.isRequired,
+  projectCollectionsIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   showOverrideModal: PropTypes.bool.isRequired,
   temporalSearch: PropTypes.shape({
     endDate: PropTypes.string,

--- a/static/src/js/components/Timeline/__tests__/Timeline.test.js
+++ b/static/src/js/components/Timeline/__tests__/Timeline.test.js
@@ -159,20 +159,20 @@ describe('Timeline component', () => {
     const { enzymeWrapper } = setup({
       pathname: '/search/granules',
       collectionMetadata: {
-        collectionId: {
-          title: 'Test Collection'
+        firstCollection: {
+          title: '1st Collection'
         },
         secondCollection: {
-          title: '2nd Test Collection'
+          title: '2nd Collection'
         },
         thirdCollection: {
           title: '3rd Collection'
         }
       },
-      projectCollectionsIds: ['collectionId', 'secondCollection', 'thirdCollection'],
+      projectCollectionsIds: ['firstCollection', 'secondCollection', 'thirdCollection'],
       timeline: {
         intervals: {
-          collectionId: [
+          firstCollection: [
             [
               1525132800,
               1618185600,
@@ -206,15 +206,15 @@ describe('Timeline component', () => {
     const timeline = enzymeWrapper.find(EDSCTimeline)
     expect(timeline.props().data).toEqual([{
       color: '#2ECC71',
-      id: 'collectionId',
+      id: 'firstCollection',
       intervals: [[1525132800000, 1618185600000]],
-      title: 'Test Collection'
+      title: '1st Collection'
     },
     {
       color: '#3498DB',
       id: 'secondCollection',
       intervals: [[1525132800000, 1618185600000]],
-      title: '2nd Test Collection'
+      title: '2nd Collection'
     },
     {
       color: '#E67E22',

--- a/static/src/js/components/Timeline/__tests__/Timeline.test.js
+++ b/static/src/js/components/Timeline/__tests__/Timeline.test.js
@@ -157,7 +157,7 @@ describe('Timeline component', () => {
 
   test('setup data creates the correct intervals in the correct order for EDSCTimeline', () => {
     const { enzymeWrapper } = setup({
-      pathname: '/search/granules',
+      pathname: '/projects',
       collectionMetadata: {
         firstCollection: {
           title: '1st Collection'

--- a/static/src/js/components/Timeline/__tests__/Timeline.test.js
+++ b/static/src/js/components/Timeline/__tests__/Timeline.test.js
@@ -155,6 +155,41 @@ describe('Timeline component', () => {
     }])
   })
 
+  test('timeline displays on focused collection even when projectCollectionsIds is empty', () => {
+    const { enzymeWrapper } = setup({
+      pathname: '/search/granules', // Indicating it's not a project page
+      collectionMetadata: {
+        someCollection: {
+          title: 'Some Collection'
+        }
+      },
+      projectCollectionsIds: [], // Empty project collections
+      timeline: {
+        intervals: {
+          someCollection: [
+            [1525132800, 1618185600]
+          ]
+        },
+        query: {
+          center: 1552425382,
+          interval: 'day',
+          endDate: '2020-09-11T21:16:22.000Z',
+          startDate: '2017-09-09T21:16:22.000Z'
+        }
+      }
+    })
+
+    const timeline = enzymeWrapper.find(EDSCTimeline)
+    expect(timeline.props().data).toEqual([
+      {
+        color: '#2ECC71',
+        id: 'someCollection',
+        intervals: [[1525132800000, 1618185600000]],
+        title: 'Some Collection'
+      }
+    ])
+  })
+
   test('setup data creates the correct intervals in the correct order for EDSCTimeline', () => {
     const { enzymeWrapper } = setup({
       pathname: '/projects',


### PR DESCRIPTION
# Overview

### What is the feature?

Fixing the Timeline display to show the temporal window of the focused collection.

### What is the Solution?

Updating the Timeline component to reflect the focused collection temporal window while still saving the position of collections added to the project on the timeline.

### What areas of the application does this impact?

EDSC

# Testing

### Reproduction steps

1. Select a collection with a temporal window.
2. Verify that the timeline reflects the temporal window for the focused collection.
3. Add the collection to the project.
4. Reproduce steps 2-3 for two other collections.
5. Go to "My Project" and verify that the colors on the timeline match the colors on the project panel.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
