### PR TITLE
EDSC-3904: Improving edge cases for variable selection form

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -470,8 +470,9 @@ export class AccessMethod extends Component {
     const selectedSpatialDisplay = createSpatialDisplay(spatial)
 
     // Checking to see if the selectedMethod variables exists and has at least one variable
-    // eslint-disable-next-line max-len
-    const hasVariables = selectedMethod.variables ? Object.keys(selectedMethod.variables).length > 0 : false
+    const hasVariables = selectedMethod.variables
+      ? Object.keys(selectedMethod.variables).length > 0
+      : false
 
     return (
       <div className="access-method">
@@ -667,48 +668,34 @@ export class AccessMethod extends Component {
                       nested
                     >
                       {
-                        !hasVariables && (
+                        !hasVariables ? (
                           <p className="access-method__section-status">
                             This service has no associated variables.
                           </p>
-                        )
-                      }
-                      {
-                        hasVariables && (
+                        ) : (
                           <>
-                            {
-                              selectedVariables.length > 0 && (
-                                <p className="access-method__section-status">
-                                  {`${selectedVariables.length} ${pluralize('variable', selectedVariables.length)} selected`}
-                                </p>
-                              )
-                            }
-                            {
-                              selectedVariables.length === 0 && (
-                                <p className="access-method__section-status">
-                                  No variables selected. All variables will be included in download.
-                                </p>
-                              )
-                            }
-                          </>
-                        )
-                      }
-                      {
-                        hasVariables && (
-                          <Button
-                            type="button"
-                            bootstrapVariant="primary"
-                            label="Edit Variables"
-                            bootstrapSize="sm"
-                            onClick={
-                              () => {
-                                onSetActivePanel(`0.${index}.1`)
-                                onTogglePanels(true)
+                            <p className="access-method__section-status">
+                              {
+                                selectedVariables.length > 0
+                                  ? `${selectedVariables.length} ${pluralize('variable', selectedVariables.length)} selected`
+                                  : 'No variables selected. All variables will be included in download.'
                               }
-                            }
-                          >
-                            Edit Variables
-                          </Button>
+                            </p>
+                            <Button
+                              type="button"
+                              bootstrapVariant="primary"
+                              label="Edit Variables"
+                              bootstrapSize="sm"
+                              onClick={
+                                () => {
+                                  onSetActivePanel(`0.${index}.1`)
+                                  onTogglePanels(true)
+                                }
+                              }
+                            >
+                              Edit Variables
+                            </Button>
+                          </>
                         )
                       }
                     </ProjectPanelSection>

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -670,7 +670,7 @@ export class AccessMethod extends Component {
                       {
                         !hasVariables ? (
                           <p className="access-method__section-status">
-                            This service has no associated variables.
+                            No variables available for selected item.
                           </p>
                         ) : (
                           <>

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -469,6 +469,10 @@ export class AccessMethod extends Component {
 
     const selectedSpatialDisplay = createSpatialDisplay(spatial)
 
+    // Checking to see if the selectedMethod variables exists and has at least one variable
+    // eslint-disable-next-line max-len
+    const hasVariables = selectedMethod.variables ? Object.keys(selectedMethod.variables).length > 0 : false
+
     return (
       <div className="access-method">
         <ProjectPanelSection
@@ -663,34 +667,50 @@ export class AccessMethod extends Component {
                       nested
                     >
                       {
-                        selectedVariables.length > 0 && (
+                        !hasVariables && (
                           <p className="access-method__section-status">
-                            {`${selectedVariables.length} ${pluralize('variable', selectedVariables.length)} selected`}
+                            This service has no associated variables.
                           </p>
                         )
                       }
-
                       {
-                        selectedVariables.length === 0 && (
-                          <p className="access-method__section-status">
-                            No variables selected. All variables will be included in download.
-                          </p>
+                        hasVariables && (
+                          <>
+                            {
+                              selectedVariables.length > 0 && (
+                                <p className="access-method__section-status">
+                                  {`${selectedVariables.length} ${pluralize('variable', selectedVariables.length)} selected`}
+                                </p>
+                              )
+                            }
+                            {
+                              selectedVariables.length === 0 && (
+                                <p className="access-method__section-status">
+                                  No variables selected. All variables will be included in download.
+                                </p>
+                              )
+                            }
+                          </>
                         )
                       }
-                      <Button
-                        type="button"
-                        bootstrapVariant="primary"
-                        label="Edit Variables"
-                        bootstrapSize="sm"
-                        onClick={
-                          () => {
-                            onSetActivePanel(`0.${index}.1`)
-                            onTogglePanels(true)
-                          }
-                        }
-                      >
-                        Edit Variables
-                      </Button>
+                      {
+                        hasVariables && (
+                          <Button
+                            type="button"
+                            bootstrapVariant="primary"
+                            label="Edit Variables"
+                            bootstrapSize="sm"
+                            onClick={
+                              () => {
+                                onSetActivePanel(`0.${index}.1`)
+                                onTogglePanels(true)
+                              }
+                            }
+                          >
+                            Edit Variables
+                          </Button>
+                        )
+                      }
                     </ProjectPanelSection>
                   )
                 }

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -282,7 +282,7 @@ describe('AccessMethod component', () => {
         selectedAccessMethod: 'opendap'
       })
 
-      expect(screen.getByText('This service has no associated variables.')).toBeInTheDocument()
+      expect(screen.getByText('No variables available for selected item.')).toBeInTheDocument()
       expect(screen.queryByText(/variables selected/)).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Edit Variables' })).not.toBeInTheDocument()
     })

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -236,31 +236,7 @@ describe('AccessMethod component', () => {
       expect(screen.getByText(/variables selected/)).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Edit Variables' })).toBeInTheDocument()
     })
-  })
 
-  describe('when the selected access method has no variables', () => {
-    test('displays correct elements in variables window', () => {
-      const accessMethodsWithoutVariables = {
-        opendap: {
-          isValid: true,
-          type: 'OPeNDAP',
-          variables: {},
-          supportsVariableSubsetting: true
-        }
-      }
-
-      setup({
-        accessMethods: accessMethodsWithoutVariables,
-        selectedAccessMethod: 'opendap'
-      })
-
-      expect(screen.getByText('This service has no associated variables.')).toBeInTheDocument()
-      expect(screen.queryByText(/variables selected/)).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Edit Variables' })).not.toBeInTheDocument()
-    })
-  })
-
-  describe('when selectedAccessMethod has selectedVariables', () => {
     test('displays the number of selected variables', async () => {
       const selectedVariables = ['VAR123', 'VAR456']
       setup({
@@ -287,6 +263,28 @@ describe('AccessMethod component', () => {
 
       // Check if the text indicating the number of selected variables is present
       expect(screen.getByText(`${selectedVariables.length} variables selected`)).toBeInTheDocument()
+    })
+  })
+
+  describe('when the selected access method has no variables', () => {
+    test('displays correct elements in variables window', () => {
+      const accessMethodsWithoutVariables = {
+        opendap: {
+          isValid: true,
+          type: 'OPeNDAP',
+          variables: {},
+          supportsVariableSubsetting: true
+        }
+      }
+
+      setup({
+        accessMethods: accessMethodsWithoutVariables,
+        selectedAccessMethod: 'opendap'
+      })
+
+      expect(screen.getByText('This service has no associated variables.')).toBeInTheDocument()
+      expect(screen.queryByText(/variables selected/)).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Edit Variables' })).not.toBeInTheDocument()
     })
   })
 

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -260,6 +260,36 @@ describe('AccessMethod component', () => {
     })
   })
 
+  describe('when selectedAccessMethod has selectedVariables', () => {
+    test('displays the number of selected variables', async () => {
+      const selectedVariables = ['VAR123', 'VAR456']
+      setup({
+        accessMethods: {
+          opendap: {
+            isValid: true,
+            type: 'OPeNDAP',
+            variables: {
+              VAR123: {
+                meta: {},
+                umm: {}
+              },
+              VAR456: {
+                meta: {},
+                umm: {}
+              }
+            },
+            selectedVariables,
+            supportsVariableSubsetting: true
+          }
+        },
+        selectedAccessMethod: 'opendap'
+      })
+
+      // Check if the text indicating the number of selected variables is present
+      expect(screen.getByText(`${selectedVariables.length} variables selected`)).toBeInTheDocument()
+    })
+  })
+
   describe('when the selected access method has an echoform', () => {
     test('lazy loads the echo-forms component and provides the correct fallback', async () => {
       const collectionId = 'collectionId'

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -210,6 +210,56 @@ describe('AccessMethod component', () => {
     })
   })
 
+  describe('when the selected access method has variables', () => {
+    test('displays correct elements in variables window', () => {
+      const accessMethodsWithVariables = {
+        opendap: {
+          isValid: true,
+          type: 'OPeNDAP',
+          variables: {
+            VAR123: {
+              conceptId: 'VAR123',
+              longName: 'Variable 123',
+              name: 'Var123'
+            }
+          },
+          supportsVariableSubsetting: true
+        }
+      }
+
+      setup({
+        accessMethods: accessMethodsWithVariables,
+        selectedAccessMethod: 'opendap'
+      })
+
+      expect(screen.queryByText('This service has no associated variables.')).not.toBeInTheDocument()
+      expect(screen.getByText(/variables selected/)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Edit Variables' })).toBeInTheDocument()
+    })
+  })
+
+  describe('when the selected access method has no variables', () => {
+    test('displays correct elements in variables window', () => {
+      const accessMethodsWithoutVariables = {
+        opendap: {
+          isValid: true,
+          type: 'OPeNDAP',
+          variables: {},
+          supportsVariableSubsetting: true
+        }
+      }
+
+      setup({
+        accessMethods: accessMethodsWithoutVariables,
+        selectedAccessMethod: 'opendap'
+      })
+
+      expect(screen.getByText('This service has no associated variables.')).toBeInTheDocument()
+      expect(screen.queryByText(/variables selected/)).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Edit Variables' })).not.toBeInTheDocument()
+    })
+  })
+
   describe('when the selected access method has an echoform', () => {
     test('lazy loads the echo-forms component and provides the correct fallback', async () => {
       const collectionId = 'collectionId'

--- a/static/src/js/components/ProjectPanels/VariableTreePanel.js
+++ b/static/src/js/components/ProjectPanels/VariableTreePanel.js
@@ -20,7 +20,11 @@ export const VariableTreePanel = (props) => {
     onViewDetails
   } = props
 
-  if (!accessMethods || !selectedAccessMethod) return null
+  if (!accessMethods || !selectedAccessMethod) {
+    return (
+      <div className="variable-tree-panel__no-variables">No variables available for selected access method</div>
+    )
+  }
 
   const selectedMethod = accessMethods[selectedAccessMethod]
   const {
@@ -30,6 +34,7 @@ export const VariableTreePanel = (props) => {
     selectedVariables = [],
     variables
   } = selectedMethod
+
   if (!variables) return null
 
   const hierarchyButtonClasses = classNames([
@@ -73,6 +78,7 @@ export const VariableTreePanel = (props) => {
   )
 
   let items = treeView === 'hierarchy' ? hierarchyMappings : keywordMappings
+  const isItemsEmpty = items.length === 0
 
   // If keywordMappings or hierarchyMappings don't exist, default items to the one that does exist
   if (keywordMappings.length && !hierarchyMappings.length) items = keywordMappings
@@ -81,16 +87,22 @@ export const VariableTreePanel = (props) => {
   return (
     <ProjectPanelSection heading="Variable Selection">
       {keywordMappings.length > 0 && hierarchyMappings.length > 0 && browseBy}
-      <Tree
-        key={`${selectedAccessMethodServiceConceptId}_${treeView}`}
-        collectionId={collectionId}
-        index={index}
-        items={items}
-        selectedVariables={selectedVariables}
-        variables={variables}
-        onUpdateSelectedVariables={onUpdateSelectedVariables}
-        onViewDetails={onViewDetails}
-      />
+      {
+        isItemsEmpty ? (
+          <div className="variable-tree-panel__no-variables">No variables available for selected access method</div>
+        ) : (
+          <Tree
+            key={`${selectedAccessMethodServiceConceptId}_${treeView}`}
+            collectionId={collectionId}
+            index={index}
+            items={items}
+            selectedVariables={selectedVariables}
+            variables={variables}
+            onUpdateSelectedVariables={onUpdateSelectedVariables}
+            onViewDetails={onViewDetails}
+          />
+        )
+      }
     </ProjectPanelSection>
   )
 }

--- a/static/src/js/components/ProjectPanels/VariableTreePanel.js
+++ b/static/src/js/components/ProjectPanels/VariableTreePanel.js
@@ -87,13 +87,13 @@ export const VariableTreePanel = (props) => {
   if (keywordMappings.length && !hierarchyMappings.length) items = keywordMappings
   if (!keywordMappings.length && hierarchyMappings.length) items = hierarchyMappings
 
-  const isItemsEmpty = items.length === 0
+  const hasVariableItems = items.length
 
   return (
     <ProjectPanelSection heading="Variable Selection">
       {keywordMappings.length > 0 && hierarchyMappings.length > 0 && browseBy}
       {
-        isItemsEmpty ? (
+        !hasVariableItems ? (
           <div className="variable-tree-panel__no-variables">No variables available for selected access method</div>
         ) : (
           <Tree

--- a/static/src/js/components/ProjectPanels/VariableTreePanel.js
+++ b/static/src/js/components/ProjectPanels/VariableTreePanel.js
@@ -35,7 +35,11 @@ export const VariableTreePanel = (props) => {
     variables
   } = selectedMethod
 
-  if (!variables) return null
+  if (!variables) {
+    return (
+      <div className="variable-tree-panel__no-variables">No variables available for selected access method</div>
+    )
+  }
 
   const hierarchyButtonClasses = classNames([
     'variable-tree-panel__tree-switcher-button',
@@ -78,11 +82,12 @@ export const VariableTreePanel = (props) => {
   )
 
   let items = treeView === 'hierarchy' ? hierarchyMappings : keywordMappings
-  const isItemsEmpty = items.length === 0
 
   // If keywordMappings or hierarchyMappings don't exist, default items to the one that does exist
   if (keywordMappings.length && !hierarchyMappings.length) items = keywordMappings
   if (!keywordMappings.length && hierarchyMappings.length) items = hierarchyMappings
+
+  const isItemsEmpty = items.length === 0
 
   return (
     <ProjectPanelSection heading="Variable Selection">

--- a/static/src/js/components/ProjectPanels/VariableTreePanel.scss
+++ b/static/src/js/components/ProjectPanels/VariableTreePanel.scss
@@ -35,6 +35,10 @@
     }
   }
 
+  &__no-variables {
+    margin-left: 2rem;
+  }
+
   &__list {
     margin: 0;
     padding: 0;

--- a/static/src/js/components/ProjectPanels/__tests__/VariableTreePanel.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/VariableTreePanel.test.js
@@ -110,7 +110,6 @@ describe('VariableTreePanel', () => {
       }
     })
 
-    expect(enzymeWrapper.exists()).toBeTruthy()
     expect(enzymeWrapper.find('.variable-tree-panel__no-variables').exists()).toBeTruthy()
     expect(enzymeWrapper.find('.variable-tree-panel__no-variables').text()).toBe('No variables available for selected access method')
   })

--- a/static/src/js/components/ProjectPanels/__tests__/VariableTreePanel.test.js
+++ b/static/src/js/components/ProjectPanels/__tests__/VariableTreePanel.test.js
@@ -89,6 +89,32 @@ describe('VariableTreePanel', () => {
     ])
   })
 
+  test('displays a message when there are no items to display', () => {
+    const { enzymeWrapper } = setup({
+      accessMethods: {
+        opendap: {
+          hierarchyMappings: [],
+          keywordMappings: [],
+          selectedVariables: [],
+          variables: {
+            'V123456-EDSC': {
+              meta: {},
+              umm: {}
+            },
+            'V987654-EDSC': {
+              meta: {},
+              umm: {}
+            }
+          }
+        }
+      }
+    })
+
+    expect(enzymeWrapper.exists()).toBeTruthy()
+    expect(enzymeWrapper.find('.variable-tree-panel__no-variables').exists()).toBeTruthy()
+    expect(enzymeWrapper.find('.variable-tree-panel__no-variables').text()).toBe('No variables available for selected access method')
+  })
+
   test('displays a Tree hierarchical mappings', () => {
     const { enzymeWrapper } = setup({
       accessMethods: {

--- a/static/src/js/components/Tree/TreeItem.js
+++ b/static/src/js/components/Tree/TreeItem.js
@@ -132,7 +132,7 @@ export const TreeItem = ({
       className={treeItemClasses}
     >
       <div
-        className="tree-item__header"
+        className="tree-item__headervariable"
       >
         {
           isParent && (

--- a/static/src/js/components/Tree/TreeItem.js
+++ b/static/src/js/components/Tree/TreeItem.js
@@ -132,7 +132,7 @@ export const TreeItem = ({
       className={treeItemClasses}
     >
       <div
-        className="tree-item__headervariable"
+        className="tree-item__header-variable"
       >
         {
           isParent && (

--- a/static/src/js/components/Tree/TreeItem.scss
+++ b/static/src/js/components/Tree/TreeItem.scss
@@ -3,7 +3,7 @@
   margin-left: 1.5rem;
   margin-bottom: 0.325rem;
 
-  &__header {
+  &__headervariable {
     vertical-align: middle;
     display: flex;
     align-items: flex-start;

--- a/static/src/js/components/Tree/TreeItem.scss
+++ b/static/src/js/components/Tree/TreeItem.scss
@@ -3,7 +3,7 @@
   margin-left: 1.5rem;
   margin-bottom: 0.325rem;
 
-  &__headervariable {
+  &__header-variable {
     vertical-align: middle;
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
# Overview

### What is the feature?

Currently, the variables section of the customization form displays empty content when no variables exist. This is confusing UX. We should hide the variables section when no variables exist. The new behavior is to hide the `Edit Variables` button and display text letting the user know that there are no variables to edit for the selected service.

There was also a minor visual bug where the variables would display double, which was confusing to look at. This has also been rectified.

### What areas of the application does this impact?

Project panel

# Testing

### Reproduction steps

1. Add a collection with variables associated to a service to your project.
2. Repeat for a collection without any variables.
3. Go to project panel page, and select `Edit Options` for a collection with a service that has variables associated.
4. Verify that the `Variables` panel displays as expected, and select `Edit Variables` to ensure the proper behavior.
5. Repeat for a collection without any variables, and verify that the Variables panel doesn't have an `Edit Variables` button and that the text in the panel informs the user that there are no variables to customize.
6. Switch between the two collections by selecting `Edit Options` for the other collection, and verify that the visual bug of Variables displaying double does not happen.

### Attachments

![Screenshot 2024-02-12 at 10 53 42 PM](https://github.com/nasa/earthdata-search/assets/21003704/74284339-9cbd-40bf-b0c3-7330f22852c6)
(See new Variable panel for collections without Variables to customize for selected service)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
