### PR TITLE
EDSC-4060: Allow authentication on the OBDAAC portal

### DIFF
--- a/portals/obdaac/config.json
+++ b/portals/obdaac/config.json
@@ -1,7 +1,6 @@
 {
   "features": {
     "advancedSearch": true,
-    "authentication": false,
     "featureFacets": {
       "showAvailableInEarthdataCloud": false,
       "showCustomizable": false,


### PR DESCRIPTION
# Overview

### What is the feature?

Ensure that OBDAAC portal users do have authentication enabled. It was decided that this was a desired change to the portal configuration

### What is the Solution?

authentication is no longer being set to false, instead we are going to use the default (true) value see https://wiki.earthdata.nasa.gov/display/EDSC/Portal+Creation+Guide 

### What areas of the application does this impact?

OBDAAC portal

# Testing

### Reproduction steps

Use the OBDAAC portal and ensure that you can log into EDSC and download multiple granules

### Attachments

![image](https://github.com/nasa/earthdata-search/assets/34591886/543938c1-80a6-4133-8b46-4cdbf65d6c54)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
