### PR TITLE
EDSC-4006 adds granule query params back into fetchCmrLinks

### DIFF
--- a/serverless/src/retrieveGranuleLinks/__tests__/fetchCmrLinks.test.js
+++ b/serverless/src/retrieveGranuleLinks/__tests__/fetchCmrLinks.test.js
@@ -3,8 +3,23 @@ import { fetchCmrLinks } from '../fetchCmrLinks'
 
 describe('fetchCmrLinks', () => {
   test('returns a list of links from CMR', async () => {
+    const granulesGraphQlQuery = '\n  query GetGranuleLinks( $params: GranulesInput ) {\n    granules( params: $params) {\n      cursor\n      items {\n        links\n      }\n    }\n  }'
     nock(/graphql/)
-      .post(/api/)
+      .post(/api/, (body) => JSON.stringify(body) === JSON.stringify({
+        query: granulesGraphQlQuery,
+        variables: {
+          params: {
+            exclude: {},
+            options: {},
+            temporal: '2023-03-26T15:05:48.871Z,2023-03-27T10:48:39.230Z',
+            conceptId: [],
+            twoDCoordinateSystem: {},
+            limit: 500,
+            linkTypes: ['data', 's3'],
+            collectionConceptId: 'C1214470488-ASF'
+          }
+        }
+      }))
       .reply(200, {
         data: {
           granules: {

--- a/serverless/src/retrieveGranuleLinks/fetchCmrLinks.js
+++ b/serverless/src/retrieveGranuleLinks/fetchCmrLinks.js
@@ -1,5 +1,7 @@
 import axios from 'axios'
+import camelcaseKeys from 'camelcase-keys'
 
+import { prepareGranuleAccessParams } from '../../../sharedUtils/prepareGranuleAccessParams'
 import { getApplicationConfig, getEarthdataConfig } from '../../../sharedUtils/config'
 import { getDownloadUrls } from '../../../sharedUtils/getDownloadUrls'
 import { getS3Urls } from '../../../sharedUtils/getS3Urls'
@@ -29,14 +31,18 @@ export const fetchCmrLinks = async ({
 
   const graphQlUrl = `${graphQlHost}/api`
 
-  const { concept_id: conceptIdsFromParams = [] } = granuleParams
+  const preparedGranuleParams = camelcaseKeys(prepareGranuleAccessParams(granuleParams))
+
+  delete preparedGranuleParams.pageNum
+  delete preparedGranuleParams.pageSize
+  delete preparedGranuleParams.echoCollectionId
 
   const variables = {
     params: {
+      ...preparedGranuleParams,
       limit: parseInt(granuleLinksPageSize, 10),
       linkTypes: linkTypes.split(','),
       collectionConceptId: collectionId,
-      conceptId: conceptIdsFromParams,
       cursor
     }
   }


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes granule_links look up to properly filter granules

### What is the Solution?

Passing along the granule query params to the fetchLinks call was recently removed, adding it back

### What areas of the application does this impact?

Download Panels

# Testing

### Reproduction steps

- PROD
- C2324689816-LPCLOUD

1. Order granules Direct Download with some temporal fitlering
2. Download Panels should show more granules than filtered for

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
