### PR TITLE
EDSC-4101: Add check to ensure size of service associated variables is not empty

### DIFF
--- a/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
+++ b/static/src/js/util/accessMethods/__tests__/buildAccessMethods.test.js
@@ -1097,4 +1097,931 @@ describe('buildAccessMethods', () => {
       })
     })
   })
+
+  describe('when the collection contains variables directly associated to the collection and no variables associated to it services (empty)', () => {
+    test('variables on the collection are returned instead of variables associated to the service', () => {
+      const collectionMetadata = {
+        services: {
+          items: [{
+            conceptId: 'S100000-EDSC',
+            longName: 'Mock Service Name',
+            name: 'mock-name',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 0,
+              items: []
+            }
+          }, {
+            conceptId: 'S100001-EDSC',
+            longName: 'Mock Service Name 2',
+            name: 'mock-name 2',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example2.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 4,
+              items: []
+            }
+          },
+          {
+            conceptId: 'S100002-EDSC',
+            longName: 'Mock Service Name 3',
+            name: 'mock-name 3',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example3.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }]
+          }]
+        },
+        variables: {
+          count: 3,
+          items: [{
+            conceptId: 'V100003-EDSC',
+            definition: 'Beta channel value',
+            longName: 'Beta channel ',
+            name: 'beta_var',
+            nativeId: 'mmt_variable_4972',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100004-EDSC',
+            definition: 'Orange channel value',
+            longName: 'Orange channel',
+            name: 'orange_var',
+            nativeId: 'mmt_variable_4971',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100005-EDSC',
+            definition: 'Purple channel value',
+            longName: 'Purple channel',
+            name: 'purple_var',
+            nativeId: 'mmt_variable_4970',
+            scienceKeywords: null
+          }]
+        }
+      }
+      const isOpenSearch = false
+
+      const methods = buildAccessMethods(collectionMetadata, isOpenSearch)
+
+      expect(methods).toEqual({
+        harmony0: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100000-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name',
+          name: 'mock-name',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
+              scienceKeywords: null
+            }
+          }
+        },
+        harmony1: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100001-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 2',
+          name: 'mock-name 2',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example2.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
+              scienceKeywords: null
+            }
+          }
+        },
+        // Harmony2 contains the default variables in the coll -> var association
+        harmony2: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100002-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 3',
+          name: 'mock-name 3',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example3.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
+              scienceKeywords: null
+            }
+          }
+        }
+      })
+    })
+  })
+
+  describe('when the collection contains variables directly associated to the collection and some variables associated to some services', () => {
+    test('variables on the collection are returned for services without variables but, variables associated to the service are returned for services that have them', () => {
+      const collectionMetadata = {
+        services: {
+          items: [{
+            conceptId: 'S100000-EDSC',
+            longName: 'Mock Service Name',
+            name: 'mock-name',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 4,
+              items: [{
+                conceptId: 'V100000-EDSC',
+                definition: 'Alpha channel value',
+                longName: 'Alpha channel ',
+                name: 'alpha_var',
+                nativeId: 'mmt_variable_3972',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100001-EDSC',
+                definition: 'Blue channel value',
+                longName: 'Blue channel',
+                name: 'blue_var',
+                nativeId: 'mmt_variable_3971',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100002-EDSC',
+                definition: 'Green channel value',
+                longName: 'Green channel',
+                name: 'green_var',
+                nativeId: 'mmt_variable_3970',
+                scienceKeywords: null
+              }, {
+                conceptId: 'V100003-EDSC',
+                definition: 'Red channel value',
+                longName: 'Red Channel',
+                name: 'red_var',
+                nativeId: 'mmt_variable_3969',
+                scienceKeywords: null
+              }]
+            }
+          }, {
+            conceptId: 'S100001-EDSC',
+            longName: 'Mock Service Name 2',
+            name: 'mock-name 2',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example2.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }],
+            variables: {
+              count: 4,
+              items: []
+            }
+          },
+          {
+            conceptId: 'S100002-EDSC',
+            longName: 'Mock Service Name 3',
+            name: 'mock-name 3',
+            type: 'Harmony',
+            url: {
+              description: 'Mock URL',
+              urlValue: 'https://example3.com'
+            },
+            serviceOptions: {
+              subset: {
+                spatialSubset: {
+                  boundingBox: {
+                    allowMultipleValues: false
+                  }
+                },
+                variableSubset: {
+                  allowMultipleValues: true
+                }
+              },
+              supportedOutputProjections: [{
+                projectionName: 'Polar Stereographic'
+              }, {
+                projectionName: 'Geographic'
+              }],
+              interpolationTypes: [
+                'Bilinear Interpolation',
+                'Nearest Neighbor'
+              ],
+              supportedReformattings: [{
+                supportedInputFormat: 'NETCDF-4',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }, {
+                supportedInputFormat: 'GEOTIFF',
+                supportedOutputFormats: [
+                  'GEOTIFF',
+                  'PNG',
+                  'TIFF',
+                  'NETCDF-4'
+                ]
+              }]
+            },
+            supportedOutputProjections: [{
+              projectionName: 'Polar Stereographic'
+            }, {
+              projectionName: 'Geographic'
+            }],
+            supportedReformattings: [{
+              supportedInputFormat: 'NETCDF-4',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }, {
+              supportedInputFormat: 'GEOTIFF',
+              supportedOutputFormats: [
+                'GEOTIFF',
+                'PNG',
+                'TIFF',
+                'NETCDF-4'
+              ]
+            }]
+          }]
+        },
+        variables: {
+          count: 3,
+          items: [{
+            conceptId: 'V100003-EDSC',
+            definition: 'Beta channel value',
+            longName: 'Beta channel ',
+            name: 'beta_var',
+            nativeId: 'mmt_variable_4972',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100004-EDSC',
+            definition: 'Orange channel value',
+            longName: 'Orange channel',
+            name: 'orange_var',
+            nativeId: 'mmt_variable_4971',
+            scienceKeywords: null
+          }, {
+            conceptId: 'V100005-EDSC',
+            definition: 'Purple channel value',
+            longName: 'Purple channel',
+            name: 'purple_var',
+            nativeId: 'mmt_variable_4970',
+            scienceKeywords: null
+          }]
+        }
+      }
+      const isOpenSearch = false
+
+      const methods = buildAccessMethods(collectionMetadata, isOpenSearch)
+
+      expect(methods).toEqual({
+        harmony0: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100000-EDSC'
+            },
+            {
+              id: 'V100001-EDSC'
+            },
+            {
+              id: 'V100002-EDSC'
+            },
+            {
+              id: 'V100003-EDSC'
+            }
+          ],
+          id: 'S100000-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name',
+          name: 'mock-name',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example.com',
+          variables: {
+            'V100000-EDSC': {
+              conceptId: 'V100000-EDSC',
+              definition: 'Alpha channel value',
+              longName: 'Alpha channel ',
+              name: 'alpha_var',
+              nativeId: 'mmt_variable_3972',
+              scienceKeywords: null
+            },
+            'V100001-EDSC': {
+              conceptId: 'V100001-EDSC',
+              definition: 'Blue channel value',
+              longName: 'Blue channel',
+              name: 'blue_var',
+              nativeId: 'mmt_variable_3971',
+              scienceKeywords: null
+            },
+            'V100002-EDSC': {
+              conceptId: 'V100002-EDSC',
+              definition: 'Green channel value',
+              longName: 'Green channel',
+              name: 'green_var',
+              nativeId: 'mmt_variable_3970',
+              scienceKeywords: null
+            },
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Red channel value',
+              longName: 'Red Channel',
+              name: 'red_var',
+              nativeId: 'mmt_variable_3969',
+              scienceKeywords: null
+            }
+          }
+        },
+        harmony1: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100001-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 2',
+          name: 'mock-name 2',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example2.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
+              scienceKeywords: null
+            }
+          }
+        },
+        // Harmony2 contains the default variables in the coll -> var association
+        harmony2: {
+          defaultConcatenation: false,
+          enableConcatenateDownload: false,
+          enableTemporalSubsetting: true,
+          enableSpatialSubsetting: true,
+          hierarchyMappings: [
+            {
+              id: 'V100003-EDSC'
+            },
+            {
+              id: 'V100004-EDSC'
+            },
+            {
+              id: 'V100005-EDSC'
+            }
+          ],
+          id: 'S100002-EDSC',
+          isValid: true,
+          keywordMappings: [],
+          longName: 'Mock Service Name 3',
+          name: 'mock-name 3',
+          supportedOutputFormats: [
+            'GEOTIFF',
+            'PNG',
+            'TIFF',
+            'NETCDF-4'
+          ],
+          supportedOutputProjections: [],
+          supportsBoundingBoxSubsetting: true,
+          supportsConcatenation: false,
+          supportsShapefileSubsetting: false,
+          supportsTemporalSubsetting: false,
+          supportsVariableSubsetting: true,
+          type: 'Harmony',
+          url: 'https://example3.com',
+          variables: {
+            'V100003-EDSC': {
+              conceptId: 'V100003-EDSC',
+              definition: 'Beta channel value',
+              longName: 'Beta channel ',
+              name: 'beta_var',
+              nativeId: 'mmt_variable_4972',
+              scienceKeywords: null
+            },
+            'V100004-EDSC': {
+              conceptId: 'V100004-EDSC',
+              definition: 'Orange channel value',
+              longName: 'Orange channel',
+              name: 'orange_var',
+              nativeId: 'mmt_variable_4971',
+              scienceKeywords: null
+            },
+            'V100005-EDSC': {
+              conceptId: 'V100005-EDSC',
+              definition: 'Purple channel value',
+              longName: 'Purple channel',
+              name: 'purple_var',
+              nativeId: 'mmt_variable_4970',
+              scienceKeywords: null
+            }
+          }
+        }
+      })
+    })
+  })
 })

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -47,6 +47,7 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
         variables: serviceAssociatedVariables = {}
       } = serviceItem
 
