### PR TITLE
EDSC-3967: Update the dbSecret to reference the new database

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -27,26 +27,6 @@ Resources:
       SecretId:
         Ref: DbPasswordSecret
       TargetId:
-        Ref: Database
-      TargetType: AWS::RDS::DBInstance
-
-  # Encrypted Database password secret storage
-  EncryptedDbPasswordSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: "EDSC Encrypted RDS database master password"
-      GenerateSecretString:
-        SecretStringTemplate: "{\"username\":\"edsc\"}"
-        GenerateStringKey: "password"
-        PasswordLength: 30
-        ExcludeCharacters: "\"@/\\"
-
-  SecretEncryptedRDSInstanceAttachment:
-    Type: "AWS::SecretsManager::SecretTargetAttachment"
-    Properties:
-      SecretId:
-        Ref: EncryptedDbPasswordSecret
-      TargetId:
         Ref: EncryptedDatabase
       TargetType: AWS::RDS::DBInstance
 


### PR DESCRIPTION
# Overview

### What is the feature?

Fix a discrepancy between the secret pointing to the old database and instead point to the new one (we cannot simply update the values in the Database because the username is not editable after creation)

### What is the Solution?

Update the value of the secret manager so that it will point to the new database remove the newly created secret which was not being used

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
