### PR TITLE
EDSC-3971: Update feature toggles to be string for bamboo vars

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -45,8 +45,8 @@
       "lambda": "eed-PORTAL-ENV-serverless-lambda"
     },
     "disableEddDownload": "false",
-    "disableOrdering": false,
-    "disableDatabaseComponents": false,
+    "disableOrdering": "false",
+    "disableDatabaseComponents": "false",
     "macOSEddDownloadSize":130,
     "windowsEddDownloadSize":100,
     "linuxEddDownloadSize":90

--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.js
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.js
@@ -64,6 +64,9 @@ export class SpatialSelectionDropdown extends PureComponent {
   render() {
     const { disableDatabaseComponents } = getApplicationConfig()
 
+    // Parse string field `disableDatabaseComponents` disable shapefile search if true
+    const disableShapefileSearch = disableDatabaseComponents === 'true'
+
     const spatialSelectionFileSpan = (
       <span>
         File
@@ -131,10 +134,10 @@ export class SpatialSelectionDropdown extends PureComponent {
             icon={FaFile}
             onClick={() => this.onItemClick('file')}
             label="Select Shapefile"
-            disabled={disableDatabaseComponents}
+            disabled={disableShapefileSearch}
           >
             {
-              disableDatabaseComponents ? (
+              disableShapefileSearch ? (
                 <OverlayTrigger
                   placement="right"
                   overlay={

--- a/static/src/js/components/SpatialDisplay/__tests__/SpatialSelectionDropdown.test.js
+++ b/static/src/js/components/SpatialDisplay/__tests__/SpatialSelectionDropdown.test.js
@@ -104,7 +104,7 @@ describe('SpatialSelectionDropdown component', () => {
   describe('if the database is disabled', () => {
     test('searching with the `shapefileUpload` buttons should also be disabled', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        disableDatabaseComponents: true
+        disableDatabaseComponents: 'true'
       }))
 
       const { enzymeWrapper } = setup()
@@ -119,7 +119,7 @@ describe('SpatialSelectionDropdown component', () => {
 
     test('hovering over the shapefile reveals tool-tip', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        disableDatabaseComponents: true
+        disableDatabaseComponents: 'true'
       }))
 
       const { enzymeWrapper } = setup()

--- a/static/src/js/containers/AuthRequiredContainer/AuthRequiredContainer.js
+++ b/static/src/js/containers/AuthRequiredContainer/AuthRequiredContainer.js
@@ -22,7 +22,7 @@ export const AuthRequiredContainer = ({
     const { disableDatabaseComponents } = getApplicationConfig()
 
     const token = get('authToken')
-    if (disableDatabaseComponents) {
+    if (disableDatabaseComponents === 'true') {
       remove('authToken')
     }
 
@@ -32,7 +32,7 @@ export const AuthRequiredContainer = ({
       setIsLoggedIn(false)
       if (!noRedirect) {
         let location = `${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(returnPath)}`
-        if (disableDatabaseComponents) {
+        if (disableDatabaseComponents === 'true') {
           location = '/search'
         }
 

--- a/static/src/js/containers/AuthRequiredContainer/__tests__/AuthRequiredContainer.test.js
+++ b/static/src/js/containers/AuthRequiredContainer/__tests__/AuthRequiredContainer.test.js
@@ -110,7 +110,7 @@ describe('AuthRequiredContainer component', () => {
   describe('when database components are turned off', () => {
     test('should redirect to the home `search` page', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        disableDatabaseComponents: true
+        disableDatabaseComponents: 'true'
       }))
 
       setup()
@@ -120,7 +120,7 @@ describe('AuthRequiredContainer component', () => {
 
     test('the token cookie should be cleared', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        disableDatabaseComponents: true
+        disableDatabaseComponents: 'true'
       }))
 
       jest.spyOn(tinyCookie, 'remove').mockImplementation(() => null)

--- a/static/src/js/containers/ErrorBannerContainer/ErrorBannerContainer.js
+++ b/static/src/js/containers/ErrorBannerContainer/ErrorBannerContainer.js
@@ -32,7 +32,7 @@ export const ErrorBannerContainer = ({ errors, onRemoveError }) => {
   const regex = /connect ECONNREFUSED/
   const dbConnectionError = regex.test(error.message)
 
-  if (disableDatabaseComponents && dbConnectionError) {
+  if ((disableDatabaseComponents === 'true') && dbConnectionError) {
     console.log('Error caught for database being down ', error.message)
 
     return null

--- a/static/src/js/containers/ErrorBannerContainer/__tests__/ErrorBannerContainer.test.js
+++ b/static/src/js/containers/ErrorBannerContainer/__tests__/ErrorBannerContainer.test.js
@@ -38,7 +38,7 @@ function setup(overrideProps) {
 describe('When the database is disabled', () => {
   test('ensure that error messages for database connections refusals do not render', async () => {
     jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementationOnce(() => ({
-      disableDatabaseComponents: true
+      disableDatabaseComponents: 'true'
     }))
 
     const { enzymeWrapper } = setup({

--- a/static/src/js/containers/SecondaryToolbarContainer/SecondaryToolbarContainer.js
+++ b/static/src/js/containers/SecondaryToolbarContainer/SecondaryToolbarContainer.js
@@ -31,7 +31,9 @@ export const mapStateToProps = (state) => ({
 export const SecondaryToolbarContainer = (props) => {
   const { disableDatabaseComponents } = getApplicationConfig()
   let secondaryToolbarEnabled = true
-  if (disableDatabaseComponents) secondaryToolbarEnabled = false
+
+  if (disableDatabaseComponents === 'true') secondaryToolbarEnabled = false
+
   const {
     authToken,
     earthdataEnvironment,

--- a/static/src/js/containers/SecondaryToolbarContainer/__tests__/SecondaryToolbarContainer.test.js
+++ b/static/src/js/containers/SecondaryToolbarContainer/__tests__/SecondaryToolbarContainer.test.js
@@ -14,7 +14,7 @@ import SecondaryToolbar from '../../../components/SecondaryToolbar/SecondaryTool
 
 beforeEach(() => {
   jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-    disableDatabaseComponents: false
+    disableDatabaseComponents: 'false'
   }))
 })
 
@@ -114,7 +114,7 @@ describe('SecondaryToolbarContainer component', () => {
 describe('if the secondaryToolbar should be disabled', () => {
   test('passes the `secondaryToolbarEnabled` prop and to the Secondary toolbar as false', () => {
     jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-      disableDatabaseComponents: true
+      disableDatabaseComponents: 'true'
     }))
 
     const { enzymeWrapper } = setup()

--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -4,7 +4,7 @@ import * as getApplicationConfig from '../../../../../../sharedUtils/config'
 
 beforeEach(() => {
   jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-    disableOrdering: false
+    disableOrdering: 'false'
   }))
 })
 
@@ -120,7 +120,7 @@ describe('buildAccessMethods', () => {
   describe('when ordering is disabled', () => {
     test('no echo-order access method is returned', () => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        disableOrdering: true
+        disableOrdering: 'true'
       }))
 
       const collectionMetadata = {

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -60,7 +60,7 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
 
       // Only process orderOptions if the service type uses orderOptions
       // Do not include access if orders are disabled
-      if (supportsOrderOptions.includes(serviceType.toLowerCase()) && !disableOrdering) {
+      if (supportsOrderOptions.includes(serviceType.toLowerCase()) && (disableOrdering !== 'true')) {
         const { items: orderOptionsItems } = orderOptions
         if (orderOptionsItems === null) return
 


### PR DESCRIPTION
# Overview

### What is the feature?

The existing feature toggle needs to be a string otherwise it is getting parsed as truthy. We must update the feature toggles to be strings

### What is the Solution?

Update those feature toggles to be string values instead of booleans so that the value that bamboo passes can get parsed with the correct logic

### What areas of the application does this impact?

ordering for the order feature toggle and all database interactions as this disabled the secondary toolbar


# Testing

Set the toggles for the database toggle and set the toggle for cmr-ordering and the database related rendered components in your `override.static.config.json` file

Ensure your database is either deleted or otherwise turned off I did so using: `pg_ctl -D /usr/local/var/postgresql@14 stop`

To test colormaps toggle against prod locally use: `C1996881146-POCLOUD`

To test cmr-ordering toggle against prod locally use: `C1299783631-LPDAAC_ECS`

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
