### PR TITLE
EDSC-4084: Fix accessibility of the Redis Cache

### DIFF
--- a/serverless-configs/aws-infrastructure-resources.yml
+++ b/serverless-configs/aws-infrastructure-resources.yml
@@ -141,16 +141,18 @@ Resources:
                   - states:*
                 Resource: '*'
 
-  # Redis Cache for browse-scaler
+  # Redis Cache for browse-scaler/image-resizing
+  # The CIDR notation 0.0. 0.0/0 defines an IP block containing all possible IP addresses
   RedisSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Ingress for Redis Cluster
-      VpcId: ${env:VPC_ID}
       SecurityGroupIngress:
-      - IpProtocol: tcp
+      - CidrIp: '0.0.0.0/0'
+        IpProtocol: tcp
         FromPort: 1521
         ToPort: 1521
+      VpcId: ${env:VPC_ID}
 
   RedisCacheSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup
@@ -179,7 +181,7 @@ Resources:
       ClusterName: browse-scaler-${self:provider.stage}
       CacheNodeType: cache.t2.medium
       NumCacheNodes: 1
-      # In transit encryption is not currenlty supported with the REDIS engine.
+      # In transit encryption is not currently supported with the REDIS engine.
       # TransitEncryptionEnabled: true
       CacheParameterGroupName:
         Ref: RedisParameterGroup
@@ -226,3 +228,19 @@ Outputs:
         - Endpoint.Port
     Export:
       Name: ${self:provider.stage}-EncryptedDatabasePort
+
+  ElastiCacheEndpoint:
+    Value:
+      Fn::GetAtt:
+        - RedisElasticCacheCluster
+        - RedisEndpoint.Address
+    Export:
+      Name: ${self:provider.stage}-ElastiCacheEndpoint
+
+  ElastiCachePort:
+    Value:
+      Fn::GetAtt:
+        - RedisElasticCacheCluster
+        - RedisEndpoint.Port
+    Export:
+      Name: ${self:provider.stage}-ElastiCachePort

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,7 @@ provider:
     obfuscationSpinShapefiles: ${self:custom.variables.obfuscationSpinShapefiles}
 
     orderDelaySeconds: ${self:custom.variables.orderDelaySeconds}
+    useCache: ${self:custom.variables.useCache}
 
     configSecretId:
       Fn::ImportValue: ${self:provider.stage}-DbPasswordSecret
@@ -42,6 +43,13 @@ provider:
     collectionCapabilitiesLambda: ${self:custom.siteName}-generateCollectionCapabilityTags
 
     NODE_OPTIONS: '--enable-source-maps'
+
+    # Redis cache configuration
+    cacheHost:
+      Fn::ImportValue: ${self:provider.stage}-ElastiCacheEndpoint
+    cachePort:
+      Fn::ImportValue: ${self:provider.stage}-ElastiCachePort
+    cacheKeyExpireSeconds: ${self:custom.variables.cacheKeyExpireSeconds}
 
   vpc:
     securityGroupIds:
@@ -107,6 +115,8 @@ custom:
       Exclude:
         - provider.environment.databaseEndpoint
         - provider.environment.databasePort
+        - provider.environment.cacheHost
+        - provider.environment.cachePort
         - provider.environment.colorMapQueueUrl
         - provider.environment.tagQueueUrl
         - provider.environment.cmrOrderingOrderQueueUrl
@@ -122,9 +132,11 @@ custom:
 
   variables:
     # Default values for environment variables used to set environment variables
+    cacheKeyExpireSeconds: ${env:CACHE_KEY_EXPIRE_SECONDS, '84000'}
     obfuscationSpin: ${env:OBFUSCATION_SPIN, ''}
     obfuscationSpinShapefiles: ${env:OBFUSCATION_SPIN_SHAPEFILES, ''}
     orderDelaySeconds: ${env:ORDER_DELAY_SECONDS, '1'}
+    useCache: ${env:USE_CACHE, 'false'}
 
     cloudfrontToCloudwatchBucketPrefixApi:
       Fn::Join:


### PR DESCRIPTION
# Overview

### What is the feature?

Fix the security rule for the elasti-cache instance so that it is accessible group from EC2 instance and from lambda add exported variables which can be accessed by lambdas

### What is the Solution?

The current setting for the redis-cache instance was not making it possible to connect to it via EC2 instance or lambdas. This is being used for the image rescaling lambda that will deprecate browse-scaler

### What areas of the application does this impact?

Configuration for redis cache, adds variables accessible to lambdas for references to the cache 

# Testing

Log into AWS or connect to it locally. connect to the EC2 instance and ensure that using `redis-cli6 ` can connect to the cache to view or del a key in SIT

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
