### PR TITLE
EDSC-4129, EDSC-4131: Fixes temporal selection bugs

### DIFF
--- a/static/src/js/components/Datepicker/Datepicker.js
+++ b/static/src/js/components/Datepicker/Datepicker.js
@@ -60,6 +60,7 @@ class Datepicker extends PureComponent {
   render() {
     const {
       isValidDate,
+      label,
       onBlur,
       onChange,
       picker,
@@ -79,7 +80,8 @@ class Datepicker extends PureComponent {
             id,
             placeholder: format,
             autoComplete: 'off',
-            className: `form-control ${size === 'sm' ? 'form-control-sm' : ''}`
+            className: `form-control ${size === 'sm' ? 'form-control-sm' : ''}`,
+            'aria-label': label
           }
         }
         isValidDate={isValidDate}
@@ -97,14 +99,16 @@ class Datepicker extends PureComponent {
 
 Datepicker.defaultProps = {
   format: 'YYYY-MM-DD HH:mm:ss',
+  label: '',
   size: '',
   value: '',
   viewMode: 'years'
 }
 
 Datepicker.propTypes = {
-  id: PropTypes.string.isRequired,
   format: PropTypes.string,
+  label: PropTypes.string,
+  id: PropTypes.string.isRequired,
   isValidDate: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
@@ -385,6 +385,20 @@ export const GranuleFiltersForm = (props) => {
                     setFieldValue('temporal.isRecurring', isChecked)
                     setFieldTouched('temporal.isRecurring', isChecked)
 
+                    // If recurring is checked and values exist, set the recurringDay values
+                    if (isChecked) {
+                      const newStartDate = moment(temporal.startDate || undefined).utc()
+                      if (temporal.startDate) {
+                        setFieldValue('temporal.recurringDayStart', newStartDate.dayOfYear())
+                      }
+
+                      const newEndDate = moment(temporal.endDate || undefined).utc()
+                      if (temporal.endDate) {
+                        // Use the start year to calculate the end day of year. This avoids leap years potentially causing day mismatches
+                        setFieldValue('temporal.recurringDayEnd', newEndDate.year(newStartDate.year()).dayOfYear())
+                      }
+                    }
+
                     setTimeout(() => {
                       handleSubmit()
                     }, 0)

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.js
@@ -408,21 +408,13 @@ export const GranuleFiltersForm = (props) => {
                   (value) => {
                     const { temporal: newTemporal } = values
 
-                    const newStartDate = moment(newTemporal.startDate || undefined).utc()
-                    newStartDate.set({
-                      year: value.min,
-                      hour: '00',
-                      minute: '00',
-                      second: '00'
-                    })
+                    const newStartDate = moment(newTemporal.startDate || undefined)
+                      .utc()
+                      .year(value.min)
 
-                    const newEndDate = moment(newTemporal.endDate || undefined).utc()
-                    newEndDate.set({
-                      year: value.max,
-                      hour: '23',
-                      minute: '59',
-                      second: '59'
-                    })
+                    const newEndDate = moment(newTemporal.endDate || undefined)
+                      .utc()
+                      .year(value.max)
 
                     setFieldValue('temporal.startDate', newStartDate.toISOString())
                     setFieldTouched('temporal.startDate')
@@ -431,7 +423,7 @@ export const GranuleFiltersForm = (props) => {
                     setFieldTouched('temporal.endDate')
 
                     setFieldValue('temporal.recurringDayStart', newStartDate.dayOfYear())
-                    setFieldValue('temporal.recurringDayEnd', newEndDate.dayOfYear())
+                    setFieldValue('temporal.recurringDayEnd', newEndDate.year(value.min).dayOfYear())
 
                     handleSubmit()
                   }
@@ -845,12 +837,12 @@ GranuleFiltersForm.propTypes = {
   setFieldValue: PropTypes.func.isRequired,
   touched: PropTypes.shape({
     cloudCover: PropTypes.shape({}),
-    gridCoords: PropTypes.string,
+    gridCoords: PropTypes.bool,
     orbitNumber: PropTypes.shape({}),
     equatorCrossingLongitude: PropTypes.shape({}),
     equatorCrossingDate: PropTypes.shape({}),
     temporal: PropTypes.shape({}),
-    readableGranuleName: PropTypes.string
+    readableGranuleName: PropTypes.bool
   }).isRequired,
   values: PropTypes.shape({
     browseOnly: PropTypes.bool,

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -251,6 +251,26 @@ describe('GranuleFiltersForm component', () => {
           expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 225)
           expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 226)
         })
+
+        test('calls the correct callbacks on onRecurringToggle when a leap day is involved', () => {
+          const { enzymeWrapper, props } = setup({
+            values: {
+              temporal: {
+                startDate: '2019-06-01T00:00:00.000Z',
+                endDate: '2024-06-01T23:59:59.999Z'
+              }
+            }
+          })
+          const temporalSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
+          temporalSection.find(TemporalSelection).prop('onRecurringToggle')({ target: { checked: true } })
+
+          expect(props.setFieldTouched).toHaveBeenCalledTimes(1)
+          expect(props.setFieldTouched).toHaveBeenCalledWith('temporal.isRecurring', true)
+          expect(props.setFieldValue).toHaveBeenCalledTimes(3)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.isRecurring', true)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 152)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 152)
+        })
       })
     })
 

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -231,6 +231,26 @@ describe('GranuleFiltersForm component', () => {
           expect(props.setFieldValue).toHaveBeenCalledTimes(1)
           expect(props.setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2019-08-14T23:59:59:999Z')
         })
+
+        test('calls the correct callbacks on onRecurringToggle', () => {
+          const { enzymeWrapper, props } = setup({
+            values: {
+              temporal: {
+                startDate: '2019-08-13T00:00:00.000Z',
+                endDate: '2019-08-14T23:59:59.999Z'
+              }
+            }
+          })
+          const temporalSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
+          temporalSection.find(TemporalSelection).prop('onRecurringToggle')({ target: { checked: true } })
+
+          expect(props.setFieldTouched).toHaveBeenCalledTimes(1)
+          expect(props.setFieldTouched).toHaveBeenCalledWith('temporal.isRecurring', true)
+          expect(props.setFieldValue).toHaveBeenCalledTimes(3)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.isRecurring', true)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 225)
+          expect(props.setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 226)
+        })
       })
     })
 

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.js
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.js
@@ -70,8 +70,11 @@ const TemporalSelectionDropdown = ({
     }
 
     if (existingIsRecurring) {
-      newTemporal.recurringDayStart = moment(existingStartDate).utc().dayOfYear()
-      newTemporal.recurringDayEnd = moment(existingEndDate).utc().dayOfYear()
+      newTemporal.recurringDayStart = `${moment(existingStartDate).utc().dayOfYear()}`
+
+      // Use the start year to calculate the end day of year. This avoids leap years potentially causing day mismatches
+      const startYear = moment(existingStartDate).utc().year()
+      newTemporal.recurringDayEnd = `${moment(existingEndDate).utc().year(startYear).dayOfYear()}`
     }
 
     onChangeQuery({
@@ -127,21 +130,13 @@ const TemporalSelectionDropdown = ({
         endDate: existingEndDate
       } = temporal
 
-      const newStartDate = moment(existingStartDate || undefined).utc()
-      newStartDate.set({
-        year: value.min,
-        hour: '00',
-        minute: '00',
-        second: '00'
-      })
+      const newStartDate = moment(existingStartDate || undefined)
+        .utc()
+        .year(value.min)
 
-      const newEndDate = moment(existingEndDate || undefined).utc()
-      newEndDate.set({
-        year: value.max,
-        hour: '23',
-        minute: '59',
-        second: '59'
-      })
+      const newEndDate = moment(existingEndDate || undefined)
+        .utc()
+        .year(value.max)
 
       setTemporal({
         ...temporal,

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -201,6 +202,59 @@ describe('TemporalSelectionDropdown component', () => {
           isRecurring: false,
           startDate: validStartDate,
           endDate: validEndDate
+        }
+      }
+    })
+
+    expect(onChangeQueryMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('applies the values for leap years onApplyClick', async () => {
+    const onChangeQueryMock = jest.fn()
+    const user = userEvent.setup()
+
+    setup({
+      onChangeQuery: onChangeQueryMock
+    })
+
+    const validStartDate = '2021-06-15 00:00:00'
+    const validEndDate = '2024-06-15 23:59:59'
+
+    await act(async () => {
+      await user.click(screen.getByRole('button'))
+    })
+
+    const startField = await screen.findByRole('textbox', { name: 'Start Date' })
+    const endField = await screen.findByRole('textbox', { name: 'End Date' })
+
+    // Select the start date
+    await user.click(startField)
+    await user.click((await screen.findAllByText('2021')).at(0))
+    await user.click(await screen.findByText('Jun'))
+    await user.click(await screen.findByText('15'))
+    expect(startField).toHaveValue(validStartDate)
+
+    // Select the end date
+    await user.click(endField)
+    await user.click((await screen.findAllByText('2024')).at(1))
+    await user.click(await screen.findByText('Jun'))
+    await user.click(await screen.findByText('15'))
+    expect(endField).toHaveValue(validEndDate)
+
+    // Select Recurring
+    await user.click(screen.getByLabelText('Recurring?'))
+
+    const applyBtn = screen.getByRole('button', { name: 'Apply' })
+    await user.click(applyBtn)
+
+    expect(onChangeQueryMock).toHaveBeenCalledWith({
+      collection: {
+        temporal: {
+          isRecurring: true,
+          startDate: '2021-06-15T00:00:00.000Z',
+          endDate: '2024-06-15T23:59:59.999Z',
+          recurringDayEnd: '166',
+          recurringDayStart: '166'
         }
       }
     })

--- a/static/src/js/components/TemporalSelection/TemporalSelection.js
+++ b/static/src/js/components/TemporalSelection/TemporalSelection.js
@@ -164,6 +164,7 @@ export class TemporalSelection extends Component {
                 </Form.Label>
                 <DatepickerContainer
                   id={`${controlId}__temporal-form__start-date`}
+                  label="Start Date"
                   onSubmit={(value) => onSubmitStart(value)}
                   type="start"
                   size={size}
@@ -183,6 +184,7 @@ export class TemporalSelection extends Component {
                 </Form.Label>
                 <DatepickerContainer
                   id={`${controlId}__temporal-form__end-date`}
+                  label="End Date"
                   onSubmit={(value) => onSubmitEnd(value)}
                   type="end"
                   size={size}

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.js
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.js
@@ -129,6 +129,7 @@ class DatepickerContainer extends Component {
     const {
       id,
       format,
+      label,
       size,
       viewMode
     } = this.props
@@ -149,6 +150,7 @@ class DatepickerContainer extends Component {
         id={id}
         format={format}
         isValidDate={this.isValidDate}
+        label={label}
         onBlur={this.onBlur}
         onChange={this.onChange}
         onClearClick={this.onClearClick}
@@ -164,6 +166,7 @@ class DatepickerContainer extends Component {
 
 DatepickerContainer.defaultProps = {
   format: 'YYYY-MM-DD HH:mm:ss',
+  label: '',
   maxDate: '',
   minDate: '',
   shouldValidate: true,
@@ -176,6 +179,7 @@ DatepickerContainer.defaultProps = {
 DatepickerContainer.propTypes = {
   format: PropTypes.string,
   id: PropTypes.string.isRequired,
+  label: PropTypes.string,
   maxDate: PropTypes.string,
   minDate: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,


### PR DESCRIPTION
# Overview

### What is the feature?

EDSC-4129: When toggling recurring temporal on for granule temporal, the days of the year were not being set. So if you had already put the start and end date in before selecting Recurring, no days were set, resulting in the UI looking correct, but the wrong query being sent to CMR.

EDSC-4131: If one of the recurring start/end years was a leap year and the day was after 2/28, the day of the year was not comparable to the other year. For example, June 1 2023 is not the same day of the year as June 1 2024 (leap year). This fix was to always calculate the day of the year based off the start year of the recurring range

### What areas of the application does this impact?

Recurring temporal, collection and granule level

# Testing

EDSC-4129: 
From the collection level temporal:
select a start date
select an end date
then check the Recurring checkbox
If you inspect the request sent to CMR, or view granules returned for a collection they should show the correct data

EDSC-4131: 
For collection level and granule level temporal:
select a start date
select an end date of the same day, with a different year
check Recurring checkbox
Change the range of the recurring slider to include one leap year and one standard year
Inspect the request sent to CMR, ensure that the last two parameters in the temporal query are the same number

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
