### PR TITLE
EDSC-4044: Add granule download button to the disabledDownloadComponents

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.js
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.js
@@ -12,6 +12,8 @@ import { locationPropType } from '../../util/propTypes/location'
 import Button from '../Button/Button'
 import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLinkContainer'
 
+import { getApplicationConfig } from '../../../../../sharedUtils/config'
+
 export const GranuleDownloadButton = (props) => {
   const {
     badge,
@@ -26,6 +28,7 @@ export const GranuleDownloadButton = (props) => {
     onChangePath,
     tooManyGranules
   } = props
+  const { disableDatabaseComponents } = getApplicationConfig()
 
   if (tooManyGranules) {
     return (
@@ -129,7 +132,7 @@ export const GranuleDownloadButton = (props) => {
         bootstrapVariant="success"
         className="granule-results-actions__download-all-button"
         dataTestId="granule-results-actions__download-all-button"
-        disabled={granuleCount === 0 || initialLoading}
+        disabled={granuleCount === 0 || initialLoading || (disableDatabaseComponents === 'true')}
         icon={FaDownload}
         label={buttonText}
         variant="full"

--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.js
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.js
@@ -5,14 +5,14 @@ import { FaDownload } from 'react-icons/fa'
 import { parse } from 'qs'
 import { Tooltip, OverlayTrigger } from 'react-bootstrap'
 
+import { getApplicationConfig } from '../../../../../sharedUtils/config'
+
 import { commafy } from '../../util/commafy'
 import { stringify } from '../../util/url/url'
 import { locationPropType } from '../../util/propTypes/location'
 
 import Button from '../Button/Button'
 import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLinkContainer'
-
-import { getApplicationConfig } from '../../../../../sharedUtils/config'
 
 export const GranuleDownloadButton = (props) => {
   const {
@@ -28,6 +28,7 @@ export const GranuleDownloadButton = (props) => {
     onChangePath,
     tooManyGranules
   } = props
+
   const { disableDatabaseComponents } = getApplicationConfig()
 
   if (tooManyGranules) {

--- a/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
@@ -5,6 +5,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import GranuleDownloadButton from '../GranuleDownloadButton'
 import Button from '../../Button/Button'
 import PortalLinkContainer from '../../../containers/PortalLinkContainer/PortalLinkContainer'
+import * as getApplicationConfig from '../../../../../../sharedUtils/config'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -77,7 +78,7 @@ describe('GranuleDownloadButton component', () => {
   })
 
   describe('when the collection is not in the project', () => {
-    describe('when there are no other pg paramters in the URL', () => {
+    describe('when there are no other pg parameters in the URL', () => {
       test('clicking the button calls onAddProjectCollection and onChangePath', () => {
         const { enzymeWrapper, props } = setup()
 
@@ -96,7 +97,7 @@ describe('GranuleDownloadButton component', () => {
       })
     })
 
-    describe('when there are some pg paramters in the URL', () => {
+    describe('when there are some pg parameters in the URL', () => {
       test('clicking the button calls onAddProjectCollection and onChangePath', () => {
         const { enzymeWrapper, props } = setup({
           location: {
@@ -118,6 +119,26 @@ describe('GranuleDownloadButton component', () => {
         expect(props.onChangePath).toHaveBeenCalledTimes(1)
         expect(props.onChangePath).toHaveBeenCalledWith('/projects?p=collectionId!collectionId&pg[1][gsk]=start_date&pg[1][v]=t&ff=Map%20Imagery')
       })
+    })
+  })
+
+  describe('when the database components are disabled', () => {
+    test('the granule download button is disabled', () => {
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        disableDatabaseComponents: 'true'
+      }))
+
+      const { enzymeWrapper } = setup({
+        isCollectionInProject: true,
+        location: {
+          pathname: '/search/granules',
+          search: '?p=collectionId!collectionId&pg[1][gsk]=start_date&ff=Map%20Imagery'
+        }
+      })
+
+      const button = enzymeWrapper.find(Button)
+
+      expect(button.props().disabled).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

This adds the granule download button to the components that are disabled when the `disableDatabaseComponents` feature toggle is on

### What is the Solution?

Pull out the configuration value and disable the button if it is on

### What areas of the application does this impact?

Granule downloads when the feature toggle to disable the database components is on

# Testing

### Reproduction steps

Override the value in your static.json config for `disableDatabaseComponents` set it equal to the string value 'true' then try to do a granule download (make sure that it is being disabled by the fact that this feature toggle is on not because there are too many granules) so filter down to 1 or 2 granules. In SIT will need to redeploy EDSC with the bamboo variables set to true

### Attachments

![image](https://github.com/nasa/earthdata-search/assets/34591886/a7ab4161-ab0c-4796-8dde-b26a4db009cc)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
