### PR TITLE
EDSC-4134: Harmony Order status not updating when harmony is progressing with errors

### DIFF
--- a/sharedUtils/__tests__/orderStatus.test.js
+++ b/sharedUtils/__tests__/orderStatus.test.js
@@ -55,5 +55,11 @@ describe('aggregatedOrderStatus', () => {
         state: 'failed'
       }])).toEqual('failed')
     })
+
+    test('returns the correct state when complete for running errors', () => {
+      expect(aggregatedOrderStatus([{
+        state: 'running_with_errors'
+      }])).toEqual('in progress')
+    })
   })
 })

--- a/sharedUtils/orderStatus.js
+++ b/sharedUtils/orderStatus.js
@@ -39,6 +39,7 @@ export const orderStates = {
     'quoted',
     'quoting',
     'running',
+    'running_with_errors',
     'submitted_with_exceptions',
     'submitting',
     'validated'

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
@@ -107,7 +107,6 @@ describe('OrderStatus component', () => {
       expect(link).toBeInTheDocument()
     })
 
-    // TODO I'm not positive this is the same thing
     test('status link has correct href', () => {
       setup()
       const link = screen.getByRole('link', { name: 'Download Status and History' })

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.js
@@ -71,8 +71,7 @@ describe('OrderStatus component', () => {
     expect(onFetchRetrieval).toHaveBeenCalledWith('7', 'testToken')
   })
 
-  // TODO idk what this describe block means
-  describe('introduction', () => {
+  describe('Order Status page', () => {
     beforeEach(() => {
       jest.spyOn(config, 'getEnvironmentConfig').mockImplementation(() => ({ edscHost: 'http://localhost' }))
       jest.spyOn(config, 'getApplicationConfig').mockImplementation(() => ({
@@ -83,7 +82,6 @@ describe('OrderStatus component', () => {
 
     test('displays the correct text', () => {
       setup()
-      // http://localhost/downloads/7 or the Download Status and History page.
       expect(screen.getByText(/This page will automatically update as your orders are processed. The Download Status page can be accessed later by visiting/))
         .toBeInTheDocument()
 
@@ -131,8 +129,7 @@ describe('OrderStatus component', () => {
   describe('data links', () => {
     test('renders data links in a list', () => {
       setup()
-      // TODO there is only one link with the url but, there are other link attributes in the document
-      screen.getByRole('link', { name: 'http://linkurl.com/test' })
+      expect(screen.getByRole('link', { name: 'http://linkurl.com/test' })).toBeInTheDocument()
     })
   })
 
@@ -142,43 +139,16 @@ describe('OrderStatus component', () => {
       const relatedCollectionsHeading = screen.getByRole('heading', { name: 'You might also be interested in...' })
       expect(relatedCollectionsHeading).toBeInTheDocument()
       const listElements = screen.getAllByRole('list')
-      console.log('size of list', listElements.length)
+      // Several other list elements on DOM get the related collections list
       const relatedColList = listElements[3]
 
-      // Expect(within(relatedCollections).getByRole('link', { name: 'Test Title 1' })).toBeInTheDocument()
+      // Get list-items for each individual related collections
       const relatedCollections = within(relatedColList).getAllByRole('listitem')
 
       expect(relatedCollections.length).toEqual(3)
-      console.log('🚀 ~ file: OrderStatusRTL.test.js:203 ~ test ~ relatedCollections:', relatedCollections[0])
-
       expect(within(relatedCollections[0]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_3_111' })).toBeInTheDocument()
       expect(within(relatedCollections[1]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_2_111' })).toBeInTheDocument()
       expect(within(relatedCollections[2]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_1_111' })).toBeInTheDocument()
-      // Expect(within(relatedCollections[2]).getByText('Test Title 2'))
-      // expect(within(relatedCollections[1]).getByText('Test Title 3'))
-      // TODO for some reason this next one is failing but, I can see on the `screen its there for relatedCollections[3]
-      // expect(within(relatedCollections[2]).getByText('Test Title 3'))latedCollections[1])
-
-      // Console.log('🚀 ~ file: OrderStausRTL.test.js:194 ~ test ~ relatedCollections:', relatedCollections)
-      // expect(within(relatedCollections[1]).getByText('Test Title 1'))
-
-      // Expect(within(relatedCollections[0]).getByRole('link', { name: 'Test Title 1' })).toBeInTheDocument()
-      // expect(within(relatedCollections[1]).getByRole('link', { name: 'Test Title 2' })).toBeInTheDocument()
-      // expect(within(relatedCollections[2]).getByRole('link', { name: 'Test Title 3' })).toBeInTheDocument()
-
-      // Expect(within(relatedCollections).getByRole('link', { name: 'Test Title 2' })).toBeInTheDocument()
-      // expect(within(relatedCollections).getByRole('link', { name: 'Test Title 3' })).toBeInTheDocument()
-
-      // Console.log('🚀 ~ file: OrderStatusRTL.test.js:168 ~ test ~ relatedCollections:', relatedCollections)
-      // screen.getByRole(relatedCollections, 'listItem', { name: 'Test Title 1' })
-      // screen.getByRole(relatedCollections, 'link', { name: 'Test Title 1' })
-
-      // console.log('🚀 ~ file: OrderStatusRTL.test.js:167 ~ test ~ relatedCollections:', relatedCollections)
-
-      // Screen.getByRole('link', { name: 'Test Title 1' })
-      // screen.getByRole('link', { name: 'Test Title 2' })
-      // screen.getByRole('link', { name: 'Test Title 3' })
-      screen.debug()
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Adding a new state for Harmony orders `running_with_errors`. There were Harmony orders failing/going on indefinitely   because the status that Harmony was passing back was `running_with_errors` which the state machine was failing to transition from `in_progress` as a result the state went to `false` which caused errors.

### What is the Solution?

By updating the enum list of `in_progress` we can ensure that the state machine is able to transition between `in_progress` to `running_with_errors` correctly (`running_with_errors`) will resolve to EDSC as `in_progress` but, the status is coming from Harmony and we were not mapping it correctly

### What areas of the application does this impact?

AWS state machine for fetching the Harmony job status updates

# Testing

### Reproduction steps

- **Environment for testing: Prod**
- **Collection to test with: C2142776747-LPCLOUD**

Use a collection such as `[/search?p=!C2142776747-LPCLOUD&pg[1][v]=t&pg[1][gsk]=-start_date&pg[1][m]=harmony0&pg[1][uv]=V2837647271-LPCLOUD!V2837647276-LPCLOUD!V2837647281-LPCLOUD!V2837648090-LPCLOUD!V2837648094-LPCLOUD!V2837648097-LPCLOUD!V2837648585-LPCLOUD!V2837648626-LPCLOUD!V2837648667-LPCLOUD&pg[1][cd]=f&pg[1][ets]=t&pg[1][ess]=t&q=gedi%20L2B&qt=2021-01-01T00%3A00%3A00.000Z%2C2021-01-01T23%3A59%3A59.999Z&ff=Available%20in%20Earthdata%20Cloud&tl=1718376540!3!!](https://search.earthdata.nasa.gov/search?p=!C2142776747-LPCLOUD&pg%5B1%5D%5Bv%5D=t&pg%5B1%5D%5Bgsk%5D=-start_date&pg%5B1%5D%5Bm%5D=harmony0&pg%5B1%5D%5Buv%5D=V2837647271-LPCLOUD!V2837647276-LPCLOUD!V2837647281-LPCLOUD!V2837648090-LPCLOUD!V2837648094-LPCLOUD!V2837648097-LPCLOUD!V2837648585-LPCLOUD!V2837648626-LPCLOUD!V2837648667-LPCLOUD&pg%5B1%5D%5Bcd%5D=f&pg%5B1%5D%5Bets%5D=t&pg%5B1%5D%5Bess%5D=t&q=gedi%20L2B&qt=2021-01-01T00%3A00%3A00.000Z%2C2021-01-01T23%3A59%3A59.999Z&ff=Available%20in%20Earthdata%20Cloud&tl=1718376540!3!!)`
but, in the SIT env and choose some variables to subset on Harmony https://harmony.earthdata.nasa.gov/workflow-ui
for your login you should see this progress. At some point in the progress this is going to hit `running_with_errors` prior to this change `running_with_errors` would cause our state machine to error out. See attachments and/or logs from SIT env


### Attachments

Obfuscated passing while this was deployed in SIT:
![Pasted Graphic 3](https://github.com/nasa/earthdata-search/assets/34591886/838c5dd4-e720-4027-b9fa-85c1877e0471)

Obfuscated failing while this was not deployed in SIT:
![Pasted Graphic 4](https://github.com/nasa/earthdata-search/assets/34591886/be1bd94b-360e-4134-a602-3207e9624641)

![Pasted Graphic](https://github.com/nasa/earthdata-search/assets/34591886/6ac7d21a-f437-416d-b8bf-9ad3964a96b2)
Harmony state which would have resulted in errors on the state machine


Completed Order:
![image](https://github.com/nasa/earthdata-search/assets/34591886/1c377e54-9e8a-499c-96cc-847b800892c6)


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
