### PR TITLE
EDSC-3865: Updating wording for unconverted data output formats

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -952,7 +952,7 @@ export class AccessMethod extends Component {
                       >
                         {
                           [
-                            <option key="output-format-none" value="">No data conversion</option>,
+                            <option key="output-format-none" value="">No Data Conversion</option>,
                             ...supportedOutputFormatOptions
                           ]
                         }

--- a/static/src/js/components/AccessMethod/AccessMethod.js
+++ b/static/src/js/components/AccessMethod/AccessMethod.js
@@ -952,7 +952,7 @@ export class AccessMethod extends Component {
                       >
                         {
                           [
-                            <option key="output-format-none" value="">None</option>,
+                            <option key="output-format-none" value="">No data conversion</option>,
                             ...supportedOutputFormatOptions
                           ]
                         }

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -394,7 +394,7 @@ describe('AccessMethod component', () => {
         selectedAccessMethod: 'opendap'
       })
 
-      expect(screen.getByRole('option', { name: 'No data conversion' }).selected).toBe(true)
+      expect(screen.getByRole('option', { name: 'No Data Conversion' }).selected).toBe(true)
       expect(screen.getByTestId('access-methods__output-format-options').value).toBe('')
 
       await user.selectOptions(

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -377,7 +377,7 @@ describe('AccessMethod component', () => {
   })
 
   describe('when the selected access method is opendap', () => {
-    test('selecting a output format calls onUpdateAccessMethod', async () => {
+    test.only('selecting a output format calls onUpdateAccessMethod', async () => {
       const user = userEvent.setup()
       const collectionId = 'collectionId'
       const { onUpdateAccessMethod } = setup({
@@ -394,11 +394,15 @@ describe('AccessMethod component', () => {
         selectedAccessMethod: 'opendap'
       })
 
+      expect(screen.getByRole('option', { name: 'No data conversion' }).selected).toBe(true)
+      expect(screen.getByTestId('access-methods__output-format-options').value).toBe('')
+
       await user.selectOptions(
         screen.getByTestId('access-methods__output-format-options'),
         screen.getByRole('option', { name: 'NETCDF-4' })
       )
 
+      expect(screen.getByTestId('access-methods__output-format-options').value).toBe('nc4')
       expect(screen.getByRole('option', { name: 'NETCDF-4' }).selected).toBe(true)
       expect(onUpdateAccessMethod).toHaveBeenCalledTimes(1)
       expect(onUpdateAccessMethod).toHaveBeenCalledWith({


### PR DESCRIPTION
# Overview

### What is the feature?

Updating wording in the Output Format section of on Data Download options in EDS when a user uses a data customization service to improve clarity to the user.


### What is the Solution?

Dropdown language has been be updated from "None" to "No Data Conversion"

### What areas of the application does this impact?

Access Methods page

# Testing

### Reproduction steps

- **Environment for testing:** Prod
- **Collection to test with:** C1692982090-GES_DISC

1. Search for `C1692982090-GES_DISC` on EDSC
2. Add the collection (or a few granules) to your project
3. Navigate to project page
4. Select Edit Options
5. Select `Customize with Harmony`, select a service, and scroll down to `Output Format`
6. Verify that `No Data Conversion` is listed as the first dropdown item rather than `None`


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