+      // Overwrite variables if there are variables associated to the service record
       if (serviceAssociatedVariables.items && serviceAssociatedVariables.items.length > 0) {
         associatedVariables = serviceAssociatedVariables
       }

--- a/static/src/js/util/accessMethods/buildAccessMethods.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods.js
@@ -47,7 +47,7 @@ export const buildAccessMethods = (collectionMetadata, isOpenSearch) => {
         variables: serviceAssociatedVariables = {}
       } = serviceItem
 
-      if (serviceAssociatedVariables.items) {
+      if (serviceAssociatedVariables.items && serviceAssociatedVariables.items.length > 0) {
         associatedVariables = serviceAssociatedVariables
       }
 


### PR DESCRIPTION
# Overview

### What is the feature?

This fixes and issue due to an update in [graphql](https://github.com/nasa/cmr-graphql/commit/d393cb77b182b96acc90e69a6fa101616ccb1a85) where responses are now returning an empty array instead of null. Normally variables available for subsetting are those which are associated to the collection record itself, however, to support a use-case in `EDSC-3909` variables that can be subset are overwritten by the variables associated to the service record instead (if they exist). Due to the graphql change we are now also ensuring that there are variable records not just that the response object exists

### What is the Solution?

Update logic for overwriting variables off of the UMM-S record

### What areas of the application does this impact?

Variable subsetting

# Testing

### Reproduction steps

1) Ensure that the tempo collection in UAT C1254854453-LARC_CLOUD has selectable variables which are those associated to the collection directly.

2) Ensure that the collection C1200277763-E2E_18_4 in the SIT env only has the variables associated to its services as the selectable variables

### Attachments

![image](https://github.com/nasa/earthdata-search/assets/34591886/fac875da-b78a-442a-bba8-5711a8a05da4)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
