### PR TITLE
EDSC-2673: Lazy load Leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The production build of the application will be output in the `/static/dist/` di
 
     npm run build
 
+This production build can be run locally with any number of http-server solution. A simple one is to use the http-server package
+
+    npx http-server static/dist
+
 ### Run the Application Locally
 
 The local development environment for the static assets can be started by executing the command below in the project root directory:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The production build of the application will be output in the `/static/dist/` di
 
     npm run build
 
-This production build can be run locally with any number of http-server solution. A simple one is to use the http-server package
+This production build can be run locally with any number of http-server solutions. A simple one is to use the http-server package
 
     npx http-server static/dist
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ npm is a separate project from Node.js, and tends to update more frequently. As 
 
 ##### NVM
 
-To ensure that you're using the correct version of Node it is recommended that you use Node Version Manager. Installation instructions can be found on [the repository](https://github.com/nvm-sh/nvm#install--update-script). The version used is defined in .nvmrc and will be used automatically if NVM is configured correctly.
+To ensure that you're using the correct version of Node it is recommended that you use Node Version Manager. Installation instructions can be found on [the repository](https://github.com/nvm-sh/nvm#install--update-script). The version used is defined in .nvmrc and will be used automatically if NVM is configured correctly. Using nvm we can switch node versions to the one utilized on Earthdata Search. From the top-level directory:
+
+    nvm use
 
 ##### Serverless Framework
 

--- a/cypress/e2e/panels/panels_behavior.cy.js
+++ b/cypress/e2e/panels/panels_behavior.cy.js
@@ -98,6 +98,6 @@ describe('Panel Behavior', () => {
   it('drags the panel to maximum width', () => {
     dragPanelToX(1500)
 
-    getByTestId('panels-section').should('have.css', 'width', '1035px')
+    getByTestId('panels-section').should('have.css', 'width', '1000px')
   })
 })

--- a/cypress/e2e/panels/panels_behavior.cy.js
+++ b/cypress/e2e/panels/panels_behavior.cy.js
@@ -98,6 +98,6 @@ describe('Panel Behavior', () => {
   it('drags the panel to maximum width', () => {
     dragPanelToX(1500)
 
-    getByTestId('panels-section').should('have.css', 'width', '1000px')
+    getByTestId('panels-section').should('have.css', 'width', '1035px')
   })
 })

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -51,6 +51,16 @@
     .route-wrapper--content-page-centered & {
       justify-content: center;
     }
+
+  }
+  // TODO this should just be an extension of __content
+  &__content--map {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    justify-content: space-between;
+    flex-direction: column;
+    background-color: $color__black;
   }
 
   &__content-nav {

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -10,16 +10,32 @@
   align-items: flex-end;
   background-color: #f3f3f3;
   background-image: linear-gradient(#f3f3f3, #f5f5f5);
+  // &__evil {
+  //   background: $color__black;
+  // }
+
+  &--evil {
+    background: $color__black;
+  }
 
   &__header {
     background-color: $color__black--800;
     color: $color__black--400;
     border-bottom: 1px solid $color__black--700;
 
+
+    // .route-wrapper--evil & {
+    //   background: $color__black;
+    // }
+
     .route-wrapper--light & {
       border-bottom: 1px solid $color__black--200;
     }
   }
+
+  // &__map--black {
+  //   background-color: $color__black;
+  // }
 
   &__header-primary {
     display: flex;
@@ -50,6 +66,10 @@
 
     .route-wrapper--content-page-centered & {
       justify-content: center;
+    }
+
+    &--evil {
+      background: $color__black;
     }
 
   }

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -16,7 +16,6 @@
     color: $color__black--400;
     border-bottom: 1px solid $color__black--700;
 
-
     .route-wrapper--light & {
       border-bottom: 1px solid $color__black--200;
     }

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -53,7 +53,7 @@
       justify-content: center;
     }
 
-    &--evil {
+    &--dark {
       background: $color__black;
     }
 

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -53,7 +53,7 @@
     }
 
   }
