### PR TITLE
EDSC-4048: added example to Granules IDs tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@edsc/geo-utils": "^1.0.4",
         "@edsc/smart-handoffs": "^1.0.5",
         "@edsc/timeline": "^1.1.7",
-        "@radix-ui/colors": "3.0.0",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "2.0.0",
         "@react-leaflet/core": "^2.1.0",
@@ -11135,11 +11134,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
-    },
-    "node_modules/@radix-ui/colors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
-      "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
@@ -46806,11 +46800,6 @@
       "version": "2.11.6",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
-    },
-    "@radix-ui/colors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
-      "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="
     },
     "@radix-ui/number": {
       "version": "1.0.1",

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
@@ -260,6 +260,11 @@ export const GranuleFiltersForm = (props) => {
                           <strong>Delimiters:</strong>
                           {' '}
                           Separate multiple granule IDs by commas.
+                          <br />
+                          <br />
+                          <strong>Example:</strong>
+                          {' '}
+                          SWOT_*_01?_26?_10*_*
                         </Tooltip>
                       )
                     }


### PR DESCRIPTION
# Overview

### What is the feature?

Adds an example to the Granule IDs search tooltip.
Also updated the package-lock.json (which was not updated on a previous unrelated commit and simply removes an unused dependency `radix_colors`)

### What is the Solution?

Straight forward example added.

### What areas of the application does this impact?

GranuleFiltersForm.js

# Testing

### Reproduction steps

- **Environment for testing:**prod
- **Collection to test with:**C2799438271-POCLOUD

1. go to [search.sit.earthdata.nasa.gov/search](https://search.sit.earthdata.nasa.gov/search)
2. Search for C2799438271-POCLOUD
3. try and search for granules using the example (SWOT_*_01?_26?_10*_*)
4. ensure it shows up in the tooltip when hovering over Granule ID(s)

### Attachments

<img width="353" alt="image" src="https://github.com/nasa/earthdata-search/assets/8591291/42da00cc-b9c9-404a-ba58-56e3f9d77715">
Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
