### PR TITLE
EDSC-4053: Add SWORD info on advance filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@edsc/geo-utils": "^1.0.4",
         "@edsc/smart-handoffs": "^1.0.5",
         "@edsc/timeline": "^1.1.7",
-        "@radix-ui/colors": "3.0.0",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "2.0.0",
         "@react-leaflet/core": "^2.1.0",
@@ -11136,11 +11135,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@radix-ui/colors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
-      "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="
-    },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -18150,9 +18144,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001553",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
-      "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "funding": [
         {
           "type": "opencollective",
@@ -46807,11 +46801,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
-    "@radix-ui/colors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
-      "integrity": "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="
-    },
     "@radix-ui/number": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -52439,9 +52428,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001553",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
-      "integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A=="
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/static/src/js/components/AdvancedSearchModal/RegionSearchForm.js
+++ b/static/src/js/components/AdvancedSearchModal/RegionSearchForm.js
@@ -214,6 +214,26 @@ export class RegionSearchForm extends Component {
                       </EDSCAlert>
                     )
                   }
+                  {
+                    endpoint === 'rivers/reach' && (
+                      <EDSCAlert
+                        variant="small"
+                        bootstrapVariant="light"
+                        icon={FaQuestionCircle}
+                      >
+                        Find River Reach IDs in the SWOT River Database (SWORD):
+                        {' '}
+                        <a
+                          className="link--external"
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          href="https://www.swordexplorer.com/"
+                        >
+                          https://www.swordexplorer.com/
+                        </a>
+                      </EDSCAlert>
+                    )
+                  }
                 </Col>
               </Row>
             )

--- a/static/src/js/components/AdvancedSearchModal/__tests__/RegionSearchForm.test.js
+++ b/static/src/js/components/AdvancedSearchModal/__tests__/RegionSearchForm.test.js
@@ -111,6 +111,31 @@ describe('RegionSearchForm component', () => {
       expect(alertChildren.at(2).prop('href')).toEqual('https://water.usgs.gov/GIS/huc.html')
       expect(alertChildren.at(2).text()).toEqual('https://water.usgs.gov/GIS/huc.html')
     })
+
+    test('when the rivers/reach endpoint is selected', () => {
+      const { enzymeWrapper } = setup({
+        regionSearchForm: {
+          errors: {},
+          handleBlur: jest.fn(),
+          handleChange: jest.fn(),
+          handleSubmit: jest.fn(),
+          touched: {},
+          values: {
+            endpoint: 'rivers/reach'
+          },
+          validateForm: jest.fn(),
+          isValid: false
+        },
+        selectedRegion: {},
+        onRemoveSelected: jest.fn()
+      })
+
+      const alertChildren = enzymeWrapper.find(EDSCAlert).children()
+
+      expect(alertChildren.at(0).text()).toEqual('Find River Reach IDs in the SWOT River Database (SWORD):')
+      expect(alertChildren.at(2).prop('href')).toEqual('https://www.swordexplorer.com/')
+      expect(alertChildren.at(2).text()).toEqual('https://www.swordexplorer.com/')
+    })
   })
 
   describe('when keyword input is invalid', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

Add information for SWORD on advance search.

### What is the Solution?

Added an alert box with the information.

### What areas of the application does this impact?

- Advanced search

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** None

1. Select the advanced search filter
2. select river reach
3. Observe the information is displayed

### Attachments

![image](https://github.com/nasa/earthdata-search/assets/34591886/e9d1d195-7a7c-4836-affa-2f8be98e5ed4)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