-  // TODO this should just be an extension of __content
+  // TODO this should probably just be an extension of __content color is the only diff
   &__content--map {
     display: flex;
     width: 100%;

--- a/static/src/css/_layout.scss
+++ b/static/src/css/_layout.scss
@@ -10,13 +10,6 @@
   align-items: flex-end;
   background-color: #f3f3f3;
   background-image: linear-gradient(#f3f3f3, #f5f5f5);
-  // &__evil {
-  //   background: $color__black;
-  // }
-
-  &--evil {
-    background: $color__black;
-  }
 
   &__header {
     background-color: $color__black--800;
@@ -24,18 +17,10 @@
     border-bottom: 1px solid $color__black--700;
 
 
-    // .route-wrapper--evil & {
-    //   background: $color__black;
-    // }
-
     .route-wrapper--light & {
       border-bottom: 1px solid $color__black--200;
     }
   }
-
-  // &__map--black {
-  //   background-color: $color__black;
-  // }
 
   &__header-primary {
     display: flex;
@@ -73,15 +58,6 @@
     }
 
   }
-  // TODO this should probably just be an extension of __content color is the only diff
-  &__content--map {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    justify-content: space-between;
-    flex-direction: column;
-    background-color: $color__black;
-  }
 
   &__content-nav {
     padding: $spacer/2 $spacer;
@@ -107,6 +83,10 @@
 
   &--light {
     background: white;
+  }
+
+  &--dark {
+    background: $color__black;
   }
 
   &__page-heading {

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -23,7 +23,6 @@ import Admin from './routes/Admin/Admin'
 import ContactInfo from './routes/ContactInfo/ContactInfo'
 import Downloads from './routes/Downloads/Downloads'
 import EarthdataDownloadRedirect from './routes/EarthdataDownloadRedirect/EarthdataDownloadRedirect'
-import FooterContainer from './containers/FooterContainer/FooterContainer'
 import Preferences from './routes/Preferences/Preferences'
 import Project from './routes/Project/Project'
 import Search from './routes/Search/Search'
@@ -41,6 +40,7 @@ import DeprecatedParameterModalContainer from './containers/DeprecatedParameterM
 import EditSubscriptionModalContainer from './containers/EditSubscriptionModalContainer/EditSubscriptionModalContainer'
 import ErrorBannerContainer from './containers/ErrorBannerContainer/ErrorBannerContainer'
 import ErrorBoundary from './components/Errors/ErrorBoundary'
+import FooterContainer from './containers/FooterContainer/FooterContainer'
 import HistoryContainer from './containers/HistoryContainer/HistoryContainer'
 import KeyboardShortcutsModalContainer from './containers/KeyboardShortcutsModalContainer/KeyboardShortcutsModalContainer'
 import MetricsEventsContainer from './containers/MetricsEventsContainer/MetricsEventsContainer'
@@ -192,8 +192,6 @@ class App extends Component {
                     <Redirect exact from="/portal/:portalId/" to="/portal/:portalId/search" />
                     <Redirect exact from="/" to="/search" />
                     <Route
-                      // TODO not relevant to PR but, I want to understand why the Search component has to be loaded first
-                      // EVEN without the lazy loading
                       path={this.portalPaths('/search')}
                       render={
                         () => (

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -18,6 +18,7 @@ import configureStore from './store/configureStore'
 import history from './util/history'
 import { getApplicationConfig, getEnvironmentConfig } from '../../../sharedUtils/config'
 
+// Routes
 import Admin from './routes/Admin/Admin'
 import ContactInfo from './routes/ContactInfo/ContactInfo'
 import Downloads from './routes/Downloads/Downloads'
@@ -28,6 +29,7 @@ import Project from './routes/Project/Project'
 import Search from './routes/Search/Search'
 import Subscriptions from './routes/Subscriptions/Subscriptions'
 
+// Components and Containers
 import AboutCSDAModalContainer from './containers/AboutCSDAModalContainer/AboutCSDAModalContainer'
 import AboutCwicModalContainer from './containers/AboutCwicModalContainer/AboutCwicModalContainer'
 import AppHeader from './components/AppHeader/AppHeader'
@@ -36,19 +38,19 @@ import AuthRequiredContainer from './containers/AuthRequiredContainer/AuthRequir
 import AuthTokenContainer from './containers/AuthTokenContainer/AuthTokenContainer'
 import ChunkedOrderModalContainer from './containers/ChunkedOrderModalContainer/ChunkedOrderModalContainer'
 import DeprecatedParameterModalContainer from './containers/DeprecatedParameterModalContainer/DeprecatedParameterModalContainer'
+import EditSubscriptionModalContainer from './containers/EditSubscriptionModalContainer/EditSubscriptionModalContainer'
 import ErrorBannerContainer from './containers/ErrorBannerContainer/ErrorBannerContainer'
 import ErrorBoundary from './components/Errors/ErrorBoundary'
+import HistoryContainer from './containers/HistoryContainer/HistoryContainer'
 import KeyboardShortcutsModalContainer from './containers/KeyboardShortcutsModalContainer/KeyboardShortcutsModalContainer'
 import MetricsEventsContainer from './containers/MetricsEventsContainer/MetricsEventsContainer'
 import NotFound from './components/Errors/NotFound'
 import PortalContainer from './containers/PortalContainer/PortalContainer'
 import ShapefileDropzoneContainer from './containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer'
 import ShapefileUploadModalContainer from './containers/ShapefileUploadModalContainer/ShapefileUploadModalContainer'
+import Spinner from './components/Spinner/Spinner'
 import TooManyPointsModalContainer from './containers/TooManyPointsModalContainer/TooManyPointsModalContainer'
 import UrlQueryContainer from './containers/UrlQueryContainer/UrlQueryContainer'
-import EditSubscriptionModalContainer from './containers/EditSubscriptionModalContainer/EditSubscriptionModalContainer'
-import HistoryContainer from './containers/HistoryContainer/HistoryContainer'
-
 // Required for toast notification system
 window.reactToastProvider = React.createRef()
 
@@ -63,6 +65,7 @@ window.reactToastProvider = React.createRef()
 // }
 
 const EdscMapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
+
 // Create the root App component
 class App extends Component {
   constructor(props) {
@@ -180,13 +183,17 @@ class App extends Component {
                     <Redirect exact from="/portal/:portalId/" to="/portal/:portalId/search" />
                     <Redirect exact from="/" to="/search" />
                     <Route
+                      // TODO not relevant to PR but, I want to understand why the Search component has to be loaded first
+                      // EVEN without the lazy loading
                       path={this.portalPaths('/search')}
                       render={
                         () => (
-                          <Suspense fallback={<div />}>
+                          <>
                             <Search />
-                            <EdscMapContainer />
-                          </Suspense>
+                            <Suspense fallback={<Spinner type="dots" />}>
+                              <EdscMapContainer />
+                            </Suspense>
+                          </>
                         )
                       }
                     />

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -190,7 +190,7 @@ class App extends Component {
                         () => (
                           <>
                             <Search />
-                            <Suspense fallback={<Spinner type="dots" />}>
+                            <Suspense fallback={<Spinner type="dots" className="root__spinner spinner spinner--dots spinner--white spinner--small" />}>
                               <EdscMapContainer />
                             </Suspense>
                           </>

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -64,7 +64,7 @@ window.reactToastProvider = React.createRef()
 //   whyDidYouUpdate(React, { include: [/Search/] })
 // }
 
-const EdscMapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
+const MapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
 
 // Create the root App component
 class App extends Component {
@@ -191,7 +191,7 @@ class App extends Component {
                           <>
                             <Search />
                             <Suspense fallback={<Spinner type="dots" />}>
-                              <EdscMapContainer />
+                              <MapContainer />
                             </Suspense>
                           </>
                         )

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -64,7 +64,7 @@ window.reactToastProvider = React.createRef()
 //   whyDidYouUpdate(React, { include: [/Search/] })
 // }
 
-const MapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
+const EdscMapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
 
 // Create the root App component
 class App extends Component {
@@ -191,7 +191,7 @@ class App extends Component {
                           <>
                             <Search />
                             <Suspense fallback={<Spinner type="dots" />}>
-                              <MapContainer />
+                              <EdscMapContainer />
                             </Suspense>
                           </>
                         )

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -179,7 +179,16 @@ class App extends Component {
                         )
                       }
                     />
-                    <Route path={this.portalPaths('/projects')} component={Project} />
+                    <Route
+                      path={this.portalPaths('/projects')}
+                      render={
+                        () => (
+                          <AuthRequiredContainer>
+                            <Project />
+                          </AuthRequiredContainer>
+                        )
+                      }
+                    />
                     <Redirect exact from="/portal/:portalId/" to="/portal/:portalId/search" />
                     <Redirect exact from="/" to="/search" />
                     <Route

--- a/static/src/js/App.js
+++ b/static/src/js/App.js
@@ -1,4 +1,8 @@
-import React, { Component } from 'react'
+import React, {
+  Component,
+  lazy,
+  Suspense
+} from 'react'
 import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'connected-react-router'
 import {
@@ -32,7 +36,6 @@ import AuthRequiredContainer from './containers/AuthRequiredContainer/AuthRequir
 import AuthTokenContainer from './containers/AuthTokenContainer/AuthTokenContainer'
 import ChunkedOrderModalContainer from './containers/ChunkedOrderModalContainer/ChunkedOrderModalContainer'
 import DeprecatedParameterModalContainer from './containers/DeprecatedParameterModalContainer/DeprecatedParameterModalContainer'
-import EdscMapContainer from './containers/MapContainer/MapContainer'
 import ErrorBannerContainer from './containers/ErrorBannerContainer/ErrorBannerContainer'
 import ErrorBoundary from './components/Errors/ErrorBoundary'
 import KeyboardShortcutsModalContainer from './containers/KeyboardShortcutsModalContainer/KeyboardShortcutsModalContainer'
@@ -59,6 +62,7 @@ window.reactToastProvider = React.createRef()
 //   whyDidYouUpdate(React, { include: [/Search/] })
 // }
 
+const EdscMapContainer = lazy(() => import('./containers/MapContainer/MapContainer'))
 // Create the root App component
 class App extends Component {
   constructor(props) {
@@ -179,10 +183,10 @@ class App extends Component {
                       path={this.portalPaths('/search')}
                       render={
                         () => (
-                          <>
+                          <Suspense fallback={<div />}>
                             <Search />
                             <EdscMapContainer />
-                          </>
+                          </Suspense>
                         )
                       }
                     />

--- a/static/src/js/__tests__/App.test.js
+++ b/static/src/js/__tests__/App.test.js
@@ -229,17 +229,6 @@ describe('App component', () => {
     await waitFor(() => expect(document.title).toEqual('Earthdata Search'))
   })
 
-  // TODO this is just a prop being passed in Helmet its not rendered on DOM so I think that we should remove it for RTL test
-  test.skip('sets the correct title template', async () => {
-    setup()
-    await waitFor(() => {
-      const metaElement = document.querySelector('x[name="description"]')
-
-      expect(metaElement).toBeInTheDocument()
-      expect(metaElement).toHaveAttribute('content', 'Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
-    })
-  })
-
   test('sets the correct meta description', async () => {
     setup()
     await waitFor(() => {

--- a/static/src/js/__tests__/App.test.js
+++ b/static/src/js/__tests__/App.test.js
@@ -180,7 +180,7 @@ jest.mock('../containers/HistoryContainer/HistoryContainer', () => {
   return MockedHistoryContainer
 })
 
-// Don't mock `UrlQueryContainer` its children which contain all the routes
+// Only mock `UrlQueryContainer` not its children which are the routes
 jest.mock('../containers/UrlQueryContainer/UrlQueryContainer', () => (
   jest.fn(({ children }) => (
     <mock-UrlQueryContainer data-testid="UrlQueryContainer">

--- a/static/src/js/__tests__/App.test.js
+++ b/static/src/js/__tests__/App.test.js
@@ -189,6 +189,12 @@ jest.mock('../containers/UrlQueryContainer/UrlQueryContainer', () => (
   ))
 ))
 
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(AppConfig, 'getApplicationConfig').mockImplementation(() => ({ env: 'dev' }))
+  jest.spyOn(AppConfig, 'getEnvironmentConfig').mockImplementation(() => ({ edscHost: 'https://search.earthdata.nasa.gov' }))
+})
+
 const setup = () => {
   nock(/cmr/)
     .post(/collections/)
@@ -216,12 +222,6 @@ const setup = () => {
     props
   }
 }
-
-beforeEach(() => {
-  jest.clearAllMocks()
-  jest.spyOn(AppConfig, 'getApplicationConfig').mockImplementation(() => ({ env: 'dev' }))
-  jest.spyOn(AppConfig, 'getEnvironmentConfig').mockImplementation(() => ({ edscHost: 'https://search.earthdata.nasa.gov' }))
-})
 
 describe('App component', () => {
   test('sets the correct default title', async () => {

--- a/static/src/js/__tests__/App.test.js
+++ b/static/src/js/__tests__/App.test.js
@@ -1,8 +1,12 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import nock from 'nock'
-import Helmet from 'react-helmet'
+
+import {
+  render,
+  waitFor,
+  screen
+} from '@testing-library/react'
+import '@testing-library/jest-dom'
 
 import * as AppConfig from '../../../../sharedUtils/config'
 import App from '../App'
@@ -13,9 +17,179 @@ jest.mock('react-leaflet', () => ({
   createControlComponent: jest.fn().mockImplementation(() => {})
 }))
 
-Enzyme.configure({ adapter: new Adapter() })
+// Mock App components routes and containers
+jest.mock('../routes/Admin/Admin', () => () => {
+  const MockedAdmin = () => <div data-testid="mocked-admin" />
 
-function setup() {
+  return MockedAdmin
+})
+
+jest.mock('../routes/ContactInfo/ContactInfo', () => {
+  const MockedContactInfo = () => <div data-testid="mocked-contact-info" />
+
+  return MockedContactInfo
+})
+
+jest.mock('../routes/Downloads/Downloads', () => {
+  const MockedDownloads = () => <div data-testid="mocked-downloads" />
+
+  return MockedDownloads
+})
+
+jest.mock('../routes/EarthdataDownloadRedirect/EarthdataDownloadRedirect', () => {
+  const MockedEarthdataDownloadRedirect = () => <div data-testid="mocked-earthdata-download-redirect" />
+
+  return MockedEarthdataDownloadRedirect
+})
+
+jest.mock('../containers/FooterContainer/FooterContainer', () => {
+  const MockedFooterContainer = () => <div data-testid="mocked-footer-container" />
+
+  return MockedFooterContainer
+})
+
+jest.mock('../routes/Preferences/Preferences', () => {
+  const MockedPreferences = () => <div data-testid="mocked-preferences" />
+
+  return MockedPreferences
+})
+
+jest.mock('../routes/Project/Project', () => {
+  const MockedProject = () => <div data-testid="mocked-project" />
+
+  return MockedProject
+})
+
+jest.mock('../routes/Search/Search', () => {
+  const MockedSearch = () => <div data-testid="mocked-search" />
+
+  return MockedSearch
+})
+
+jest.mock('../routes/Subscriptions/Subscriptions', () => {
+  const MockedSubscriptions = () => <div data-testid="mocked-subscriptions" />
+
+  return MockedSubscriptions
+})
+
+jest.mock('../containers/AboutCSDAModalContainer/AboutCSDAModalContainer', () => {
+  const MockedAboutCSDAModalContainer = () => <div data-testid="mocked-about-csda-modal-container" />
+
+  return MockedAboutCSDAModalContainer
+})
+
+jest.mock('../containers/AboutCwicModalContainer/AboutCwicModalContainer', () => {
+  const MockedAboutCwicModalContainer = () => <div data-testid="mocked-about-cwic-modal-container" />
+
+  return MockedAboutCwicModalContainer
+})
+
+jest.mock('../components/AppHeader/AppHeader', () => {
+  const MockedAppHeader = () => <div data-testid="mocked-app-header" />
+
+  return MockedAppHeader
+})
+
+jest.mock('../containers/AuthCallbackContainer/AuthCallbackContainer', () => {
+  const MockedAuthCallbackContainer = () => <div data-testid="mocked-auth-callback-container" />
+
+  return MockedAuthCallbackContainer
+})
+
+jest.mock('../containers/AuthRequiredContainer/AuthRequiredContainer', () => {
+  const MockedAuthRequiredContainer = () => <div data-testid="mocked-auth-required-container" />
+
+  return MockedAuthRequiredContainer
+})
+
+jest.mock('../containers/ChunkedOrderModalContainer/ChunkedOrderModalContainer', () => {
+  const MockedChunkedOrderModalContainer = () => <div data-testid="mocked-chunked-order-modal-container" />
+
+  return MockedChunkedOrderModalContainer
+})
+
+jest.mock('../containers/DeprecatedParameterModalContainer/DeprecatedParameterModalContainer', () => {
+  const MockedDeprecatedParameterModalContainer = () => <div data-testid="mocked-deprecated-parameter-modal-container" />
+
+  return MockedDeprecatedParameterModalContainer
+})
+
+jest.mock('../containers/ErrorBannerContainer/ErrorBannerContainer', () => {
+  const MockedErrorBannerContainer = () => <div data-testid="mocked-error-banner-container" />
+
+  return MockedErrorBannerContainer
+})
+
+jest.mock('../containers/KeyboardShortcutsModalContainer/KeyboardShortcutsModalContainer', () => {
+  const MockedKeyboardShortcutsModalContainer = () => <div data-testid="mocked-keyboard-shortcuts-modal-container" />
+
+  return MockedKeyboardShortcutsModalContainer
+})
+
+jest.mock('../containers/MapContainer/MapContainer', () => {
+  const MockedMapContainer = () => <div data-testid="mocked-map-container" />
+
+  return MockedMapContainer
+})
+
+jest.mock('../containers/MetricsEventsContainer/MetricsEventsContainer', () => {
+  const MockedMetricsEventsContainer = () => <div data-testid="mocked-metrics-events-container" />
+
+  return MockedMetricsEventsContainer
+})
+
+jest.mock('../components/Errors/NotFound', () => {
+  const MockedNotFound = () => <div data-testid="mocked-not-found" />
+
+  return MockedNotFound
+})
+
+jest.mock('../containers/PortalContainer/PortalContainer', () => {
+  const MockedPortalContainer = () => <div data-testid="mocked-portal-container" />
+
+  return MockedPortalContainer
+})
+
+jest.mock('../containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer', () => {
+  const MockedShapefileDropzoneContainer = () => <div data-testid="mocked-shapefile-dropzone-container" />
+
+  return MockedShapefileDropzoneContainer
+})
+
+jest.mock('../containers/ShapefileUploadModalContainer/ShapefileUploadModalContainer', () => {
+  const MockedShapefileUploadModalContainer = () => <div data-testid="mocked-shapefile-upload-modal-container" />
+
+  return MockedShapefileUploadModalContainer
+})
+
+jest.mock('../containers/TooManyPointsModalContainer/TooManyPointsModalContainer', () => {
+  const MockedTooManyPointsModalContainer = () => <div data-testid="mocked-too-many-points-modal-container" />
+
+  return MockedTooManyPointsModalContainer
+})
+
+jest.mock('../containers/EditSubscriptionModalContainer/EditSubscriptionModalContainer', () => {
+  const MockedEditSubscriptionModalContainer = () => <div data-testid="mocked-edit-subscription-modal-container" />
+
+  return MockedEditSubscriptionModalContainer
+})
+
+jest.mock('../containers/HistoryContainer/HistoryContainer', () => {
+  const MockedHistoryContainer = () => <div data-testid="mocked-history-container" />
+
+  return MockedHistoryContainer
+})
+
+// Don't mock `UrlQueryContainer` its children which contain all the routes
+jest.mock('../containers/UrlQueryContainer/UrlQueryContainer', () => (
+  jest.fn(({ children }) => (
+    <mock-UrlQueryContainer data-testid="UrlQueryContainer">
+      {children}
+    </mock-UrlQueryContainer>
+  ))
+))
+
+const setup = () => {
   nock(/cmr/)
     .post(/collections/)
     .reply(200, {
@@ -36,10 +210,9 @@ function setup() {
 
   const props = {}
 
-  const enzymeWrapper = shallow(<App {...props} />)
+  render(<App {...props} />)
 
   return {
-    enzymeWrapper,
     props
   }
 }
@@ -51,71 +224,104 @@ beforeEach(() => {
 })
 
 describe('App component', () => {
-  test('sets the correct default title', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.props().defaultTitle).toEqual('Earthdata Search')
+  test('sets the correct default title', async () => {
+    setup()
+    await waitFor(() => expect(document.title).toEqual('Earthdata Search'))
   })
 
-  test('sets the correct title template', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.props().titleTemplate).toEqual('[DEV] %s | Earthdata Search')
+  // TODO this is just a prop being passed in Helmet its not rendered on DOM so I think that we should remove it for RTL test
+  test.skip('sets the correct title template', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('x[name="description"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
+    })
   })
 
-  test('sets the correct meta description', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(0).props().name).toEqual('description')
-    expect(helmet.childAt(0).props().content).toEqual('Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
+  test('sets the correct meta description', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[name="description"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
+    })
   })
 
-  test('sets the correct meta og:type', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(1).props().property).toEqual('og:type')
-    expect(helmet.childAt(1).props().content).toEqual('website')
+  test('sets the correct meta og:type', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[property="og:type"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'website')
+    })
   })
 
-  test('sets the correct meta og:title', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(2).props().property).toEqual('og:title')
-    expect(helmet.childAt(2).props().content).toEqual('Earthdata Search')
+  test('sets the correct meta og:title', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[property="og:title"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'Earthdata Search')
+    })
   })
 
-  test('sets the correct meta og:description', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(3).props().property).toEqual('og:description')
-    expect(helmet.childAt(3).props().content).toEqual('Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
+  test('sets the correct meta og:description', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[property="og:description"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'Search, discover, visualize, refine, and access NASA Earth Observation data in your browser with Earthdata Search')
+    })
   })
 
-  test('sets the correct meta og:url', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(4).props().property).toEqual('og:url')
-    expect(helmet.childAt(4).props().content).toEqual('https://search.earthdata.nasa.gov/search')
+  test('sets the correct meta og:url', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[property="og:url"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', 'https://search.earthdata.nasa.gov/search')
+    })
   })
 
-  test('sets the correct meta og:image', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(5).props().property).toEqual('og:image')
-    expect(helmet.childAt(5).props().content).toEqual('test-file-stub')
+  test('sets the correct meta og:image', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[property="og:image"]')
+
+      expect(metaElement).toHaveAttribute('content', 'test-file-stub')
+    })
   })
 
-  test('sets the correct meta theme-color', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(6).props().name).toEqual('theme-color')
-    expect(helmet.childAt(6).props().content).toEqual('#191a1b')
+  test('sets the correct meta theme-color', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('meta[name="theme-color"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('content', '#191a1b')
+    })
   })
 
-  test('sets the correct meta canonical url', () => {
-    const { enzymeWrapper } = setup()
-    const helmet = enzymeWrapper.find(Helmet)
-    expect(helmet.childAt(7).props().rel).toEqual('canonical')
-    expect(helmet.childAt(7).props().href).toEqual('https://search.earthdata.nasa.gov/search')
+  test('sets the correct meta canonical url', async () => {
+    setup()
+    await waitFor(() => {
+      const metaElement = document.querySelector('link[rel="canonical"]')
+
+      expect(metaElement).toBeInTheDocument()
+      expect(metaElement).toHaveAttribute('href', 'https://search.earthdata.nasa.gov/search')
+    })
+  })
+
+  // https://stackoverflow.com/questions/66667827/react-testing-library-to-cover-the-lazy-load/66690463
+  test('renders lazy component', () => {
+    setup()
+    expect(screen.getByTestId('mocked-map-container')).toBeInTheDocument()
   })
 })

--- a/static/src/js/components/DownloadHistory/DownloadHistory.js
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.js
@@ -86,7 +86,6 @@ export class DownloadHistory extends Component {
             <Spinner
               className="download-history__spinner"
               type="dots"
-              color="white"
               size="small"
             />
           )

--- a/static/src/js/routes/ContactInfo/ContactInfo.js
+++ b/static/src/js/routes/ContactInfo/ContactInfo.js
@@ -17,7 +17,7 @@ export const ContactInfo = () => (
       <meta name="robots" content="noindex, nofollow" />
       <link rel="canonical" href={`${edscHost}/contact-info`} />
     </Helmet>
-    <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+    <div className="route-wrapper route-wrapper--light route-wrapper--content-page">
       <div className="route-wrapper__content">
         <div className="route-wrapper__content-inner">
           <ContactInfoContainer />

--- a/static/src/js/routes/Downloads/Downloads.js
+++ b/static/src/js/routes/Downloads/Downloads.js
@@ -17,7 +17,7 @@ export const Downloads = ({
   return (
     <Switch>
       <Route path={`${path}`}>
-        <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+        <div className="route-wrapper route-wrapper--light route-wrapper--content-page">
           <div className="route-wrapper__content">
             <div className="route-wrapper__content-inner">
               <Switch>

--- a/static/src/js/routes/EarthdataDownloadRedirect/EarthdataDownloadRedirect.js
+++ b/static/src/js/routes/EarthdataDownloadRedirect/EarthdataDownloadRedirect.js
@@ -17,7 +17,7 @@ export const EarthdataDownloadRedirect = () => {
         <meta name="robots" content="noindex, nofollow" />
         <link rel="canonical" href={`${edscHost}/earthdata-download-redirect`} />
       </Helmet>
-      <div className="route-wrapper route-wrapper--dark route-wrapper--content-page route-wrapper--content-page-centered">
+      <div className="route-wrapper route-wrapper--light route-wrapper--content-page route-wrapper--content-page-centered">
         <div className="route-wrapper__content">
           <div className="route-wrapper__content-inner">
             <EarthdataDownloadRedirectContainer />

--- a/static/src/js/routes/Preferences/Preferences.js
+++ b/static/src/js/routes/Preferences/Preferences.js
@@ -17,7 +17,7 @@ export const Preferences = () => {
         <meta name="robots" content="noindex, nofollow" />
         <link rel="canonical" href={`${edscHost}/preferences`} />
       </Helmet>
-      <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+      <div className="route-wrapper route-wrapper--light route-wrapper--content-page">
         <div className="route-wrapper__content">
           <div className="route-wrapper__content-inner">
             <PreferencesContainer />

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -91,11 +91,10 @@ export const Project = (props) => {
         id="form__project"
         onSubmit={handleSubmit}
         method="post"
+        name="project form"
         className="route-wrapper__content--map route-wrapper--project"
       >
-        <SidebarContainer
-          panels={<ProjectPanelsContainer />}
-        >
+        <SidebarContainer panels={<ProjectPanelsContainer />}>
           <ProjectCollectionsContainer />
         </SidebarContainer>
         <OverrideTemporalModalContainer />

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -1,4 +1,8 @@
-import React, { Component } from 'react'
+import React, {
+  Component,
+  lazy,
+  Suspense
+} from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
@@ -16,9 +20,12 @@ import ProjectCollectionsContainer
 import ProjectPanelsContainer from '../../containers/ProjectPanelsContainer/ProjectPanelsContainer'
 import OverrideTemporalModalContainer
   from '../../containers/OverrideTemporalModalContainer/OverrideTemporalModalContainer'
-import EdscMapContainer from '../../containers/MapContainer/MapContainer'
 import SavedProjectsContainer from '../../containers/SavedProjectsContainer/SavedProjectsContainer'
 import AuthRequiredContainer from '../../containers/AuthRequiredContainer/AuthRequiredContainer'
+
+import Spinner from '../../components/Spinner/Spinner'
+
+const EdscMapContainer = lazy(() => import('../../containers/MapContainer/MapContainer'))
 
 const mapDispatchToProps = (dispatch) => ({
   onSubmitRetrieval:
@@ -109,7 +116,9 @@ export class Project extends Component {
           </SidebarContainer>
           <OverrideTemporalModalContainer />
         </form>
-        <EdscMapContainer />
+        <Suspense fallback={<Spinner type="dots" />}>
+          <EdscMapContainer />
+        </Suspense>
       </AuthRequiredContainer>
     )
   }

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -107,7 +107,7 @@ export class Project extends Component {
           id="form__project"
           onSubmit={this.handleSubmit}
           method="post"
-          className="route-wrapper route-wrapper--project"
+          className="route-wrapper__content--map route-wrapper--project"
         >
           <SidebarContainer
             panels={<ProjectPanelsContainer />}
@@ -116,7 +116,7 @@ export class Project extends Component {
           </SidebarContainer>
           <OverrideTemporalModalContainer />
         </form>
-        <Suspense fallback={<Spinner type="dots" />}>
+        <Suspense fallback={<Spinner type="dots" className="root__spinner spinner spinner--dots spinner--white spinner--small" />}>
           <EdscMapContainer />
         </Suspense>
       </AuthRequiredContainer>

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -1,8 +1,4 @@
-import React, {
-  Component,
-  lazy,
-  Suspense
-} from 'react'
+import React, { lazy, Suspense } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
@@ -21,8 +17,6 @@ import ProjectPanelsContainer from '../../containers/ProjectPanelsContainer/Proj
 import OverrideTemporalModalContainer
   from '../../containers/OverrideTemporalModalContainer/OverrideTemporalModalContainer'
 import SavedProjectsContainer from '../../containers/SavedProjectsContainer/SavedProjectsContainer'
-import AuthRequiredContainer from '../../containers/AuthRequiredContainer/AuthRequiredContainer'
-
 import Spinner from '../../components/Spinner/Spinner'
 
 const EdscMapContainer = lazy(() => import('../../containers/MapContainer/MapContainer'))
@@ -39,24 +33,15 @@ const mapStateToProps = (state) => ({
   name: state.savedProject.name
 })
 
-export class Project extends Component {
-  constructor(props) {
-    super(props)
+export const Project = (props) => {
+  const {
+    onSubmitRetrieval,
+    onToggleChunkedOrderModal,
+    projectCollectionsRequiringChunking
+  } = props
 
-    this.handleSubmit = this.handleSubmit.bind(this)
-
-    const { edscHost } = getEnvironmentConfig()
-    this.edscHost = edscHost
-  }
-
-  handleSubmit(event) {
+  const handleSubmit = (event) => {
     event.preventDefault()
-
-    const {
-      onSubmitRetrieval,
-      onToggleChunkedOrderModal,
-      projectCollectionsRequiringChunking
-    } = this.props
 
     if (Object.keys(projectCollectionsRequiringChunking).length > 0) {
       onToggleChunkedOrderModal(true)
@@ -65,63 +50,61 @@ export class Project extends Component {
     }
   }
 
-  render() {
-    const {
-      location,
-      name
-    } = this.props
-    const { search } = location
-    const { edscHost } = this
+  const {
+    location,
+    name
+  } = props
+  const { search } = location
+  const { edscHost } = getEnvironmentConfig()
 
-    // If there are no params in the URL, show the saved projects page
-    if (search === '') {
-      return (
-        <AuthRequiredContainer>
-          <Helmet>
-            <title>Saved Projects</title>
-            <meta name="title" content="Saved Projects" />
-            <meta name="robots" content="noindex, nofollow" />
-            <link rel="canonical" href={`${edscHost}/projects`} />
-          </Helmet>
-          <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
-            <div className="route-wrapper__content">
-              <div className="route-wrapper__content-inner">
-                <SavedProjectsContainer />
-              </div>
+  // If there are no params in the URL, show the saved projects page
+  if (search === '') {
+    return (
+      <>
+        <Helmet>
+          <title>Saved Projects</title>
+          <meta name="title" content="Saved Projects" />
+          <meta name="robots" content="noindex, nofollow" />
+          <link rel="canonical" href={`${edscHost}/projects`} />
+        </Helmet>
+        <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+          <div className="route-wrapper__content">
+            <div className="route-wrapper__content-inner">
+              <SavedProjectsContainer />
             </div>
           </div>
-        </AuthRequiredContainer>
-      )
-    }
-
-    // Show the project page
-    return (
-      <AuthRequiredContainer>
-        <Helmet>
-          <title>{name || 'Untitled Project'}</title>
-          <meta name="title" content={name || 'Untitled Project'} />
-          <meta name="robots" content="noindex, nofollow" />
-          <link rel="canonical" href={`${edscHost}`} />
-        </Helmet>
-        <form
-          id="form__project"
-          onSubmit={this.handleSubmit}
-          method="post"
-          className="route-wrapper__content--map route-wrapper--project"
-        >
-          <SidebarContainer
-            panels={<ProjectPanelsContainer />}
-          >
-            <ProjectCollectionsContainer />
-          </SidebarContainer>
-          <OverrideTemporalModalContainer />
-        </form>
-        <Suspense fallback={<Spinner type="dots" className="root__spinner spinner spinner--dots spinner--white spinner--small" />}>
-          <EdscMapContainer />
-        </Suspense>
-      </AuthRequiredContainer>
+        </div>
+      </>
     )
   }
+
+  // Show the project page
+  return (
+    <>
+      <Helmet>
+        <title>{name || 'Untitled Project'}</title>
+        <meta name="title" content={name || 'Untitled Project'} />
+        <meta name="robots" content="noindex, nofollow" />
+        <link rel="canonical" href={`${edscHost}`} />
+      </Helmet>
+      <form
+        id="form__project"
+        onSubmit={handleSubmit}
+        method="post"
+        className="route-wrapper__content--map route-wrapper--project"
+      >
+        <SidebarContainer
+          panels={<ProjectPanelsContainer />}
+        >
+          <ProjectCollectionsContainer />
+        </SidebarContainer>
+        <OverrideTemporalModalContainer />
+      </form>
+      <Suspense fallback={<Spinner type="dots" className="root__spinner spinner spinner--dots spinner--white spinner--small" />}>
+        <EdscMapContainer />
+      </Suspense>
+    </>
+  )
 }
 
 Project.propTypes = {

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -92,7 +92,7 @@ export const Project = (props) => {
         onSubmit={handleSubmit}
         method="post"
         name="project form"
-        className="route-wrapper__content--map route-wrapper--project"
+        className="route-wrapper route-wrapper--evil"
       >
         <SidebarContainer panels={<ProjectPanelsContainer />}>
           <ProjectCollectionsContainer />

--- a/static/src/js/routes/Project/Project.js
+++ b/static/src/js/routes/Project/Project.js
@@ -67,7 +67,7 @@ export const Project = (props) => {
           <meta name="robots" content="noindex, nofollow" />
           <link rel="canonical" href={`${edscHost}/projects`} />
         </Helmet>
-        <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+        <div className="route-wrapper route-wrapper--light route-wrapper--content-page">
           <div className="route-wrapper__content">
             <div className="route-wrapper__content-inner">
               <SavedProjectsContainer />
@@ -92,7 +92,7 @@ export const Project = (props) => {
         onSubmit={handleSubmit}
         method="post"
         name="project form"
-        className="route-wrapper route-wrapper--evil"
+        className="route-wrapper route-wrapper--dark"
       >
         <SidebarContainer panels={<ProjectPanelsContainer />}>
           <ProjectCollectionsContainer />

--- a/static/src/js/routes/Project/__tests__/Project.test.js
+++ b/static/src/js/routes/Project/__tests__/Project.test.js
@@ -23,7 +23,6 @@ jest.mock('react-leaflet', () => ({
   createControlComponent: jest.fn().mockImplementation(() => {})
 }))
 
-// Mock App components routes and containers
 jest.mock('../../../containers/SidebarContainer/SidebarContainer', () => {
   const MockedSidebarContainer = () => <div data-testid="mocked-sidebarContainer" />
 
@@ -104,64 +103,6 @@ const setup = (overrideProps) => {
 }
 
 describe('Project component', () => {
-  test('should render self', async () => {
-    nock(/localhost/)
-      .post(/retrievals/)
-      .reply(200, {
-        id: 7
-      })
-
-    const store = mockStore({
-      project: {
-        collections: {
-          allIds: [],
-          byId: {},
-          isSubmitted: false,
-          isSubmitting: false
-        }
-      },
-      portal: { portalId: 'edsc' },
-      router: {
-        location: {
-          search: ''
-        }
-      },
-      shapefile: {
-        shapefileId: '',
-        selectedFeatures: null
-      }
-    })
-
-    await store.dispatch(actions.submitRetrieval())
-
-    setup({
-      location: {
-        search: ''
-      }
-    })
-
-    await waitFor(() => {
-      // Document title
-      expect(document.title).toEqual('Saved Projects')
-
-      // Document meta elements
-      const metaTitleElement = document.querySelector('[name="title"]')
-
-      expect(metaTitleElement).toHaveAttribute('content', 'Saved Projects')
-
-      const metaBotsElement = document.querySelector('[name="robots"]')
-
-      expect(metaBotsElement).toHaveAttribute('content', 'noindex, nofollow')
-
-      const metaLinkElement = document.querySelector('link[rel="canonical"]')
-
-      // TODO why was this updated to `/projects`
-      expect(metaLinkElement).toHaveAttribute('href', 'https://search.earthdata.nasa.gov/projects')
-
-      expect(metaLinkElement).toBeInTheDocument()
-    })
-  })
-
   describe('Saved projects page', () => {
     test('displays the SavedProjectsContainer', async () => {
       nock(/localhost/)
@@ -283,7 +224,7 @@ describe('Project component', () => {
         }
       })
 
-      store.dispatch(actions.submitRetrieval())
+      await store.dispatch(actions.submitRetrieval())
 
       const { onSubmitRetrieval } = setup({
         location: {
@@ -329,7 +270,7 @@ describe('Project component', () => {
         }
       })
 
-      store.dispatch(actions.submitRetrieval())
+      await store.dispatch(actions.submitRetrieval())
 
       const { onSubmitRetrieval, onToggleChunkedOrderModal } = setup({
         location: {
@@ -348,6 +289,60 @@ describe('Project component', () => {
       fireEvent.submit(formSubmit)
       expect(onToggleChunkedOrderModal).toBeCalledTimes(1)
       expect(onSubmitRetrieval).toBeCalledTimes(0)
+    })
+  })
+
+  // RTL Lazy loading issue with mocks between https://github.com/testing-library/react-testing-library/issues/716
+  describe('render self', () => {
+    test('should render self', async () => {
+      nock(/localhost/)
+        .post(/retrievals/)
+        .reply(200, {
+          id: 1
+        })
+
+      const store = mockStore({
+        project: {
+          collections: {
+            allIds: [],
+            byId: {},
+            isSubmitted: false,
+            isSubmitting: false
+          }
+        },
+        portal: { portalId: 'edsc' },
+        router: {
+          location: {
+            search: ''
+          }
+        },
+        shapefile: {
+          shapefileId: '',
+          selectedFeatures: null
+        }
+      })
+
+      await store.dispatch(actions.submitRetrieval())
+
+      setup()
+
+      await waitFor(() => {
+        // Document title
+        expect(document.title).toEqual('Test Project')
+
+        // Document meta elements
+        const metaTitleElement = document.querySelector('[name="title"]')
+
+        expect(metaTitleElement).toHaveAttribute('content', 'Test Project')
+
+        const metaBotsElement = document.querySelector('[name="robots"]')
+
+        expect(metaBotsElement).toHaveAttribute('content', 'noindex, nofollow')
+
+        const metaLinkElement = document.querySelector('link[rel="canonical"]')
+
+        expect(metaLinkElement).toHaveAttribute('href', 'https://search.earthdata.nasa.gov')
+      })
     })
   })
 })

--- a/static/src/js/routes/Project/__tests__/Project.test.js
+++ b/static/src/js/routes/Project/__tests__/Project.test.js
@@ -288,6 +288,7 @@ describe('Project component', () => {
       // TODO: `UserEvent` does not have submit func and `click` not recognized as submit
       fireEvent.submit(formSubmit)
       expect(onToggleChunkedOrderModal).toBeCalledTimes(1)
+      expect(onToggleChunkedOrderModal).toHaveBeenCalledWith(true)
       expect(onSubmitRetrieval).toBeCalledTimes(0)
     })
   })

--- a/static/src/js/routes/Project/__tests__/Project.test.js
+++ b/static/src/js/routes/Project/__tests__/Project.test.js
@@ -1,15 +1,26 @@
 import React from 'react'
-import Enzyme, { shallow } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
-import Helmet from 'react-helmet'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import nock from 'nock'
 
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+
+// TODO Memory router is supposed to be more lightweight?
+import { BrowserRouter as Router } from 'react-router-dom'
 import * as AppConfig from '../../../../../../sharedUtils/config'
+import actions from '../../../actions'
+import '@testing-library/jest-dom'
+import { Project } from '../Project'
 
-import Project from '../Project'
-import SavedProjectsContainer
-  from '../../../containers/SavedProjectsContainer/SavedProjectsContainer'
-import ProjectCollectionsContainer
-  from '../../../containers/ProjectCollectionsContainer/ProjectCollectionsContainer'
+// Import SavedProjectsContainer
+//   from '../../../containers/SavedProjectsContainer/SavedProjectsContainer'
+// import ProjectCollectionsContainer
+//   from '../../../containers/ProjectCollectionsContainer/ProjectCollectionsContainer'
 
 // Mock react-leaflet because it causes errors
 jest.mock('react-leaflet', () => ({
@@ -17,14 +28,77 @@ jest.mock('react-leaflet', () => ({
   createControlComponent: jest.fn().mockImplementation(() => {})
 }))
 
-Enzyme.configure({ adapter: new Adapter() })
+// Mock App components routes and containers
+jest.mock('../../../containers/SidebarContainer/SidebarContainer', () => {
+  const MockedSidebarContainer = () => <div data-testid="mocked-sidebarContainer" />
+
+  return MockedSidebarContainer
+})
+
+jest.mock('../../../containers/ProjectCollectionsContainer/ProjectCollectionsContainer', () => {
+  const MockedProjectCollectionsContainer = () => <div data-testid="mocked-projectCollectionsContainer" />
+
+  return MockedProjectCollectionsContainer
+})
+
+jest.mock('../../../containers/SavedProjectsContainer/SavedProjectsContainer', () => {
+  const MockedSavedProjectsContainer = () => <div data-testid="mocked-savedProjectsContainer" />
+
+  return MockedSavedProjectsContainer
+})
+
+jest.mock('../../../containers/OverrideTemporalModalContainer/OverrideTemporalModalContainer', () => {
+  const MockedOverrideTemporalModalContainer = () => <div data-testid="mocked-overrideTemporalModalContainer" />
+
+  return MockedOverrideTemporalModalContainer
+})
+
+jest.mock('../../../containers/MapContainer/MapContainer', () => {
+  const MockedMapContainer = () => <div data-testid="mocked-mapContainer" />
+
+  return MockedMapContainer
+})
+
+jest.mock('../../../containers/MapContainer/MapContainer', () => {
+  const MockedMapContainer = () => <div data-testid="mocked-mapContainer" />
+
+  return MockedMapContainer
+})
+
+jest.mock('../../../components/Spinner/Spinner', () => {
+  const MockedSpinner = () => <div data-testid="mocked-spinner" />
+
+  return MockedSpinner
+})
+
+// Jest.mock('react-router-dom', () => ({
+//   ...jest.requireActual('react-router-dom')
+// }))
+
+// Define a MockRouter component
+// eslint-disable-next-line react/prop-types
+// const MockRouter = ({ children }) => (
+//   <MemoryRouter initialEntries={['/']}>
+//     {children}
+//   </MemoryRouter>
+// )
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom')
+}))
+
+const mockStore = configureMockStore([thunk])
+// Const store = configureStore()
 
 beforeEach(() => {
   jest.clearAllMocks()
-  jest.spyOn(AppConfig, 'getEnvironmentConfig').mockImplementation(() => ({ edscHost: 'https://search.earthdata.nasa.gov' }))
+  jest.spyOn(AppConfig, 'getEnvironmentConfig').mockImplementation(() => ({
+    edscHost: 'https://search.earthdata.nasa.gov',
+    apiHost: 'https://cmr.earthdata.nasa.gov'
+  }))
 })
 
-function setup(overrideProps) {
+const setup = (overrideProps) => {
   const props = {
     location: {},
     name: 'Test Project',
@@ -35,81 +109,286 @@ function setup(overrideProps) {
     ...overrideProps
   }
 
-  const enzymeWrapper = shallow(<Project.WrappedComponent {...props} />)
+  render(
+    <Router>
+      <Project {...props} />
+    </Router>
+  )
 
   return {
-    enzymeWrapper,
-    props
+    onSubmitRetrieval: props.onSubmitRetrieval,
+    onToggleChunkedOrderModal: props.onToggleChunkedOrderModal
   }
 }
 
 describe('Project component', () => {
-  test('should render self', () => {
-    const { enzymeWrapper } = setup()
+  describe('Saved projects page', () => {
+    test('displays the SavedProjectsContainer', async () => {
+      nock(/cmr/)
+        .post(/retrievals/)
+        .reply(200, {
+          id: 7
+        })
 
-    expect(enzymeWrapper.exists()).toBeTruthy()
-  })
-
-  test('sets the correct Helmet meta information', () => {
-    const { enzymeWrapper } = setup()
-
-    const helmet = enzymeWrapper.find(Helmet)
-
-    expect(helmet.childAt(0).type()).toEqual('title')
-    expect(helmet.childAt(0).text()).toEqual('Test Project')
-    expect(helmet.childAt(1).props().name).toEqual('title')
-    expect(helmet.childAt(1).props().content).toEqual('Test Project')
-    expect(helmet.childAt(2).props().name).toEqual('robots')
-    expect(helmet.childAt(2).props().content).toEqual('noindex, nofollow')
-    expect(helmet.childAt(3).props().rel).toEqual('canonical')
-    expect(helmet.childAt(3).props().href).toEqual('https://search.earthdata.nasa.gov')
-  })
-
-  describe('handleSubmit', () => {
-    test('calls onSubmitRetrieval', () => {
-      const { enzymeWrapper, props } = setup()
-
-      const form = enzymeWrapper.find('form')
-
-      form.simulate('submit', { preventDefault: jest.fn() })
-      expect(props.onSubmitRetrieval.mock.calls.length).toBe(1)
-    })
-
-    test('calls onToggleChunkedOrderModal when any collections require chunking', () => {
-      const { enzymeWrapper, props } = setup({
-        projectCollectionsRequiringChunking: {
-          collectionId: {}
+      const store = mockStore({
+        retrieval: {
+          id: null,
+          collections: {},
+          isLoading: false,
+          isLoaded: false
+        },
+        project: {
+          collections:
+        {
+          allIds: [],
+          byId: {},
+          isSubmitted: false,
+          isSubmitting: false
+        }
+        },
+        portal: { portalId: 'edsc' },
+        router: {
+          location: {
+            search: ''
+          }
+        },
+        shapefile: {
+          shapefileId: '',
+          selectedFeatures: null
         }
       })
 
-      const form = enzymeWrapper.find('form')
+      await store.dispatch(actions.submitRetrieval())
 
-      form.simulate('submit', { preventDefault: jest.fn() })
-      expect(props.onToggleChunkedOrderModal.mock.calls.length).toBe(1)
-    })
-  })
-
-  describe('Saved projects page', () => {
-    test('displays the SavedProjectsContainer', () => {
-      const { enzymeWrapper } = setup({
+      setup({
         location: {
           search: ''
         }
       })
 
-      expect(enzymeWrapper.find(SavedProjectsContainer).length).toBe(1)
+      expect(screen.getByTestId('mocked-savedProjectsContainer')).toBeInTheDocument()
+      await waitFor(() => {
+        // Title
+        expect(document.title).toEqual('Saved Projects')
+
+        // Meta elements
+        const metaTitleElement = document.querySelector('[name="title"]')
+
+        expect(metaTitleElement).toHaveAttribute('content', 'Saved Projects')
+
+        const metaBotsElement = document.querySelector('[name="robots"]')
+
+        expect(metaBotsElement).toHaveAttribute('content', 'noindex, nofollow')
+
+        const metaLinkElement = document.querySelector('link[rel="canonical"]')
+        // TODO why was this updated to `/projects`
+        expect(metaLinkElement).toHaveAttribute('href', 'https://search.earthdata.nasa.gov/projects')
+
+        expect(metaLinkElement).toBeInTheDocument()
+      })
     })
   })
 
   describe('Projects page', () => {
-    test('displays the ProjectCollectionsContainer', () => {
-      const { enzymeWrapper } = setup({
+    test('displays the ProjectCollectionsContainer', async () => {
+      nock(/cmr/)
+        .post(/retrievals/)
+        .reply(200, {
+          id: 7
+        })
+
+      const store = mockStore({
+        retrieval: {
+          id: null,
+          collections: {},
+          isLoading: false,
+          isLoaded: false
+        },
+        project: {
+          collections:
+        {
+          allIds: [],
+          byId: {},
+          isSubmitted: false,
+          isSubmitting: false
+        }
+        },
+        portal: { portalId: 'edsc' },
+        router: {
+          location: {
+            search: ''
+          }
+        },
+        shapefile: {
+          shapefileId: '',
+          selectedFeatures: null
+        }
+      })
+
+      await store.dispatch(actions.submitRetrieval())
+
+      setup({
         location: {
           search: '?p=!C123456-EDSC'
         }
       })
 
-      expect(enzymeWrapper.find(ProjectCollectionsContainer).length).toBe(1)
+      // Ensure that the map is being lazy loaded; spinner during load
+      expect(screen.getByTestId('mocked-spinner')).toBeInTheDocument()
+
+      await waitFor(() => {
+        expect(document.title).toEqual('Test Project')
+        expect(screen.getByTestId('mocked-overrideTemporalModalContainer')).toBeInTheDocument()
+        expect(screen.getByTestId('mocked-sidebarContainer')).toBeInTheDocument()
+        expect(screen.getByTestId('mocked-mapContainer')).toBeInTheDocument()
+      })
     })
   })
+
+  describe('handleSubmit', () => {
+    test('calls onSubmitRetrieval', async () => {
+      nock(/cmr/)
+        .post(/retrievals/)
+        .reply(200, {
+          id: 7
+        })
+
+      const store = mockStore({
+        retrieval: {
+          id: null,
+          collections: {},
+          isLoading: false,
+          isLoaded: false
+        },
+        project: {
+          collections:
+      {
+        allIds: [],
+        byId: {},
+        isSubmitted: false,
+        isSubmitting: false
+      }
+        },
+        portal: { portalId: 'edsc' },
+        router: {
+          location: {
+            search: ''
+          }
+        },
+        shapefile: {
+          shapefileId: '',
+          selectedFeatures: null
+        }
+      })
+
+      store.dispatch(actions.submitRetrieval())
+
+      const { onSubmitRetrieval } = setup({
+        location: {
+          search: '?p=!C123456-EDSC'
+        }
+      })
+
+      // TODO RTL Does not seem to be able to find by form without the `name` prop on the form element
+      // https://github.com/testing-library/dom-testing-library/issues/937
+      const formSubmit = screen.getByRole('form')
+
+      // TODO: `UserEvent` does not have submit func and `click` not recognized as submit
+      fireEvent.submit(formSubmit)
+      expect(onSubmitRetrieval).toBeCalledTimes(1)
+    })
+
+    test('calls onToggleChunkedOrderModal when any collections require chunking', async () => {
+      nock(/cmr/)
+        .post(/retrievals/)
+        .reply(200, {
+          id: 7
+        })
+
+      const store = mockStore({
+        retrieval: {
+          id: null,
+          collections: {},
+          isLoading: false,
+          isLoaded: false
+        },
+        project: {
+          collections:
+      {
+        allIds: [],
+        byId: {},
+        isSubmitted: false,
+        isSubmitting: false
+      }
+        },
+        portal: { portalId: 'edsc' },
+        router: {
+          location: {
+            search: ''
+          }
+        },
+        shapefile: {
+          shapefileId: '',
+          selectedFeatures: null
+        }
+      })
+
+      store.dispatch(actions.submitRetrieval())
+
+      const { onSubmitRetrieval, onToggleChunkedOrderModal } = setup({
+        location: {
+          search: '?p=!C123456-EDSC'
+        },
+        projectCollectionsRequiringChunking: {
+          collectionId: {}
+        }
+      })
+
+      // TODO RTL Does not seem to be able to find by form without the `name` prop on the form element
+      // https://github.com/testing-library/dom-testing-library/issues/937
+      const formSubmit = screen.getByRole('form')
+
+      // TODO: `UserEvent` does not have submit func and `click` not recognized as submit
+      fireEvent.submit(formSubmit)
+      expect(onToggleChunkedOrderModal).toBeCalledTimes(1)
+      expect(onSubmitRetrieval).toBeCalledTimes(0)
+    })
+  })
+
+  // Test.skip('sets the correct Helmet meta information', () => {
+  //   const { enzymeWrapper } = setup()
+
+  //   const helmet = enzymeWrapper.find(Helmet)
+
+  //   expect(helmet.childAt(0).type()).toEqual('title')
+  //   expect(helmet.childAt(0).text()).toEqual('Test Project')
+  //   expect(helmet.childAt(1).props().name).toEqual('title')
+  //   expect(helmet.childAt(1).props().content).toEqual('Test Project')
+  //   expect(helmet.childAt(2).props().name).toEqual('robots')
+  //   expect(helmet.childAt(2).props().content).toEqual('noindex, nofollow')
+  //   expect(helmet.childAt(3).props().rel).toEqual('canonical')
+  //   expect(helmet.childAt(3).props().href).toEqual('https://search.earthdata.nasa.gov')
+  // })
 })
+
+// Describe('Project component', () => {
+//   test('should render self', () => {
+//     const { enzymeWrapper } = setup()
+
+//     expect(enzymeWrapper.exists()).toBeTruthy()
+//   })
+
+//   test('sets the correct Helmet meta information', () => {
+//     const { enzymeWrapper } = setup()
+
+//     const helmet = enzymeWrapper.find(Helmet)
+
+//     expect(helmet.childAt(0).type()).toEqual('title')
+//     expect(helmet.childAt(0).text()).toEqual('Test Project')
+//     expect(helmet.childAt(1).props().name).toEqual('title')
+//     expect(helmet.childAt(1).props().content).toEqual('Test Project')
+//     expect(helmet.childAt(2).props().name).toEqual('robots')
+//     expect(helmet.childAt(2).props().content).toEqual('noindex, nofollow')
+//     expect(helmet.childAt(3).props().rel).toEqual('canonical')
+//     expect(helmet.childAt(3).props().href).toEqual('https://search.earthdata.nasa.gov')
+//   })

--- a/static/src/js/routes/Project/__tests__/Project.test.js
+++ b/static/src/js/routes/Project/__tests__/Project.test.js
@@ -10,7 +10,6 @@ import {
   waitFor
 } from '@testing-library/react'
 
-// TODO Memory router is supposed to be more lightweight?
 import { BrowserRouter as Router } from 'react-router-dom'
 import * as AppConfig from '../../../../../../sharedUtils/config'
 import actions from '../../../actions'

--- a/static/src/js/routes/Search/Search.js
+++ b/static/src/js/routes/Search/Search.js
@@ -227,7 +227,7 @@ export const Search = ({
           </Route>
         </Switch>
       </SidebarContainer>
-      <div className="route-wrapper__content route-wrapper__content--evil">
+      <div className="route-wrapper__content route-wrapper__content--dark">
         <PortalBrowserModalContainer />
         <RelatedUrlsModalContainer />
         <FacetsModalContainer />

--- a/static/src/js/routes/Search/Search.js
+++ b/static/src/js/routes/Search/Search.js
@@ -227,7 +227,7 @@ export const Search = ({
           </Route>
         </Switch>
       </SidebarContainer>
-      <div className="route-wrapper__content">
+      <div className="route-wrapper__content--map">
         <PortalBrowserModalContainer />
         <RelatedUrlsModalContainer />
         <FacetsModalContainer />

--- a/static/src/js/routes/Search/Search.js
+++ b/static/src/js/routes/Search/Search.js
@@ -227,7 +227,7 @@ export const Search = ({
           </Route>
         </Switch>
       </SidebarContainer>
-      <div className="route-wrapper__content--map">
+      <div className="route-wrapper__content route-wrapper__content--evil">
         <PortalBrowserModalContainer />
         <RelatedUrlsModalContainer />
         <FacetsModalContainer />

--- a/static/src/js/routes/Subscriptions/Subscriptions.js
+++ b/static/src/js/routes/Subscriptions/Subscriptions.js
@@ -16,7 +16,7 @@ export const Subscriptions = () => {
         <meta name="robots" content="noindex, nofollow" />
         <link rel="canonical" href={`${edscHost}`} />
       </Helmet>
-      <div className="route-wrapper route-wrapper--dark route-wrapper--content-page">
+      <div className="route-wrapper route-wrapper--light route-wrapper--content-page">
         <div className="route-wrapper__content">
           <div className="route-wrapper__content-inner">
             <SubscriptionsListContainer />

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1491,7 +1491,7 @@ test.describe('Map interactions', () => {
             await page.mouse.move(1000, 600)
             await page.mouse.up()
 
-            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M987 548L993 573L1024 566L1019 541L987 548z')
+            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M994 441L996 454L1012 451L1009 438L994 441z')
             await expect(page.locator('.granule-spatial-label-temporal')).toHaveText('2021-05-31 15:30:522021-05-31 15:31:22')
           })
         })

--- a/tests/e2e/map/map.spec.js
+++ b/tests/e2e/map/map.spec.js
@@ -1491,7 +1491,7 @@ test.describe('Map interactions', () => {
             await page.mouse.move(1000, 600)
             await page.mouse.up()
 
-            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M994 441L996 454L1012 451L1009 438L994 441z')
+            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M987 548L993 573L1024 566L1019 541L987 548z')
             await expect(page.locator('.granule-spatial-label-temporal')).toHaveText('2021-05-31 15:30:522021-05-31 15:31:22')
           })
         })
@@ -1501,7 +1501,7 @@ test.describe('Map interactions', () => {
             // Zoom the map
             await page.locator('.leaflet-control-zoom-in').click()
 
-            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M1287 465L1293 490L1324 483L1319 458L1287 465z')
+            await expect(page.locator('.leaflet-interactive').nth(1)).toHaveAttribute('d', 'M1287 466L1293 491L1324 484L1319 459L1287 466z')
             await expect(page.locator('.granule-spatial-label-temporal')).toHaveText('2021-05-31 15:30:522021-05-31 15:31:22')
           })
         })


### PR DESCRIPTION
# Overview

### What is the feature?

Lazy load the `MapContainer.js` component 
### What is the Solution?

Update the imports for `MapContainer.js` so that it is bundled separately, have the error-boundry use the `Spinner` with a new class for when the Map is loading. Updated Project component to be a functional component and rendering it the same way as the other routes are. Updated App.test.js for technical debt and to test that the Map is being loaded after being awaited. Updated the project.test.js route tests to RTL for tech debt. Updates class names which were not being used before to the correct ones, add a new `scss` modifier for the loading state

### What areas of the application does this impact?

Search page, Projects page routes. Background color and scss for the other routes

# Testing

1) Ensure that the map container is not getting reloaded. Go to a page that does not contain the map such as the contact-info page. Open the DevTools and use the Coverage command to see what is being loaded onto the page ensure that the MapContainer.js component is not being loaded in. **NOTE** In order to be able to see the error boundry/Spinner, we will need to throttle internet connectivity, as was done in the screenshots the devTools network tab can be used to throttle


Ensure that the project page continues to work as expected: create new projects, go to the saved projects page, go to a project from that page, hit the download button from the project page, ensure the form submission works as expected

### Attachments

Loading state for /project  (throttling connection)
![Pasted Graphic 8](https://github.com/nasa/earthdata-search/assets/34591886/c3d50147-fe32-46e4-8ccf-60d685ec1cf0)

Loading state for /search (throttling connection)
![Pasted Graphic 9](https://github.com/nasa/earthdata-search/assets/34591886/95553a36-f4ab-4079-be68-75bd60e9583d)

Loaded state for the project page
![image](https://github.com/nasa/earthdata-search/assets/34591886/a0efe170-fe84-4c02-9e6e-00210fb28da5)

Loaded state for the /search page
![image](https://github.com/nasa/earthdata-search/assets/34591886/3379034d-9e4b-4984-94a4-4326f70b04a1)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
