### PR TITLE
EDSC-4114: Set the concatenate flag to harmony to false if it is unse…

### DIFF
--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -694,8 +694,8 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when supportsConcatenation = true and enableConcatenateDownload = true', () => {
-    test('constructs a payload containing concatenate = true', async () => {
+  describe('when the collection supports concatenation and it has been selected', () => {
+    test('constructed payload sets concatenation to true', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')
         .get('/search/granules.json?point%5B%5D=-77%2C%2034')
@@ -732,8 +732,8 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when supportsConcatenation = false or enableConcatenateDownload = false', () => {
-    test('constructed payload does not contain concatenate', async () => {
+  describe('when the collection supports concatenation but, it is not selected', () => {
+    test('constructed payload sets concatenation to false', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')
         .get('/search/granules.json?point%5B%5D=-77%2C%2034')
@@ -764,12 +764,14 @@ describe('constructOrderPayload', () => {
         accessToken
       })
 
-      expect(response.getAll('concatenate')).not.toEqual([
-        'true'
+      expect(response.getAll('concatenate')).toEqual([
+        'false'
       ])
     })
+  })
 
-    test('constructed payload does not contain concatenate', async () => {
+  describe('when the collection does not support concatenation', () => {
+    test('the constructed payload does not contain concatenate', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')
         .get('/search/granules.json?point%5B%5D=-77%2C%2034')
@@ -799,9 +801,7 @@ describe('constructOrderPayload', () => {
         accessToken
       })
 
-      expect(response.getAll('concatenate')).not.toEqual([
-        'true'
-      ])
+      expect(response.getAll('concatenate')).toEqual([])
     })
   })
 

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -732,7 +732,7 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when the accessMethod supports concatenation but, it is not selected', () => {
+  describe('when the accessMethod supports concatenation, but it is not selected', () => {
     test('constructed payload sets concatenation to false', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')

--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -694,7 +694,7 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when the collection supports concatenation and it has been selected', () => {
+  describe('when the accessMethod supports concatenation and it has been selected', () => {
     test('constructed payload sets concatenation to true', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')
@@ -732,7 +732,7 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when the collection supports concatenation but, it is not selected', () => {
+  describe('when the accessMethod supports concatenation but, it is not selected', () => {
     test('constructed payload sets concatenation to false', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')
@@ -770,7 +770,7 @@ describe('constructOrderPayload', () => {
     })
   })
 
-  describe('when the collection does not support concatenation', () => {
+  describe('when the accessMethod does not support concatenation', () => {
     test('the constructed payload does not contain concatenate', async () => {
       nock(/cmr/)
         .matchHeader('Authorization', 'Bearer access-token')

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -219,8 +219,8 @@ export const constructOrderPayload = async ({
   }
 
   // Adds supportsConcatenation to the payload and it's value
-  if (supportsConcatenation && enableConcatenateDownload) {
-    orderPayload.append('concatenate', true)
+  if (supportsConcatenation) {
+    orderPayload.append('concatenate', enableConcatenateDownload)
   }
 
   // Adds the selectedVariableNames if they were included in the access method


### PR DESCRIPTION
# Overview

### What is the feature?

Update the submitHarmonyOrder so that if concatenation is not selected pass the flag as `false` instead of not at all

### What is the Solution?

Update the logic so that we pass what the state of the checkbox is. It is being initialized to false already

### What areas of the application does this impact?

Harmony orders where concatenation is enabled

# Testing

### Reproduction steps

- **Environment for testing: PROD**
- **Collection to test with: C2930725014-LARC_CLOUD**

Ensure that with this collection and using the service we can submit a Harmony service that has concatenation and that the Harmony order (can be submitted locally with `npm run invoke-local -- --function submitHarmonyOrder --path ./event.json` where `event.json` is a mock of the order going to SQS.

### Attachments

I have attached my test documentation to the Jira ticket where I tried a number of different Harmony submissions from local machine with method above

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
