### PR TITLE
EDSC-3937 Hotfix: made the validation of a date during rendering use a regex datetime string. 

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -935,7 +935,7 @@ export class AccessMethod extends Component {
     } = temporal
 
     const temporalDateFormat = getTemporalDateFormat(isRecurring)
-    const format = moment.ISO_8601
+    const format = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 
     let startDateObject
     let endDateObject = moment.utc(endDate, format, true)

--- a/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetrics.test.js
+++ b/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetrics.test.js
@@ -79,6 +79,8 @@ describe('AdminRetrievals component', () => {
       const validEndDate = '2019-03-30T00:00:00.000Z'
       const validStartDate = '2019-03-29T00:00:00.000Z'
 
+      const updatedEndDate = '2019-03-30T23:59:59.999Z'
+
       const inputs = screen.getAllByRole('textbox')
 
       fireEvent.change(inputs[0], { target: { value: validStartDate } })
@@ -94,7 +96,7 @@ describe('AdminRetrievals component', () => {
       expect(onUpdateAdminMetricsRetrievalsStartDate).toHaveBeenCalledWith(validStartDate)
 
       expect(onUpdateAdminMetricsRetrievalsEndDate).toHaveBeenCalledTimes(1)
-      expect(onUpdateAdminMetricsRetrievalsEndDate).toHaveBeenCalledWith(validEndDate)
+      expect(onUpdateAdminMetricsRetrievalsEndDate).toHaveBeenCalledWith(updatedEndDate)
 
       expect(onFetchAdminMetricsRetrievals).toHaveBeenCalledTimes(1)
 
@@ -102,7 +104,7 @@ describe('AdminRetrievals component', () => {
       const endDateHeader = screen.getAllByRole('heading', { level: 5 })[1]
 
       expect(startDateHeader.textContent).toEqual(`Start Date:${validStartDate}`)
-      expect(endDateHeader.textContent).toEqual(`End Date:${validEndDate}`)
+      expect(endDateHeader.textContent).toEqual(`End Date:${updatedEndDate}`)
     })
   })
 })

--- a/static/src/js/components/Datepicker/Datepicker.jsx
+++ b/static/src/js/components/Datepicker/Datepicker.jsx
@@ -15,6 +15,7 @@ import './Datepicker.scss'
  * @param {Function} props.isValidDate - Callback function to determine if a date is valid
  * @param {Function} props.onBlur - Callback function to call when the field is blurred
  * @param {Function} props.onChange - Callback function to call when the field is changed
+ * @param {Function} props.onInputChange - Callback function to call when the input field is changed
  * @param {Function} props.onClearClick - Callback function to call when the clear button is clicked
  * @param {Function} props.onTodayClick - Callback function to call when the today button is clicked
  * @param {Node} props.picker - A ref for the datepicker
@@ -63,6 +64,7 @@ class Datepicker extends PureComponent {
       label,
       onBlur,
       onChange,
+      onInputChange,
       picker,
       size,
       value
@@ -81,7 +83,8 @@ class Datepicker extends PureComponent {
             placeholder: format,
             autoComplete: 'off',
             className: `form-control ${size === 'sm' ? 'form-control-sm' : ''}`,
-            'aria-label': label
+            'aria-label': label,
+            onChange: onInputChange
           }
         }
         isValidDate={isValidDate}
@@ -90,7 +93,7 @@ class Datepicker extends PureComponent {
         ref={picker}
         timeFormat={false}
         utc
-        value={value}
+        initialValue={value}
         initialViewMode={viewMode}
       />
     )
