### PR TITLE
EDSC-4116: Metadata Display link 'View More Info' returns 500 error

### DIFF
--- a/serverless/src/conceptMetadata/__tests__/handler.test.js
+++ b/serverless/src/conceptMetadata/__tests__/handler.test.js
@@ -19,7 +19,7 @@ describe('conceptMetadata', () => {
 
     const result = await conceptMetadata(event)
 
-    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?token=access_token' })
+    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?token=Bearer access_token' })
     expect(result.statusCode).toBe(307)
   })
 
@@ -35,7 +35,7 @@ describe('conceptMetadata', () => {
 
     const result = await conceptMetadata(event)
 
-    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?id=42&token=access_token' })
+    expect(result.headers).toEqual({ Location: 'http://example.com/concepts?id=42&token=Bearer access_token' })
     expect(result.statusCode).toBe(307)
   })
 })

--- a/serverless/src/conceptMetadata/handler.js
+++ b/serverless/src/conceptMetadata/handler.js
@@ -24,7 +24,7 @@ const conceptMetadata = async (event) => {
   // Access tokens used in the URL still require the client id
   const conceptUrl = `${desiredPath}?${stringify({
     ...parsedQueryParams,
-    token: `${accessToken}`
+    token: `Bearer ${accessToken}`
   }, { encode: false })}`
 
   return {

--- a/static/src/js/components/SearchPanels/SearchPanels.js
+++ b/static/src/js/components/SearchPanels/SearchPanels.js
@@ -726,8 +726,6 @@ class SearchPanels extends PureComponent {
 
     const { edscHost } = this
 
-    // TODO: does this need toe lbe lazy loaded
-    // TODO: That would be messy and probably cause problems
     return (
       <Switch key="panel-children">
         <Route


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes an issue where while logged in the collection-details `View More Info` link was not properly working and instead returning a `500` error because it was unable to pass the token from user

### What is the Solution?

 Fixing the link to metadata preview by passing full header including the `Bearer` prefix for the token

### What areas of the application does this impact?

Integration with metadata-preview the link for the collection-details

# Testing

### Reproduction steps

- **Environment for testing: Any**
- **Collection to test with: Any**

1. While logged in go to the collection details page
2. Ensure that the page's `View More Info` page correctly takes you to the metadata-preview page for the selected collection

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

Current issue:
![image](https://github.com/nasa/earthdata-search/assets/34591886/5546e20f-b981-4b17-91b5-486561d3e078)


localhost fix for a collection
![image](https://github.com/nasa/earthdata-search/assets/34591886/e7666a8d-2d0c-434c-8322-52d04fceadaf)


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
