### PR TITLE
EDSC-3967: Updating exported reference to the database endpoint and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For local development Earthdata Search uses a json configuration file to store s
 
     cp secret.config.json.example secret.config.json
 
-In order to operate against a local database this file will need `dbUsername` and `dbPassword` values set (you may need to update `dbHost`, `dbName` or `dbPort` in `static.config.json` if you have custom configuration locally). 
+In order to operate against a local database this file will need `dbUsername` and `dbPassword` values set (you may need to update `dbHost`, `dbName` or `databasePort` in `static.config.json` if you have custom configuration locally). 
 
 If you created the `postgres` user after a new PostgreSQL install as described above, both `dbUsername` and `dbPassword` will be the username you use to log into your computer.
 

--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -30,6 +30,26 @@ Resources:
         Ref: Database
       TargetType: AWS::RDS::DBInstance
 
+  # Encrypted Database password secret storage
+  EncryptedDbPasswordSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: "EDSC Encrypted RDS database master password"
+      GenerateSecretString:
+        SecretStringTemplate: "{\"username\":\"edsc\"}"
+        GenerateStringKey: "password"
+        PasswordLength: 30
+        ExcludeCharacters: "\"@/\\"
+
+  SecretEncryptedRDSInstanceAttachment:
+    Type: "AWS::SecretsManager::SecretTargetAttachment"
+    Properties:
+      SecretId:
+        Ref: EncryptedDbPasswordSecret
+      TargetId:
+        Ref: EncryptedDatabase
+      TargetType: AWS::RDS::DBInstance
+
   # RDS database
   Database:
     Type: AWS::RDS::DBInstance
@@ -229,10 +249,26 @@ Outputs:
     Export:
       Name: ${self:provider.stage}-EDSCServerlessAppRole
 
-  DatabaseEndpoint:
+  EncryptedDatabaseEndpoint:
     Value:
       Fn::GetAtt:
         - EncryptedDatabase
+        - Endpoint.Address
+    Export:
+      Name: ${self:provider.stage}-EncryptedDatabaseEndpoint
+
+  EncryptedDatabasePort:
+    Value:
+      Fn::GetAtt:
+        - EncryptedDatabase
+        - Endpoint.Port
+    Export:
+      Name: ${self:provider.stage}-EncryptedDatabasePort
+
+  DatabaseEndpoint:
+    Value:
+      Fn::GetAtt:
+        - Database
         - Endpoint.Address
     Export:
       Name: ${self:provider.stage}-DatabaseEndpoint
@@ -240,7 +276,7 @@ Outputs:
   DatabasePort:
     Value:
       Fn::GetAtt:
-        - EncryptedDatabase
+        - Database
         - Endpoint.Port
     Export:
       Name: ${self:provider.stage}-DatabasePort

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,12 @@ provider:
       Fn::ImportValue: ${self:provider.stage}-DatabaseEndpoint
     dbPort:
       Fn::ImportValue: ${self:provider.stage}-DatabasePort
+    # Variables for new Encrypted database
+    databaseEndpoint:
+      Fn::ImportValue: ${self:provider.stage}-EncryptedDatabaseEndpoint
+    databasePort:
+      Fn::ImportValue: ${self:provider.stage}-EncryptedDatabasePort
+
     dbUsername: edsc
     dbName: edsc_${self:provider.stage}
 
@@ -103,8 +109,8 @@ custom:
     # When invoking an offline lambda with `npm run invoke-local` this condition will disable serverless components that need to import or reference cloudformation values
     - If: '"${self:provider.stage}" == "invokeLocal"'
       Exclude:
-        - provider.environment.dbEndpoint
-        - provider.environment.dbPort
+        - provider.environment.databaseEndpoint
+        - provider.environment.databasePort
         - provider.environment.colorMapQueueUrl
         - provider.environment.tagQueueUrl
         - provider.environment.cmrOrderingOrderQueueUrl

--- a/serverless/src/util/database/__tests__/getDbConnectionConfig.test.js
+++ b/serverless/src/util/database/__tests__/getDbConnectionConfig.test.js
@@ -18,9 +18,9 @@ describe('getDbConnectionConfig', () => {
   })
 
   test('fetches urs credentials from secrets manager', async () => {
-    process.env.dbEndpoint = 'db://endpoint.com'
+    process.env.databaseEndpoint = 'db://endpoint.com'
     process.env.dbName = 'test-db'
-    process.env.dbPort = 1234
+    process.env.databasePort = 1234
 
     jest.spyOn(getDbCredentials, 'getDbCredentials').mockImplementationOnce(() => ({
       username: 'username',

--- a/serverless/src/util/database/getDbConnectionConfig.js
+++ b/serverless/src/util/database/getDbConnectionConfig.js
@@ -16,21 +16,21 @@ export const getDbConnectionConfig = async () => {
     }
 
     if (process.env.NODE_ENV === 'development') {
-      const { dbHost, dbName, dbPort } = getEnvironmentConfig()
+      const { dbHost, dbName, databasePort } = getEnvironmentConfig()
 
       return {
         ...configObject,
         host: dbHost,
         database: dbName,
-        port: dbPort
+        port: databasePort
       }
     }
 
     connectionConfig = {
       ...configObject,
-      host: process.env.dbEndpoint,
+      host: process.env.databaseEndpoint,
       database: process.env.dbName,
-      port: process.env.dbPort
+      port: process.env.databasePort
     }
   }
 

--- a/static.config.json
+++ b/static.config.json
@@ -60,7 +60,7 @@
     "development": {
       "dbHost": "127.0.0.1",
       "dbName": "edsc_dev",
-      "dbPort": 5432,
+      "databasePort": 5432,
       "apiHost": "http://localhost:3001/dev",
       "edscHost": "http://localhost:8080"
     },


### PR DESCRIPTION
# Overview

### What is the feature?

Cloud-formation issue because `serverless.yml` is trying to pull in a reference to the `infrastructure` as we are trying to update the value. Using an updated variable

### What is the Solution?

Add an updated variable for the new database and use that instead of overriding the value of the original one


### What areas of the application does this impact?

List impacted areas.

Infrastructure 

Ensure a new database is created which is encrypted and the version specified

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
