### PR TITLE
EDSC-3717: Fix shape searching cursor remaining if you cancel creating a shape

### DIFF
--- a/static/src/js/components/SpatialDisplay/SpatialDisplay.js
+++ b/static/src/js/components/SpatialDisplay/SpatialDisplay.js
@@ -274,6 +274,7 @@ const SpatialDisplay = ({
     setManuallyEnteringVal(false)
 
     onRemoveSpatialFilter()
+    eventEmitter.emit('map.drawCancel')
   }
 
   const onChangePointSearch = (event) => {

--- a/static/src/js/components/SpatialDisplay/__tests__/SpatialDisplay.test.js
+++ b/static/src/js/components/SpatialDisplay/__tests__/SpatialDisplay.test.js
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import '@testing-library/jest-dom'
+import * as EventEmitter from '../../../events/events'
 
 import SpatialDisplay from '../SpatialDisplay'
 
@@ -280,6 +281,7 @@ describe('SpatialDisplay component', () => {
 
   describe('#onSpatialRemove', () => {
     test('calls onRemoveSpatialFilter', async () => {
+      const eventEmitterEmitMock = jest.spyOn(EventEmitter.eventEmitter, 'emit')
       userEvent.setup()
 
       const { props } = setup({ pointSearch: [' '] })
@@ -293,6 +295,8 @@ describe('SpatialDisplay component', () => {
       await userEvent.click(actionBtn)
 
       expect(onRemoveSpatialFilter).toHaveBeenCalledTimes(1)
+      expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
+      expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.drawCancel')
     })
   })
 

--- a/static/src/js/components/SpatialSelection/SpatialSelection.js
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.js
@@ -404,6 +404,7 @@ const SpatialSelection = (props) => {
       drawControl.current._toolbars.draw._modes.marker.handler.disable()
       drawControl.current._toolbars.draw._modes.rectangle.handler.disable()
       drawControl.current._toolbars.draw._modes.circle.handler.disable()
+      drawControl.current._toolbars.draw._modes.polygon.handler.disable()
     }
   }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Minor update so that if a user does not commit to creating a `shapefile` and instead hits remove for rectangular and circular subsetting the cursor for creating the shapefile is not maintained

### What is the Solution?

Added an event emission so that the cursor is removed and the leaflet state is updated added referance to disable the polygon from the current toolbars, otherwise when the `eventEmitter.emit('map.drawCancel')` was called it was not removing it if the user had selected polygon subsetting and canceled

### What areas of the application does this impact?

Shapefile subsetting when canceling (really when using the remove button before having made a shapefile) for circles and rectangles

# Testing

Ensure that when you start trying to subset by rectangle or circle if you hit remove the cursor for the shapefile is no longer maintained

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
