### PR TITLE
EDSC-4073: Fix link styling in downloads page

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatusItem/BrowseLinksPanel.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/BrowseLinksPanel.scss
@@ -4,12 +4,12 @@
     margin: 0;
     padding: 0;
     list-style: none;
-  }
 
-  li {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+    li {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   &__pre {

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.scss
@@ -4,12 +4,12 @@
     margin: 0;
     padding: 0;
     list-style: none;
-  }
 
-  li {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+    li {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   &__pre {

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.scss
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.scss
@@ -1,4 +1,4 @@
-.download-files-panel {
+.download-files-panel, .download-links-panel {
   &__list {
     line-height: 1.625rem;
     margin: 0;

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadScriptPanel.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadScriptPanel.jsx
@@ -7,6 +7,8 @@ import { commafy } from '../../../util/commafy'
 
 import TextWindowActions from '../../TextWindowActions/TextWindowActions'
 
+import './DownloadFilesPanel.scss'
+
 /**
  * Renders DownloadScriptPanel.
  * @param {Object} arg0 - The props passed into the component.

--- a/static/src/js/components/OrderStatus/OrderStatusItem/S3LinksPanel.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/S3LinksPanel.jsx
@@ -8,6 +8,8 @@ import { commafy } from '../../../util/commafy'
 import TextWindowActions from '../../TextWindowActions/TextWindowActions'
 import CopyableText from '../../CopyableText/CopyableText'
 
+import './DownloadFilesPanel.scss'
+
 /**
  * Renders S3LinksPanel.
  * @param {Object} arg0 - The props passed into the component.


### PR DESCRIPTION
# Overview

### What is the feature?

Previous updates to the link styling included some regressions in the format of links on the download page. This addresses link formatting for four different panels of the download page.

### What is the Solution?

- Direct download links no longer wrap
- S3 links no longer wrap and no longer have bullets
- Browse imagery links no longer wrap
- The margin on the bottom of the download script panel is slightly different

### What areas of the application does this impact?

Download page

# Testing

### Reproduction steps

- **Collection to test with:**
  - `C1256568253-EEDTEST` in **UAT** is an example collection that has browse imagery
  - `C1692982070-GES_DISC` in **PROD** is an example collection with S3 links

### Attachments

#### Download links before:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/09d20811-d835-4410-8557-150fa73e52b2">


#### Download links after this PR:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/13467a51-0c94-4195-8572-d4bd6e291fb1">


#### S3 links before:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/7a658925-86b8-4235-8477-3f491732bb92">


#### S3 links after this PR:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/6e5d5785-ea4b-416a-85d1-0e7622e8dda3">


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
