### PR TITLE
EDSC-4217: Fixing focused granule thumbnail bug

### DIFF
--- a/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
@@ -336,13 +336,13 @@ const GranuleResultsFocusedMeta = ({
                         }
                       ])
                       const imgSrc = `${getEnvironmentConfig().apiHost}/scale/granules/${focusedGranuleId}?h=175&w=175&imageSrc=${href}`
+                      const key = `thumb-${href}-${i}`
 
                       return (
                         href && (
                           <EDSCImage
-                            key={href}
+                            key={key}
                             className={thumbnailClassName}
-                            dataTestId="granule-results-focused-meta-image"
                             src={imgSrc}
                             alt={description || `Browse image for ${title}`}
                             width={175}
@@ -383,18 +383,18 @@ const GranuleResultsFocusedMeta = ({
                       }
                     ])
 
-                    const modalImage = `${getEnvironmentConfig().apiHost}/scale/granules/${focusedGranuleId}?h=175&w=175&imageSrc=${href}`
+                    const modalImage = `${getEnvironmentConfig().apiHost}/scale/granules/${focusedGranuleId}?h=538&w=538&imageSrc=${href}`
+                    const key = `modal-${href}-${i}`
 
                     return (
                       href && (
                         <EDSCImage
-                          key={href}
-                          dataTestId="granule-results-focused-meta-modal-image"
+                          key={key}
                           className={thumbnailClassName}
                           src={modalImage}
                           alt={description || `Browse image for ${title}`}
-                          width={528}
-                          height={528}
+                          width={538}
+                          height={538}
                           isBase64Image
                         />
                       )

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsFocusedMeta.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsFocusedMeta.test.js
@@ -10,7 +10,11 @@ import {
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
+import EDSCImage from '../../EDSCImage/EDSCImage'
+
 import GranuleResultsFocusedMeta from '../GranuleResultsFocusedMeta'
+
+jest.mock('../../EDSCImage/EDSCImage', () => jest.fn(({ className }) => <div className={className} data-testid="mock-edsc-image">EDSC Image</div>))
 
 const setup = (overrideProps) => {
   const onMetricsBrowseGranuleImage = jest.fn()
@@ -34,6 +38,10 @@ const setup = (overrideProps) => {
 }
 
 describe('GranuleResultsFocusedMeta component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('when no links are provided', () => {
     test('should not render', () => {
       setup()
@@ -287,7 +295,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(nextButton)
           })
 
-          const images = await screen.findAllByTestId('granule-results-focused-meta-image')
+          const images = await screen.findAllByTestId('mock-edsc-image')
           const pagination = screen.queryByText('2/3')
 
           expect(images.length).toEqual(3)
@@ -334,7 +342,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(prevButton)
           })
 
-          const images = screen.queryAllByTestId('granule-results-focused-meta-image')
+          const images = screen.queryAllByTestId('mock-edsc-image')
           const pagination = screen.queryByText('1/3')
 
           expect(images.length).toEqual(3)
@@ -386,7 +394,7 @@ describe('GranuleResultsFocusedMeta component', () => {
           await user.click(popoverListItem)
 
           const pagination = screen.queryByText('3/3')
-          const images = screen.queryAllByTestId('granule-results-focused-meta-image')
+          const images = screen.queryAllByTestId('mock-edsc-image')
 
           expect(popoverList).not.toBeInTheDocument()
           expect(images[2]).toHaveClass('granule-results-focused-meta__thumb--is-active')
@@ -427,7 +435,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(nextButton)
           })
 
-          const images = screen.queryAllByTestId('granule-results-focused-meta-image')
+          const images = screen.queryAllByTestId('mock-edsc-image')
           const pagination = screen.queryByText('1/2')
 
           expect(images.length).toEqual(2)
@@ -462,7 +470,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(prevButton)
           })
 
-          const images = screen.queryAllByTestId('granule-results-focused-meta-image')
+          const images = screen.queryAllByTestId('mock-edsc-image')
           const pagination = screen.queryByText('2/2')
 
           expect(images.length).toEqual(2)
@@ -509,6 +517,39 @@ describe('GranuleResultsFocusedMeta component', () => {
           expect(modalPrev).toBeInTheDocument()
           expect(modalNext).toBeInTheDocument()
           expect(modalPopoverButton).toBeInTheDocument()
+        })
+
+        test('displays a larger image', async () => {
+          const user = userEvent.setup()
+
+          setup({
+            focusedGranuleMetadata: {
+              browseFlag: true,
+              links: [{
+                href: 'http://test.com/test.jpg',
+                rel: 'http://esipfed.org/ns/fedsearch/1.1/browse#'
+              }],
+              title: '1234 Test'
+            }
+          })
+
+          const expandButton = screen.getByLabelText('Expand browse image')
+
+          expect(EDSCImage).toHaveBeenCalledTimes(1)
+
+          EDSCImage.mockClear()
+
+          await act(async () => {
+            await user.click(expandButton)
+          })
+
+          const modal = await screen.findByTestId('granule-results-focused-meta-modal')
+          const image = within(modal).getByTestId('mock-edsc-image')
+
+          expect(image).toBeInTheDocument()
+          expect(EDSCImage).toHaveBeenLastCalledWith(expect.objectContaining({
+            src: expect.stringContaining('/scale/granules/G-1234-TEST?h=538&w=538&imageSrc=http://test.com/test.jpg')
+          }), {})
         })
 
         describe('when clicking the close button', () => {
@@ -588,7 +629,7 @@ describe('GranuleResultsFocusedMeta component', () => {
 
             await user.click(modalNext)
 
-            const images = within(modal).queryAllByTestId('granule-results-focused-meta-modal-image')
+            const images = within(modal).queryAllByTestId('mock-edsc-image')
             const pagination = within(modal).queryByText('2/3')
 
             expect(images.length).toEqual(3)
@@ -641,7 +682,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(modalNext)
             await user.click(modalPrev)
 
-            const images = within(modal).queryAllByTestId('granule-results-focused-meta-modal-image')
+            const images = within(modal).queryAllByTestId('mock-edsc-image')
             const pagination = within(modal).queryByText('1/3')
 
             expect(images.length).toEqual(3)
@@ -701,7 +742,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(popoverListItem)
 
             const pagination = within(modal).queryByText('3/3')
-            const images = within(modal).queryAllByTestId('granule-results-focused-meta-modal-image')
+            const images = within(modal).queryAllByTestId('mock-edsc-image')
 
             expect(popoverList).not.toBeInTheDocument()
             expect(images[2]).toHaveClass('granule-results-focused-meta__full--is-active')
@@ -747,7 +788,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             await user.click(modalNext)
             await user.click(modalNext)
 
-            const images = within(modal).queryAllByTestId('granule-results-focused-meta-modal-image')
+            const images = within(modal).queryAllByTestId('mock-edsc-image')
             const pagination = within(modal).queryByText('1/2')
 
             expect(images.length).toEqual(2)
@@ -832,7 +873,7 @@ describe('GranuleResultsFocusedMeta component', () => {
             })
 
             await waitFor(() => {
-              const images = within(modal).queryAllByTestId('granule-results-focused-meta-modal-image')
+              const images = within(modal).queryAllByTestId('mock-edsc-image')
               const pagination = within(modal).queryByText('2/2')
 
               expect(images.length).toEqual(2)


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes an issue where we were displaying a smaller focused granule thumbnail image than intended

### What is the Solution?

Changed the url parameters on the image request to a larger size

### What areas of the application does this impact?

Focused granule thumbnail in the expanded view

# Testing

### Reproduction steps

- **Environment for testing:** UAT
- **Collection to test with:** C1262899924-LARC_CLOUD

This UAT url should focus the granule:
/search/granules?p=C1262899924-LARC_CLOUD&pg[0][v]=f&pg[0][id]=TEMPO_CLDO4_L2_V03_20240808T000113Z_S016G05.nc&pg[0][gsk]=-start_date&ee=uat&g=G1268712859-LARC_CLOUD&q=TEMPO_CLDO4_L2_V03&tl=1723642935!3!!&lat=39.3046875&long=-53.71875

1. Focus a granule
2. View the expanded granule thumbnail
3. Confirm a 538 x 538px image is displayed

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
