### PR TITLE
EDSC-3967: First add new Encrypted database

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -63,6 +63,8 @@ Resources:
       MultiAZ: true
       StorageEncrypted: true
       StorageType: gp2
+      EnablePerformanceInsights: true
+      PerformanceInsightsRetentionPeriod: 7
       DBSubnetGroupName:
         Ref: DBSubnetGroup
       VPCSecurityGroups:

--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -38,6 +38,24 @@ Resources:
       AllocatedStorage: ${env:DB_ALLOCATED_STORAGE}
       DBInstanceClass: ${env:DB_INSTANCE_CLASS}
       Engine: postgres
+      EngineVersion: '14.4'
+      AllowMajorVersionUpgrade: true
+      MasterUsername: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:username}}"] ] }
+      MasterUserPassword: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:password}}"] ] }
+      MultiAZ: true
+      StorageType: gp2
+      DBSubnetGroupName:
+        Ref: DBSubnetGroup
+      VPCSecurityGroups:
+        - Ref: DatabaseVpcSecurityGroup
+
+  EncryptedDatabase:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBName: edsc_${self:provider.stage}
+      AllocatedStorage: ${env:DB_ALLOCATED_STORAGE}
+      DBInstanceClass: ${env:DB_INSTANCE_CLASS}
+      Engine: postgres
       EngineVersion: '14.10'
       AllowMajorVersionUpgrade: true
       MasterUsername: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:username}}"] ] }
@@ -212,7 +230,7 @@ Outputs:
   DatabaseEndpoint:
     Value:
       Fn::GetAtt:
-        - Database
+        - EncryptedDatabase
         - Endpoint.Address
     Export:
       Name: ${self:provider.stage}-DatabaseEndpoint
@@ -220,7 +238,7 @@ Outputs:
   DatabasePort:
     Value:
       Fn::GetAtt:
-        - Database
+        - EncryptedDatabase
         - Endpoint.Port
     Export:
       Name: ${self:provider.stage}-DatabasePort


### PR DESCRIPTION
# Overview

### What is the feature?

Creates the new encrypted database. In this PR we will create a new RDS instance with the properties that we need (Encryption + engine version). In a subsequent PR we will delete the old database after we have filled in this new RDS with the data from the old one. This is needed because the `serverless` `cloudformation` template requires a reference to the old database for a variable in the `serverless.yml ` stack. So the `encryption enabled` property alone causes us problems. Instead by spinning up this new one there is no destructive action taken.

### What is the Solution?

Added new encrypted RDS instance

### What areas of the application does this impact?

Infrastructure

# Testing

### Reproduction steps

Ensure the new RDS instance has been created on AWS console and it is encrypted

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
