### PR TITLE
EDSC-3993: Bump serverless-finch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
         "sass-loader": "^13.2.0",
         "scatter-swap": "^0.1.0",
         "serverless": "^3.37.0",
-        "serverless-finch": "^4.0.0",
+        "serverless-finch": "^4.0.4",
         "serverless-offline": "^12.0.4",
         "serverless-plugin-ifelse": "git+https://git@github.com/macrouch/serverless-plugin-ifelse.git",
         "serverless-plugin-log-subscription": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "sass-loader": "^13.2.0",
     "scatter-swap": "^0.1.0",
     "serverless": "^3.37.0",
-    "serverless-finch": "^4.0.0",
+    "serverless-finch": "^4.0.4",
     "serverless-offline": "^12.0.4",
     "serverless-plugin-ifelse": "git+https://git@github.com/macrouch/serverless-plugin-ifelse.git",
     "serverless-plugin-log-subscription": "^2.1.5",


### PR DESCRIPTION
# Overview

### What is the feature?

Minor version bump for `serverless-finch` to keep up with changes

### What is the Solution?

We discussed this at standup and though it does not resolve the `snyk` scan entirely due to the associated `vul` being brought in  by another package we decided to bump this version as its own ticket regardless

### What areas of the application does this impact?

The IaC specifically the deployment of static-assets into our s3 bucket

# Testing

### Reproduction steps

Regression test to ensure that this is able to deploy correctly on CI/CD and that the static assets are present correctly on s3

### Attachments


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