@@ -112,6 +115,7 @@ Datepicker.propTypes = {
   isValidDate: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
+  onInputChange: PropTypes.func.isRequired,
   onClearClick: PropTypes.func.isRequired,
   onTodayClick: PropTypes.func.isRequired,
   picker: PropTypes.oneOfType([

--- a/static/src/js/components/Datepicker/Datepicker.jsx
+++ b/static/src/js/components/Datepicker/Datepicker.jsx
@@ -85,7 +85,7 @@ class Datepicker extends PureComponent {
           }
         }
         isValidDate={isValidDate}
-        onBlur={onBlur}
+        onClose={onBlur}
         onChange={onChange}
         ref={picker}
         timeFormat={false}

--- a/static/src/js/components/Datepicker/Datepicker.jsx
+++ b/static/src/js/components/Datepicker/Datepicker.jsx
@@ -115,8 +115,8 @@ Datepicker.propTypes = {
   isValidDate: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  onInputChange: PropTypes.func.isRequired,
   onClearClick: PropTypes.func.isRequired,
+  onInputChange: PropTypes.func.isRequired,
   onTodayClick: PropTypes.func.isRequired,
   picker: PropTypes.oneOfType([
     // Either a function

--- a/static/src/js/components/Datepicker/__tests__/Datepicker.test.js
+++ b/static/src/js/components/Datepicker/__tests__/Datepicker.test.js
@@ -15,6 +15,7 @@ function setupMounted() {
     onBlur: jest.fn(),
     onChange: jest.fn(),
     onClearClick: jest.fn(),
+    onInputChange: jest.fn(),
     onTodayClick: jest.fn(),
     picker: React.createRef(),
     type: 'start',
@@ -38,6 +39,7 @@ function setupShallow() {
     onBlur: jest.fn(),
     onChange: jest.fn(),
     onClearClick: jest.fn(),
+    onInputChange: jest.fn(),
     onTodayClick: jest.fn(),
     picker: React.createRef(),
     value: '',
@@ -72,7 +74,7 @@ describe('Datepicker component', () => {
       enzymeWrapper.setProps({ value: '1988-09-0e 00:00:00' })
 
       const dateTime = enzymeWrapper.find(Datetime)
-      expect(dateTime.prop('value')).toEqual('1988-09-0e 00:00:00')
+      expect(dateTime.prop('initialValue')).toEqual('1988-09-0e 00:00:00')
     })
 
     test('handles ISO dates correctly', () => {
@@ -80,7 +82,7 @@ describe('Datepicker component', () => {
       enzymeWrapper.setProps({ value: '1988-09-03T00:00:00.000Z' })
 
       const dateTime = enzymeWrapper.find(Datetime)
-      expect(dateTime.prop('value')).toEqual('1988-09-03T00:00:00.000Z')
+      expect(dateTime.prop('initialValue')).toEqual('1988-09-03T00:00:00.000Z')
     })
   })
 

--- a/static/src/js/components/TemporalDisplay/TemporalDisplay.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalDisplay.jsx
@@ -48,7 +48,7 @@ export const TemporalDisplay = memo(({
     return null
   }
 
-  const format = moment.ISO_8601
+  const format = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
   const startDateObject = moment.utc(startDate, format, true)
   const endDateObject = moment.utc(endDate, format, true)
   const temporalStartDisplay = startDate

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownToggle.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownToggle.jsx
@@ -9,6 +9,7 @@ const TemporalSelectionDropdownToggle = ({ onToggleClick }) => (
   <Dropdown.Toggle
     variant="inline-block"
     id="temporal-selection-dropdown"
+    aria-label="temporal-selection-dropdown"
     className="search-form__button search-form__button--dark"
     onClick={onToggleClick}
   >

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
@@ -49,7 +49,7 @@ describe('TemporalSelectionDropdown component', () => {
     const user = userEvent.setup()
     setup({})
 
-    const btn = screen.getByRole('button')
+    const btn = screen.getByRole('button', { name: 'temporal-selection-dropdown' })
     expect(btn).toBeInTheDocument()
 
     await waitFor(async () => {
@@ -67,7 +67,7 @@ describe('TemporalSelectionDropdown component', () => {
     setup()
 
     await waitFor(async () => {
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'temporal-selection-dropdown' }))
     })
 
     const startDateInput = screen.getByRole('textbox', { name: 'Start Date' })
@@ -89,7 +89,7 @@ describe('TemporalSelectionDropdown component', () => {
     setup()
 
     await waitFor(async () => {
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'temporal-selection-dropdown' }))
     })
 
     const startDateInput = screen.getByRole('textbox', { name: 'Start Date' })
@@ -111,7 +111,7 @@ describe('TemporalSelectionDropdown component', () => {
     setup()
 
     await waitFor(async () => {
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'temporal-selection-dropdown' }))
     })
 
     const startDateInput = screen.getByRole('textbox', { name: 'Start Date' })
@@ -193,7 +193,7 @@ describe('TemporalSelectionDropdown component', () => {
     const expectedEndDate = '2019-03-30T23:59:59.999Z'
 
     await act(async () => {
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'temporal-selection-dropdown' }))
     })
 
     const startDateInput = screen.getByRole('textbox', { name: 'Start Date' })
@@ -238,7 +238,7 @@ describe('TemporalSelectionDropdown component', () => {
     const validEndDate = '2024-06-15 23:59:59'
 
     await act(async () => {
-      await user.click(screen.getByRole('button'))
+      await user.click(screen.getByRole('button', { name: 'temporal-selection-dropdown' }))
     })
 
     const startField = await screen.findByRole('textbox', { name: 'Start Date' })

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdown.test.js
@@ -156,9 +156,11 @@ describe('TemporalSelectionDropdown component', () => {
       await user.click(getByRole('button'))
     })
 
-    const inputs = getAllByRole('textbox')
-    expect(inputs[0].value).toBe(moment.utc(validStartDate).format('YYYY-MM-DD HH:mm:ss'))
-    expect(inputs[1].value).toBe(moment.utc(validEndDate).format('YYYY-MM-DD HH:mm:ss'))
+    const startDateInput = screen.getByRole('textbox', { name: 'Start Date' })
+    const endDateInput = screen.getByRole('textbox', { name: 'End Date' })
+
+    expect(startDateInput).toHaveValue(moment.utc(validStartDate).format('YYYY-MM-DD HH:mm:ss'))
+    expect(endDateInput).toHaveValue(moment.utc(validEndDate).format('YYYY-MM-DD HH:mm:ss'))
 
     const clearBtn = getAllByRole('button', { name: 'Clear' })[2]
     await waitFor(async () => {
@@ -169,9 +171,10 @@ describe('TemporalSelectionDropdown component', () => {
       await user.click(getByRole('button'))
     })
 
-    const updatedInputs = getAllByRole('textbox')
-    expect(updatedInputs[0].value).toBe('')
-    expect(updatedInputs[1].value).toBe('')
+    const updatedStartDateInput = screen.getByRole('textbox', { name: 'Start Date' })
+    const updatedEndtDateInput = screen.getByRole('textbox', { name: 'End Date' })
+    expect(updatedStartDateInput).toHaveValue('')
+    expect(updatedEndtDateInput).toHaveValue('')
 
     expect(onChangeQueryMock).toHaveBeenCalledTimes(1)
   })
@@ -201,8 +204,8 @@ describe('TemporalSelectionDropdown component', () => {
       await user.type(endDateInput, validEndDate)
     })
 
-    expect(startDateInput.value).toBe(moment.utc(validStartDate).format('YYYY-MM-DD HH:mm:ss'))
-    expect(endDateInput.value).toBe(moment.utc(validEndDate).endOf('day').format('YYYY-MM-DD HH:mm:ss'))
+    expect(startDateInput).toHaveValue(moment.utc(validStartDate).format('YYYY-MM-DD HH:mm:ss'))
+    expect(endDateInput).toHaveValue(moment.utc(validEndDate).endOf('day').format('YYYY-MM-DD HH:mm:ss'))
 
     const applyBtn = screen.getByRole('button', { name: 'Apply' })
 

--- a/static/src/js/components/TemporalSelection/TemporalSelection.jsx
+++ b/static/src/js/components/TemporalSelection/TemporalSelection.jsx
@@ -72,7 +72,7 @@ export class TemporalSelection extends Component {
    * @param {object} temporal - An object containing temporal values
    */
   checkTemporal(temporal) {
-    const format = moment.ISO_8601
+    const format = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
     const start = moment.utc(temporal.startDate, format, true)
 
     const end = moment.utc(temporal.endDate, format, true)

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -140,9 +140,10 @@ class DatepickerContainer extends Component {
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
     // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
-    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
+    // const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
+    const datetimeRegex = /^(\d{4})-(\d{2})-(\d{2})[T](\d{2}):(\d{2}):(\d{2}).(\d{3})[Z]$/
 
-    if (isValidISO) {
+    if (value.match(datetimeRegex)) {
       value = moment.utc(value).format(format)
     }
 

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -173,6 +173,7 @@ class DatepickerContainer extends Component {
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
+    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
 
     if (isValidISO) {

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -140,7 +140,7 @@ class DatepickerContainer extends Component {
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
     // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
-    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
+    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
 
     if (isValidISO) {
       value = moment.utc(value).format(format)

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -137,9 +137,9 @@ class DatepickerContainer extends Component {
     let { value } = this.props
 
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
-    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
+    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
 
     if (isValidISO) {

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -137,6 +137,7 @@ class DatepickerContainer extends Component {
     let { value } = this.props
 
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
+    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
     const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -57,6 +57,8 @@ class DatepickerContainer extends Component {
         valueToSet = value.startOf('day')
       } else if (type === 'end') {
         valueToSet = value.endOf('day')
+      } else {
+        valueToSet = value
       }
     } else {
       valueToSet = moment.utc(value, format, true)
@@ -171,8 +173,7 @@ class DatepickerContainer extends Component {
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
-    // We are using YYYY-MM-DDTHH:m:s.SSSZ instead of moment.ISO_8601 so that it doesn't autocomplete every time there's a valid ISO format
-    const isValidISO = moment.utc(value, moment.ISO_8601, true).isValid()
+    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true).isValid()
 
     if (isValidISO) {
       value = moment.utc(value).format(format)

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -139,7 +139,7 @@ class DatepickerContainer extends Component {
     // A valid date will come be passed as an ISO string. Check to see if the date is a valid ISO string,
     // if so, we convert it to a UTC string in our desired format. If the value is not a valid ISO date,
     // then we leave it untouched and pass it to the input.
-    const isValidISO = moment.utc(value, moment.ISO_8601, true).isValid()
+    const isValidISO = moment.utc(value, 'YYYY-MM-DDTHH:m:s.SSSZ', true).isValid()
 
     if (isValidISO) {
       value = moment.utc(value).format(format)

--- a/static/src/js/containers/DatepickerContainer/__tests__/DatepickerContainer.test.js
+++ b/static/src/js/containers/DatepickerContainer/__tests__/DatepickerContainer.test.js
@@ -37,7 +37,7 @@ describe('DatepickerContainer component', () => {
       enzymeWrapper.instance().picker.current = {}
       enzymeWrapper.instance().picker.current.setState = jest.fn()
 
-      enzymeWrapper.instance().onBlur()
+      enzymeWrapper.instance().onBlur('1988-09-03 00:00:00')
 
       expect(enzymeWrapper.instance().picker.current.setState).toHaveBeenCalledTimes(1)
       expect(enzymeWrapper.instance().picker.current.setState)


### PR DESCRIPTION
# Overview

### What is the feature?

Make the datetime picker behave as it used to before the Vite changes

### What is the Solution?

Made the validation of a date during rendering use a regex datetime string.

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**localhost
- **Collection to test with:**N/A

1. Go to all datetime inputs in earthdata search
2. Observe no unexpected autocompletion or any buggieness in the behavior

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
