### PR TITLE
EDSC-3967: Encrypt the RDS and update Engine Version

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -38,11 +38,12 @@ Resources:
       AllocatedStorage: ${env:DB_ALLOCATED_STORAGE}
       DBInstanceClass: ${env:DB_INSTANCE_CLASS}
       Engine: postgres
-      EngineVersion: '14.4'
+      EngineVersion: '14.10'
       AllowMajorVersionUpgrade: true
       MasterUsername: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:username}}"] ] }
       MasterUserPassword: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:password}}"] ] }
       MultiAZ: true
+      StorageEncrypted: true
       StorageType: gp2
       DBSubnetGroupName:
         Ref: DBSubnetGroup


### PR DESCRIPTION
# Overview

### What is the feature?

This is the cloud-formation changes needed to encrypt the database per the DAR requirements. We found for ordering we needed to update this to `14.10`. In actuality EDSC is already on `14.10` in the deployed environment because we allow minor version updates to take place, however, since this will destroy the old RDS and create a new one, the version specified must be available to AWS at the time of deployment which `14.4` was no longer. 

### What is the Solution?

Update serverless inf to encrypt the RDS instance and a minor version update to the database engine

### What areas of the application does this impact?

List impacted areas.

The database infrastructure

### Reproduction steps

Ensure that when this is deployed the `Encrypted` property in the configuration of the RDS is set to true. In this ticket we also go through the necessary alerting and backing up workflow required to do this change

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
N/A

# Checklist

- [n/a] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
