### PR TITLE
EDSC-3937: reverting how we validate datetimes so that we don't have unexpected bugs in the Vite feature.

### DIFF
--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -140,7 +140,7 @@ class DatepickerContainer extends Component {
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
     // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
-    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
+    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
 
     if (isValidISO) {
       value = moment.utc(value).format(format)

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -137,9 +137,9 @@ class DatepickerContainer extends Component {
     let { value } = this.props
 
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
-    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
+    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
 
     if (isValidISO) {

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -137,6 +137,7 @@ class DatepickerContainer extends Component {
     let { value } = this.props
 
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
+    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
     const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -139,7 +139,7 @@ class DatepickerContainer extends Component {
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
-    const isValidISO = moment.utc(value, moment.ISO_8601, true).isValid()
+    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
 
     if (isValidISO) {
       value = moment.utc(value).format(format)


### PR DESCRIPTION
# Overview

### What is the feature?

Small bugfix the resolves auto completing datetime bugs.

### What is the Solution?

changed the validation from moment.ISO_8601 to YYYY-MM-DDTHH:m:s.SSSZ

### What areas of the application does this impact?

List impacted areas.
Date picker text inputs.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Go to all datetime inputs in earthdata search
2. Observe no unexpected autocompletion or any buggieness in the behavior

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
