### PR TITLE
EDSC-3935 adds redis cache infra for browse-scaler lambda

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -138,6 +138,53 @@ Resources:
                   - states:*
                 Resource: '*'
 
+  # Redis Cache for browse-scaler
+  RedisSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Ingress for Redis Cluster
+      VpcId: ${env:VPC_ID}
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 1521
+        ToPort: 1521
+
+  RedisCacheSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      CacheSubnetGroupName: browse-scaler-${self:provider.stage}
+      Description: 'Redis Cache Subnet Group'
+      SubnetIds:
+        - ${env:SUBNET_ID_A}
+        - ${env:SUBNET_ID_B}
+
+  RedisParameterGroup:
+    Type: AWS::ElastiCache::ParameterGroup
+    Properties:
+      CacheParameterGroupFamily: redis7
+      Description: 'Redis ElasticCache Parameter Group'
+      Properties:
+        maxmemory-policy: allkeys-lru
+
+  RedisElasticCacheCluster:
+    DependsOn: RedisSecurityGroup
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      Engine: redis
+      EngineVersion: '7.0'
+      Port: 1521
+      ClusterName: browse-scaler-${self:provider.stage}
+      CacheNodeType: cache.t2.medium
+      NumCacheNodes: 1
+      # In transit encryption is not currenlty supported with the REDIS engine.
+      # TransitEncryptionEnabled: true
+      CacheParameterGroupName:
+        Ref: RedisParameterGroup
+      VpcSecurityGroupIds:
+      - "Fn::GetAtt": RedisSecurityGroup.GroupId
+      CacheSubnetGroupName:
+        Ref: RedisCacheSubnetGroup
+
 # Output the following resources so that other stacks can access the values
 Outputs:
   DbPasswordSecret:


### PR DESCRIPTION
# Overview

### What is the feature?

browse-scaler is moving to the EDSC aws account and will be rewritten as a lambda, we need to provide the redis infrastructure utilized by browse scaler

### What is the Solution?

Updated the infrastructure serverless yml file to include new redis resources.

### What areas of the application does this impact?

N/A

# Testing

Run EDSC deployment and confirm resources are deployed properly

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
