### PR TITLE
EDSC-4132: As a user, I'd like to not receive a message that I will be sent a confirmation email, if no confirmation email will be sent.

### DIFF
--- a/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
+++ b/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { parse } from 'qs'
 import { FaArrowCircleLeft } from 'react-icons/fa'
@@ -21,9 +21,6 @@ const ChunkedOrderModal = ({
   projectCollectionsMetadata,
   projectCollectionsRequiringChunking
 }) => {
-  console.log('🚀 ~ file: ChunkedOrderModal.js:24 ~ projectCollectionsMetadata:', projectCollectionsMetadata)
-  const [sendsEmails, setSendsEmails] = useState(true)
-
   const onModalClose = () => {
     onToggleChunkedOrderModal(false)
   }
@@ -63,9 +60,9 @@ const ChunkedOrderModal = ({
       Refine your search
     </PortalLinkContainer>
   )
-
+  // TODO Take out the outer div
   const body = (
-    <>
+    <div>
       {
         Object.keys(projectCollectionsRequiringChunking).length > 0 && (
           Object.keys(projectCollectionsRequiringChunking).map((collectionId, i) => {
@@ -87,56 +84,61 @@ const ChunkedOrderModal = ({
               accessMethods,
               selectedAccessMethod
             )
-            // Const isEchoOrdering = /echoOrder\d+$/
 
-            // TODO ESI does support emails
-            // const isEsi = /esi\d+$/
+            // Display notice for services which send confirmation emails
+            let sendsEmails = false
+            const isEchoOrdering = /echoOrderx\d+$/
+            const isEsi = /esi\d+$/
 
-            // If (selectedAccessMethod
-            //   && (isEchoOrdering.test(selectedAccessMethod) || isEsi.test(selectedAccessMethod))) {
-            //   setSendsEmails(true)
-            // }
+            if (selectedAccessMethod
+              && (isEchoOrdering.test(selectedAccessMethod) || isEsi.test(selectedAccessMethod))) {
+              sendsEmails = true
+            }
 
             const { [collectionId]: projectCollectionMetadata = {} } = projectCollectionsMetadata
             const { title } = projectCollectionMetadata
 
+            // TODO making the fragement an outer div and adding the key was getting rid of the warning
             return (
-              <p
-                key={key}
-                data-testid={key}
-              >
-                The collection
-                {' '}
-                <span className="chunked-order-modal__body-emphasis">{title}</span>
-                {' '}
-                contains
-                {' '}
-                <span className="chunked-order-modal__body-emphasis">{commafy(granuleCount)}</span>
-                {' '}
-                granules which exceeds the
-                {' '}
-                <span className="chunked-order-modal__body-emphasis">{commafy(granulesPerOrder)}</span>
-                {' '}
-                granule limit configured by the provider.
-                When submitted, the order will automatically be split into
-                {' '}
-                <span className="chunked-order-modal__body-strong">{`${orderCount} orders`}</span>
-                .
-              </p>
+              <div key={key}>
+                <p
+                  key={key}
+                  data-testid={key}
+                >
+                  The collection
+                  {' '}
+                  <span className="chunked-order-modal__body-emphasis">{title}</span>
+                  {' '}
+                  contains
+                  {' '}
+                  <span className="chunked-order-modal__body-emphasis">{commafy(granuleCount)}</span>
+                  {' '}
+                  granules which exceeds the
+                  {' '}
+                  <span className="chunked-order-modal__body-emphasis">{commafy(granulesPerOrder)}</span>
+                  {' '}
+                  granule limit configured by the provider.
+                  When submitted, the order will automatically be split into
+                  {' '}
+                  <span className="chunked-order-modal__body-strong">{`${orderCount} orders`}</span>
+                  .
+                </p>
+                {
+                  sendsEmails
+              && (
+                <p>
+                  Note: You will receive a separate set of confirmation emails
+                  for each order of these placed orders.
+                  {console.log('🚀 ~ file: ChunkedOrderModal.js:137 ~ ChunkedOrderModal ~ sendsEmails:', sendsEmails)}
+                </p>
+              )
+                }
+              </div>
             )
           })
         )
       }
-      {
-        sendsEmails
-      && (
-        <p>
-          Note: You will receive a separate set of confirmation emails for each order placed.
-          {console.log('🚀 ~ file: ChunkedOrderModal.js:137 ~ ChunkedOrderModal ~ sendsEmails:', sendsEmails)}
-        </p>
-      )
-      }
-    </>
+    </div>
   )
 
   return (

--- a/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
+++ b/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { parse } from 'qs'
 import { FaArrowCircleLeft } from 'react-icons/fa'
@@ -13,142 +13,148 @@ import { locationPropType } from '../../util/propTypes/location'
 
 import './ChunkedOrderModal.scss'
 
-export class ChunkedOrderModal extends Component {
-  constructor(props) {
-    super(props)
+const ChunkedOrderModal = ({
+  isOpen,
+  location,
+  onToggleChunkedOrderModal,
+  onSubmitRetrieval,
+  projectCollectionsMetadata,
+  projectCollectionsRequiringChunking
+}) => {
+  console.log('🚀 ~ file: ChunkedOrderModal.js:24 ~ projectCollectionsMetadata:', projectCollectionsMetadata)
+  const [sendsEmails, setSendsEmails] = useState(true)
 
-    this.onClickContinue = this.onClickContinue.bind(this)
-    this.onModalClose = this.onModalClose.bind(this)
-  }
-
-  onModalClose() {
-    const { onToggleChunkedOrderModal } = this.props
+  const onModalClose = () => {
     onToggleChunkedOrderModal(false)
   }
 
-  onClickContinue() {
-    const { onSubmitRetrieval, onToggleChunkedOrderModal } = this.props
-
+  const onClickContinue = () => {
     onToggleChunkedOrderModal(false)
     onSubmitRetrieval()
   }
 
-  render() {
-    const {
-      isOpen,
-      location,
-      onToggleChunkedOrderModal,
-      projectCollectionsMetadata,
-      projectCollectionsRequiringChunking
-    } = this.props
+  // Remove focused collection from back button params
+  const params = parse(location.search, {
+    ignoreQueryPrefix: true,
+    parseArrays: false
+  })
+  let { p = '' } = params
+  p = p.replace(/^[^!]*/, '')
 
-    // Remove focused collection from back button params
-    const params = parse(location.search, {
-      ignoreQueryPrefix: true,
-      parseArrays: false
-    })
-    let { p = '' } = params
-    p = p.replace(/^[^!]*/, '')
-
-    const backLink = (
-      <PortalLinkContainer
-        className="chunked-order-modal__action chunked-order-modal__action--secondary"
-        bootstrapVariant="primary"
-        type="button"
-        icon={FaArrowCircleLeft}
-        label="Refine your search"
-        onClick={() => onToggleChunkedOrderModal(false)}
-        to={
-          {
-            pathname: '/search',
-            search: stringify({
-              ...params,
-              p
-            })
-          }
-        }
-        updatePath
-      >
-        Refine your search
-      </PortalLinkContainer>
-    )
-
-    const body = (
-      <>
+  const backLink = (
+    <PortalLinkContainer
+      className="chunked-order-modal__action chunked-order-modal__action--secondary"
+      bootstrapVariant="primary"
+      type="button"
+      icon={FaArrowCircleLeft}
+      label="Refine your search"
+      onClick={() => onToggleChunkedOrderModal(false)}
+      to={
         {
-          Object.keys(projectCollectionsRequiringChunking).length > 0 && (
-            Object.keys(projectCollectionsRequiringChunking).map((collectionId, i) => {
-              const key = `chunked_order_message-${i}`
-
-              const { [collectionId]: projectCollection } = projectCollectionsRequiringChunking
-              const orderCount = calculateOrderCount(projectCollection)
-
-              const {
-                accessMethods = {},
-                granules = {},
-                selectedAccessMethod
-              } = projectCollection
-
-              const { hits: granuleCount } = granules
-
-              const granulesPerOrder = calculateGranulesPerOrder(
-                accessMethods,
-                selectedAccessMethod
-              )
-
-              const { [collectionId]: projectCollectionMetadata = {} } = projectCollectionsMetadata
-              const { title } = projectCollectionMetadata
-
-              return (
-                <p
-                  key={key}
-                  data-testid={key}
-                >
-                  The collection
-                  {' '}
-                  <span className="chunked-order-modal__body-emphasis">{title}</span>
-                  {' '}
-                  contains
-                  {' '}
-                  <span className="chunked-order-modal__body-emphasis">{commafy(granuleCount)}</span>
-                  {' '}
-                  granules which exceeds the
-                  {' '}
-                  <span className="chunked-order-modal__body-emphasis">{commafy(granulesPerOrder)}</span>
-                  {' '}
-                  granule limit configured by the provider.
-                  When submitted, the order will automatically be split into
-                  {' '}
-                  <span className="chunked-order-modal__body-strong">{`${orderCount} orders`}</span>
-                  .
-                </p>
-              )
-            })
-          )
+          pathname: '/search',
+          search: stringify({
+            ...params,
+            p
+          })
         }
+      }
+      updatePath
+    >
+      Refine your search
+    </PortalLinkContainer>
+  )
+
+  const body = (
+    <>
+      {
+        Object.keys(projectCollectionsRequiringChunking).length > 0 && (
+          Object.keys(projectCollectionsRequiringChunking).map((collectionId, i) => {
+            const key = `chunked_order_message-${i}`
+
+            const { [collectionId]: projectCollection } = projectCollectionsRequiringChunking
+            const orderCount = calculateOrderCount(projectCollection)
+
+            const {
+              accessMethods = {},
+              granules = {},
+              selectedAccessMethod
+            } = projectCollection
+            console.log('🚀 ~ file: ChunkedOrderModal.js:91 ~ ChunkedOrderModal ~ Object.keys ~ selectedAccessMethod:', selectedAccessMethod)
+
+            const { hits: granuleCount } = granules
+
+            const granulesPerOrder = calculateGranulesPerOrder(
+              accessMethods,
+              selectedAccessMethod
+            )
+            // Const isEchoOrdering = /echoOrder\d+$/
+
+            // TODO ESI does support emails
+            // const isEsi = /esi\d+$/
+
+            // If (selectedAccessMethod
+            //   && (isEchoOrdering.test(selectedAccessMethod) || isEsi.test(selectedAccessMethod))) {
+            //   setSendsEmails(true)
+            // }
+
+            const { [collectionId]: projectCollectionMetadata = {} } = projectCollectionsMetadata
+            const { title } = projectCollectionMetadata
+
+            return (
+              <p
+                key={key}
+                data-testid={key}
+              >
+                The collection
+                {' '}
+                <span className="chunked-order-modal__body-emphasis">{title}</span>
+                {' '}
+                contains
+                {' '}
+                <span className="chunked-order-modal__body-emphasis">{commafy(granuleCount)}</span>
+                {' '}
+                granules which exceeds the
+                {' '}
+                <span className="chunked-order-modal__body-emphasis">{commafy(granulesPerOrder)}</span>
+                {' '}
+                granule limit configured by the provider.
+                When submitted, the order will automatically be split into
+                {' '}
+                <span className="chunked-order-modal__body-strong">{`${orderCount} orders`}</span>
+                .
+              </p>
+            )
+          })
+        )
+      }
+      {
+        sendsEmails
+      && (
         <p>
           Note: You will receive a separate set of confirmation emails for each order placed.
+          {console.log('🚀 ~ file: ChunkedOrderModal.js:137 ~ ChunkedOrderModal ~ sendsEmails:', sendsEmails)}
         </p>
-      </>
-    )
+      )
+      }
+    </>
+  )
 
-    return (
-      <EDSCModalContainer
-        className="chunked-order"
-        id="chunked-order"
-        isOpen={isOpen}
-        onClose={this.onModalClose}
-        size="lg"
-        title="Per-order Granule Limit Exceeded"
-        body={body}
-        footerMeta={backLink}
-        primaryAction="Continue"
-        onPrimaryAction={this.onClickContinue}
-        secondaryAction="Change access methods"
-        onSecondaryAction={this.onModalClose}
-      />
-    )
-  }
+  return (
+    <EDSCModalContainer
+      className="chunked-order"
+      id="chunked-order"
+      isOpen={isOpen}
+      onClose={onModalClose}
+      size="lg"
+      title="Per-order Granule Limit Exceeded"
+      body={body}
+      footerMeta={backLink}
+      primaryAction="Continue"
+      onPrimaryAction={onClickContinue}
+      secondaryAction="Change access methods"
+      onSecondaryAction={onModalClose}
+    />
+  )
 }
 
 ChunkedOrderModal.propTypes = {

--- a/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
+++ b/static/src/js/components/ChunkedOrderModal/ChunkedOrderModal.js
@@ -45,7 +45,7 @@ const ChunkedOrderModal = ({
       type="button"
       icon={FaArrowCircleLeft}
       label="Refine your search"
-      onClick={() => onToggleChunkedOrderModal(false)}
+      onClick={onModalClose}
       to={
         {
           pathname: '/search',
@@ -60,7 +60,6 @@ const ChunkedOrderModal = ({
       Refine your search
     </PortalLinkContainer>
   )
-  // TODO Take out the outer div
   const body = (
     <div>
       {
@@ -76,7 +75,6 @@ const ChunkedOrderModal = ({
               granules = {},
               selectedAccessMethod
             } = projectCollection
-            console.log('🚀 ~ file: ChunkedOrderModal.js:91 ~ ChunkedOrderModal ~ Object.keys ~ selectedAccessMethod:', selectedAccessMethod)
 
             const { hits: granuleCount } = granules
 
@@ -87,7 +85,7 @@ const ChunkedOrderModal = ({
 
             // Display notice for services which send confirmation emails
             let sendsEmails = false
-            const isEchoOrdering = /echoOrderx\d+$/
+            const isEchoOrdering = /echoOrder\d+$/
             const isEsi = /esi\d+$/
 
             if (selectedAccessMethod
@@ -98,13 +96,12 @@ const ChunkedOrderModal = ({
             const { [collectionId]: projectCollectionMetadata = {} } = projectCollectionsMetadata
             const { title } = projectCollectionMetadata
 
-            // TODO making the fragement an outer div and adding the key was getting rid of the warning
             return (
-              <div key={key}>
-                <p
-                  key={key}
-                  data-testid={key}
-                >
+              <div
+                key={key}
+                data-testid={key}
+              >
+                <p>
                   The collection
                   {' '}
                   <span className="chunked-order-modal__body-emphasis">{title}</span>
@@ -124,14 +121,15 @@ const ChunkedOrderModal = ({
                   .
                 </p>
                 {
-                  sendsEmails
-              && (
-                <p>
-                  Note: You will receive a separate set of confirmation emails
-                  for each order of these placed orders.
-                  {console.log('🚀 ~ file: ChunkedOrderModal.js:137 ~ ChunkedOrderModal ~ sendsEmails:', sendsEmails)}
-                </p>
-              )
+                  sendsEmails && (
+                    <p>
+                      Note: You will receive a separate set of confirmation emails
+                      for each order in
+                      {' '}
+                      {title}
+                      .
+                    </p>
+                  )
                 }
               </div>
             )

--- a/static/src/js/components/ChunkedOrderModal/__tests__/ChunkedOrderModal.test.js
+++ b/static/src/js/components/ChunkedOrderModal/__tests__/ChunkedOrderModal.test.js
@@ -122,6 +122,54 @@ describe('ChunkedOrderModal component', () => {
     })
   })
 
+  describe('access methods email notice', () => {
+    const emailNotice = 'Note: You will receive a separate set of confirmation emails for each order in collection title.'
+    test('ordering shows the notice ', () => {
+      setup({
+        projectCollectionsRequiringChunking: {
+          'C100005-EDSC': {
+            granules: {
+              hits: 9001
+            },
+            selectedAccessMethod: 'echoOrder0'
+          }
+        }
+      })
+
+      expect(screen.getByText(emailNotice)).toBeInTheDocument()
+    })
+
+    test('esi shows the notice', () => {
+      setup({
+        projectCollectionsRequiringChunking: {
+          'C100005-EDSC': {
+            granules: {
+              hits: 9001
+            },
+            selectedAccessMethod: 'esi0'
+          }
+        }
+      })
+
+      expect(screen.getByText(emailNotice)).toBeInTheDocument()
+    })
+
+    test('harmony does no show the notice', () => {
+      setup({
+        projectCollectionsRequiringChunking: {
+          'C100005-EDSC': {
+            granules: {
+              hits: 9001
+            },
+            selectedAccessMethod: 'harmony0'
+          }
+        }
+      })
+
+      expect(screen.queryByText(emailNotice)).not.toBeInTheDocument()
+    })
+  })
+
   describe('modal actions', () => {
     test('\'Refine your search\' button should trigger onToggleChunkedOrderModal', async () => {
       const user = userEvent.setup()

--- a/static/src/js/containers/EDSCModalContainer/EDSCModalContainer.js
+++ b/static/src/js/containers/EDSCModalContainer/EDSCModalContainer.js
@@ -114,7 +114,7 @@ export class EDSCModalContainer extends Component {
 
         // If the element's type is a function then the element is a custom component, not a dom element
         // We can't add these props to dom elements
-        // This prevents usage of setModalOverlay and modealInnerRef on dom elements
+        // This prevents usage of setModalOverlay and modalInnerRef on dom elements
         if (typeof el.type === 'function') {
           returnObj = {
             setModalOverlay: (overlay) => {


### PR DESCRIPTION
# Overview

### What is the feature?

User did not want to see the notice for the confirmation emails when the access method does not support that functionality (for instance with Harmony). Also rewrote the component as a functional component for our continuous effort towards updating our class based components

### What is the Solution?

Rewrote the component into functional component minor changes to the `html` added a check for to include or not include the confirmation email paragraph

### What areas of the application does this impact?

The `chunkedOrderModal` component

# Testing

### Reproduction steps

1) Find collections with `> 2,000`
2) Add Selected Access method for `ordering(echo-orders)`  or/and for `esi` `C2564427300-NSIDC_ECS`
 or `C2750966856-NSIDC_ECS`
3) Ensure that when the modal for the chunked orders appear ensure that both of them have the notice for email confirmation
4) Repeat that with a service that does not have email confirmations such as `Harmony` but, ensure that the notice does **not** show up (can use `C1266136114-GES_DISC`) in prod
5) Ensure that the rest of the buttons/controllers on the modal work as expected
6) Ensure we don't have any warnings in the console

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

Harmony order example not showing the notice:
<img width="805" alt="image" src="https://github.com/nasa/earthdata-search/assets/34591886/5c7b75a5-2bdc-4e5f-8707-628fb38d58f9">

Multiple collections that need to be chunked and have confirmation email
<img width="801" alt="image" src="https://github.com/nasa/earthdata-search/assets/34591886/aa73c603-13a1-4ed2-943a-975e69a9c6e1">

A mix with both:
<img width="804" alt="image" src="https://github.com/nasa/earthdata-search/assets/34591886/d079c33f-6a93-408b-848f-053f5258be0c">


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
