### PR TITLE
EDSC-4079: Subsetting Issue When Downloading Granules from Earthdata Search

### DIFF
--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -200,6 +200,11 @@ export const getProjectCollections = () => async (dispatch, getState) => {
       action: 'getProjectCollections',
       resource: 'saved access configurations'
     }))
+
+    // If we know that the user is unauthorized and we need to redirect to EDL, stop here.
+    if (error.message?.includes('401')) {
+      return null
+    }
   }
 
   const collectionParams = prepareCollectionParams(state)


### PR DESCRIPTION
# Overview

### What is the feature?

When a user is unauthorized, either because they are not logged in or otherwise, and they select granule filters and attempt to downloaded, upon redirect to the project page then subsequent redirect to EDL then again back to the project, the filters they had selected can be dropped.

### What is the Solution?

When loading the project page, we now abort the process at the savedAccessConfigs request when a 401 is returned, instead of continuing down to the graphQl call after.  Having both requests being made and fail with 401 is what was ultimately causing the confusion with the redirects.

### What areas of the application does this impact?

project page

# Testing

### Reproduction steps

In any environment,

1. Select some granules from download while not logged in.
2. Press the download button to progress to the project page.
3. Once redirected to EDL login, enter in credentials and submit (to be redirected back)
4. Verify your granule filters are intact.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
