### PR TITLE
EDSC-4030: Nullify the retrieval_collections foreign key constraint b…

### DIFF
--- a/serverless/src/deleteProject/handler.js
+++ b/serverless/src/deleteProject/handler.js
@@ -31,7 +31,7 @@ const deleteProject = async (event, context) => {
 
   const decodedProjectId = deobfuscateId(providedProjectId)
 
-  // Retrive a connection to the database
+  // Retrieve a connection to the database
   const dbConnection = await getDbConnection()
 
   try {

--- a/serverless/src/deleteRetrieval/__tests__/handler.test.js
+++ b/serverless/src/deleteRetrieval/__tests__/handler.test.js
@@ -41,6 +41,8 @@ describe('deleteRetrieval', () => {
     dbTracker.on('query', (query, step) => {
       if (step === 1) {
         query.response(1)
+      } else if (step === 2) {
+        query.response(2)
       } else {
         query.response(undefined)
       }
@@ -55,16 +57,17 @@ describe('deleteRetrieval', () => {
     const response = await deleteRetrieval(event, {})
 
     const { queries } = dbTracker.queries
-    expect(queries[0].method).toEqual('del')
+    expect(queries[0].method).toEqual('update')
+    expect(queries[1].method).toEqual('del')
 
     expect(response.statusCode).toEqual(204)
   })
 
-  test('returns a 404 for the retrieval does not belong to the authenticated user', async () => {
+  test('returns a 404 for the retrieval if it does not belong to the authenticated user', async () => {
     const retrievalId = '7023641925'
 
     dbTracker.on('query', (query, step) => {
-      if (step === 1) {
+      if (step === 2) {
         query.response(0)
       } else {
         query.response(undefined)
@@ -80,7 +83,8 @@ describe('deleteRetrieval', () => {
     const response = await deleteRetrieval(event, {})
 
     const { queries } = dbTracker.queries
-    expect(queries[0].method).toEqual('del')
+    expect(queries[0].method).toEqual('update')
+    expect(queries[1].method).toEqual('del')
 
     expect(response.statusCode).toEqual(404)
   })

--- a/serverless/src/deleteRetrieval/handler.js
+++ b/serverless/src/deleteRetrieval/handler.js
@@ -37,7 +37,7 @@ export default async function deleteRetrieval(event, context) {
 
     // Nullify the foreign key constraint on the table before deleting
     await dbConnection('retrieval_collections')
-      .where('retrieval_id', '=', decodedRetrievalId)
+      .where('retrieval_id', decodedRetrievalId)
       .update('retrieval_id', null)
 
     // Retrieve the authenticated users' id to ensure the retrieval being deleted belongs to them

--- a/serverless/src/deleteRetrieval/handler.js
+++ b/serverless/src/deleteRetrieval/handler.js
@@ -35,6 +35,11 @@ export default async function deleteRetrieval(event, context) {
     // Retrieve a connection to the database
     const dbConnection = await getDbConnection()
 
+    // Nullify the foreign key constraint on the table before deleting
+    await dbConnection('retrieval_collections')
+      .where('retrieval_id', '=', decodedRetrievalId)
+      .update('retrieval_id', null)
+
     // Retrieve the authenticated users' id to ensure the retrieval being deleted belongs to them
     const affectedRows = await dbConnection('retrievals')
       .where({

--- a/serverless/src/saveProject/__tests__/handler.test.js
+++ b/serverless/src/saveProject/__tests__/handler.test.js
@@ -12,7 +12,7 @@ let dbTracker
 beforeEach(() => {
   jest.clearAllMocks()
   jest.spyOn(getJwtToken, 'getJwtToken').mockImplementation(() => 'mockJwt')
-  jest.spyOn(getVerifiedJwtToken, 'getVerifiedJwtToken').mockImplementation(() => ({ username: 'testuser' }))
+  jest.spyOn(getVerifiedJwtToken, 'getVerifiedJwtToken').mockImplementation(() => ({ id: 1 }))
 
   jest.spyOn(getDbConnection, 'getDbConnection').mockImplementationOnce(() => {
     dbConnectionToMock = knex({
@@ -35,7 +35,7 @@ afterEach(() => {
 })
 
 describe('saveProject', () => {
-  describe('as an unauthticated user', () => {
+  describe('as an unauthenticated user', () => {
     test('saves an unnamed project into the database', async () => {
       const path = '/search?p=C123456-EDSC'
 
@@ -79,10 +79,6 @@ describe('saveProject', () => {
       dbTracker.on('query', (query, step) => {
         if (step === 1) {
           query.response({
-            id: 12
-          })
-        } else if (step === 2) {
-          query.response({
             id: 12,
             path
           })
@@ -111,20 +107,17 @@ describe('saveProject', () => {
       const { queries } = dbTracker.queries
 
       expect(queries[0].method).toEqual('first')
-      expect(queries[1].method).toEqual('update')
 
       expect(result.body).toEqual(expectedBody)
     })
   })
 
-  describe('as an authticated user', () => {
+  describe('as an authenticated user', () => {
     test('saves an unnamed project into the database', async () => {
       const path = '/search?p=C123456-EDSC'
 
       dbTracker.on('query', (query, step) => {
         if (step === 1) {
-          query.response([{ id: 1 }])
-        } else if (step === 2) {
           query.response([{
             id: 12
           }])
@@ -152,8 +145,7 @@ describe('saveProject', () => {
 
       const { queries } = dbTracker.queries
 
-      expect(queries[0].method).toEqual('first')
-      expect(queries[1].method).toEqual('insert')
+      expect(queries[0].method).toEqual('insert')
 
       expect(result.body).toEqual(expectedBody)
     })
@@ -163,12 +155,10 @@ describe('saveProject', () => {
 
       dbTracker.on('query', (query, step) => {
         if (step === 1) {
-          query.response([{ id: 1 }])
-        } else if (step === 2) {
           query.response({
             id: 12
           })
-        } else if (step === 3) {
+        } else if (step === 2) {
           query.response({
             id: 12
           })
@@ -198,8 +188,7 @@ describe('saveProject', () => {
       const { queries } = dbTracker.queries
 
       expect(queries[0].method).toEqual('first')
-      expect(queries[1].method).toEqual('first')
-      expect(queries[2].method).toEqual('update')
+      expect(queries[1].method).toEqual('update')
 
       expect(result.body).toEqual(expectedBody)
     })
@@ -209,11 +198,9 @@ describe('saveProject', () => {
 
       dbTracker.on('query', (query, step) => {
         if (step === 1) {
-          query.response([{ id: 1 }])
-        } else if (step === 2) {
           // Find project by projectId and userId
           query.response(undefined)
-        } else if (step === 3) {
+        } else if (step === 2) {
           query.response([{
             id: 13
           }])
@@ -243,8 +230,7 @@ describe('saveProject', () => {
       const { queries } = dbTracker.queries
 
       expect(queries[0].method).toEqual('first')
-      expect(queries[1].method).toEqual('first')
-      expect(queries[2].method).toEqual('insert')
+      expect(queries[1].method).toEqual('insert')
 
       expect(result.body).toEqual(expectedBody)
     })
@@ -311,8 +297,6 @@ describe('saveProject', () => {
 
     dbTracker.on('query', (query, step) => {
       if (step === 1) {
-        query.response([{ id: 1 }])
-      } else if (step === 2) {
         // Find project by projectId and userId
         query.response(undefined)
       } else {
@@ -335,8 +319,6 @@ describe('saveProject', () => {
     const { queries } = dbTracker.queries
 
     expect(queries[0].method).toEqual('first')
-    expect(queries[1].method).toEqual('first')
-    expect(queries[2].method).toEqual('insert')
 
     expect(result.statusCode).toEqual(500)
   })

--- a/serverless/src/saveProject/handler.js
+++ b/serverless/src/saveProject/handler.js
@@ -31,7 +31,7 @@ const saveProject = async (event, context) => {
 
   const earthdataEnvironment = deployedEnvironment()
 
-  // Retrive a connection to the database
+  // Retrieve a connection to the database
   const dbConnection = await getDbConnection()
 
   let newProjectId
@@ -40,11 +40,7 @@ const saveProject = async (event, context) => {
     let userId
     // If user information was included, use it in the queries
     if (authToken) {
-      const { username } = getVerifiedJwtToken(authToken, earthdataEnvironment)
-
-      const userRecord = await dbConnection('users').first('id').where({ urs_id: username })
-
-      const { id } = userRecord
+      const { id } = getVerifiedJwtToken(authToken, earthdataEnvironment)
       userId = id
     }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Due to the update to the database where we encrypted/created a new database instance something changed in either the `knex` commands (which would normally be skipped during the migrateDatabases lambda if the tables/schema already existed) or in the database version that we had to update our RDS instance to (the old one was not available). that allowed this constraint which should have always existed but, simply did not to be created

### What is the Solution?

By nullifying the foreign key before we do the deletion command we are able to get around this introduced constraint


### What areas of the application does this impact?

List impacted areas.

# Testing

1) Create a retrieval ensure that it can be deleted from the history page; if you have historical retrievals ensure we can delete some of those as well

2) Ensure that we can create a project and delete that project

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
