### PR TITLE
IDN-105: Change link on IDN Portal's icon

### DIFF
--- a/portals/idn/config.json
+++ b/portals/idn/config.json
@@ -1,5 +1,5 @@
 {
-  "moreInfoUrl": "https://idn.ceos.org/",
+  "moreInfoUrl": "https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/",
   "pageTitle": "IDN",
   "parentConfig": "edsc",
   "portalBrowser": true,

--- a/static/src/js/components/SearchSidebar/__tests__/SearchSidebarHeader.test.js
+++ b/static/src/js/components/SearchSidebar/__tests__/SearchSidebarHeader.test.js
@@ -117,7 +117,7 @@ describe('SearchSidebarHeader component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByTestId('portal-logo-link').href).toEqual('https://idn.ceos.org/')
+        expect(screen.getByTestId('portal-logo-link').href).toEqual('https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/')
       })
     })
   })

--- a/static/src/js/util/__tests__/portals.test.js
+++ b/static/src/js/util/__tests__/portals.test.js
@@ -57,7 +57,7 @@ describe('buildConfig', () => {
           href: 'https://access.earthdata.nasa.gov/'
         }]
       },
-      moreInfoUrl: 'https://idn.ceos.org/',
+      moreInfoUrl: 'https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/',
       pageTitle: 'IDN',
       portalBrowser: true,
       portalId: 'idn',


### PR DESCRIPTION


# Overview
Updated IDN Portal config.json

### What is the feature?
Update moreInfoUrl link value (logo link) in the config file.

### What is the Solution?

Changed moreInfoUrl link value (logo link) in the config file.
It was changed to the ceos.org IDN site: https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/

### What areas of the application does this impact?

It impact the logo in the EDSC's IDN Seach Portal and the More Info... link in the EDSC portal selection pop.

# Testing

### Reproduction steps

- Create a local EDSC in my local environment on my computer. 
- Clicked on the "Browse Portals"
- Clicked on the IDN Portal box's "More Info" link.
   -  Link goes to https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/
- Click on the IDN Portal box on the pop for "Browse Portals".
- Click on the CEOS logo image.
   -  Link goes to https://ceos.org/ourwork/workinggroups/wgiss/access/international-directory-network/

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
