### PR TITLE
EDSC-3967: Second remove the old UnEncryptedDatabase

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -31,24 +31,6 @@ Resources:
       TargetType: AWS::RDS::DBInstance
 
   # RDS database
-  Database:
-    Type: AWS::RDS::DBInstance
-    Properties:
-      DBName: edsc_${self:provider.stage}
-      AllocatedStorage: ${env:DB_ALLOCATED_STORAGE}
-      DBInstanceClass: ${env:DB_INSTANCE_CLASS}
-      Engine: postgres
-      EngineVersion: '14.4'
-      AllowMajorVersionUpgrade: true
-      MasterUsername: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:username}}"] ] }
-      MasterUserPassword: {"Fn::Join": ["", ["{{resolve:secretsmanager:",{"Ref": "DbPasswordSecret"},":SecretString:password}}"] ] }
-      MultiAZ: true
-      StorageType: gp2
-      DBSubnetGroupName:
-        Ref: DBSubnetGroup
-      VPCSecurityGroups:
-        - Ref: DatabaseVpcSecurityGroup
-
   EncryptedDatabase:
     Type: AWS::RDS::DBInstance
     Properties:
@@ -244,19 +226,3 @@ Outputs:
         - Endpoint.Port
     Export:
       Name: ${self:provider.stage}-EncryptedDatabasePort
-
-  DatabaseEndpoint:
-    Value:
-      Fn::GetAtt:
-        - Database
-        - Endpoint.Address
-    Export:
-      Name: ${self:provider.stage}-DatabaseEndpoint
-
-  DatabasePort:
-    Value:
-      Fn::GetAtt:
-        - Database
-        - Endpoint.Port
-    Export:
-      Name: ${self:provider.stage}-DatabasePort

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,10 +9,6 @@ provider:
   endpointType: PRIVATE
   memorySize: 128
   environment:
-    dbEndpoint:
-      Fn::ImportValue: ${self:provider.stage}-DatabaseEndpoint
-    dbPort:
-      Fn::ImportValue: ${self:provider.stage}-DatabasePort
     # Variables for new Encrypted database
     databaseEndpoint:
       Fn::ImportValue: ${self:provider.stage}-EncryptedDatabaseEndpoint


### PR DESCRIPTION
# Overview

### What is the feature?

This step is needed as its own deployment because the first deployment work needed to spin up the new encrypted RDS and move the references in the source code to using the new database properties which was failing to deploy in bamboo because the references could not be updated or deleted. This serves to 'clean up'  the old variables and infrastructure which is no longer being used

### What is the Solution?

We fix some naming inconsistency from the previous commit, update the secret password for the encrypted database to be the correct value, and the main purpose which is to remove the old database infrastructure which is no longer getting written to

### What areas of the application does this impact?

List impacted areas.
Infrastructure

# Testing

When this completes we will have only a single database that is encrypted in SIT and all references in the source code will be pointing to that instance. We will also have a single related `secret` in the secrets manager which will contain the necessary values for tunneling into the database with the correct credentials

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
