### PR TITLE
EDSC-4139: Fixes granule datepicker being partially hidden

### DIFF
--- a/static/src/js/components/Sidebar/SidebarSection.scss
+++ b/static/src/js/components/Sidebar/SidebarSection.scss
@@ -6,7 +6,6 @@
   border-radius: 0.25rem;
   border: 1px solid darken($color__black--200, 5);
   box-shadow: 0 0.25rem 0.75rem 0 rgba(0, 0, 0, 0.1);
-  overflow: hidden;
 
   &--padded {
     padding: 0.5*$spacer;


### PR DESCRIPTION
# Overview

### What is the feature?

The granule datepicker was being partially hidden when the parent container did not have enough room. 

### What is the Solution?

Removed `overflow: hidden;` from SidebarSection.scss

### What areas of the application does this impact?

Granule temporal searches

# Testing

http://localhost:8080/search/granules?p=C2069247359-GES_DISC

Ensure both start and end date picker are fully visible

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
