### PR TITLE
EDSC-4212: Fix the minify exception when running with invoke-local; Add workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ This will provide access to API Gateway at [http://localhost:3001](http://localh
 
 Additionally, this ties in with the `serverless webpack` plugin which will ensure that your lambdas are re-built when changes are detected.
 
+### Invoking lambdas locally
+
+To invoke lambdas locally we must create a stringified JSON file with the order information to the specific lambda we are trying to run the structure of the events will differ between the lambda. Typically this will include data from your local database instance which is used in the event information.
+
+    npm run invoke-local -- --function <name-of-lambda-function> --path ./event.json
+
 ### Run the Automated [Jest](https://jestjs.io/) tests
 
 Once the project is built, you must ensure that the automated unit tests pass:

--- a/serverless.yml
+++ b/serverless.yml
@@ -191,8 +191,9 @@ custom:
     # https://github.com/dherault/serverless-offline#run-modes
     # useInProcess: true
 
-  # Don't minify the build in development
+  # Don't minify the build in development or when invoking lambdas locally
   minifyBuild:
+    invokeLocal: false
     dev: false
     sit: true
     uat: true


### PR DESCRIPTION
…dd documentation for running lambdas

# Overview

### What is the feature?

This fixes an issue on `esbuild` where if you run lambda's locally we are not able to fire this off because the build is getting minified. This is because the stage is getting resolved to `invokeLocal`

### What is the Solution?

Update the map for whether to minify or not with `invokeLocal` as an option and make it false if that is the case

### What areas of the application does this impact?

Local development workflows for running lambdas on dev machines

# Testing

### Reproduction steps

- **Environment for testing:*Local Only*
- **Collection to test with:**

1. Create a Harmony order on EDSC locally
2. Submit the Harmony order via `npm run invoke-local -- --function fetchHarmonyOrder --path ./event.json`
Where the `event.json` is some file that includes `{
  "Records": [
      {
          "body": {
              "accessToken": "",
              "id": 1
          }
      }
  ]
}`

id is going to be the latest (or whichever matches the Harmony submission you did) id value on the RDS for the retrieval_orders table and the accessToken is the JWT token associated to the order (should be in the corresponding `retrievals` table if you follow the foreign keys) 

3. This event we either need to disable the JSON.parse on the lambda or otherwise stringify the event above.

4. Once submitted check that it worked on `https://harmony.earthdata.nasa.gov/workflow-ui` (this is PROD Harmony, but, its just whatever env your harmony order was made in)

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
