### PR TITLE
EDSC-4079: error status code check change

### DIFF
--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -202,7 +202,9 @@ export const getProjectCollections = () => async (dispatch, getState) => {
     }))
 
     // If we know that the user is unauthorized and we need to redirect to EDL, stop here.
-    if (error.message?.includes('401')) {
+    console.log('🚀 ~ getProjectCollections ~ error:', error)
+    console.log('🚀 ~ getProjectCollections ~ error.response.status:', error.response.status)
+    if (error.response.status === 401) {
       return null
     }
   }

--- a/static/src/js/actions/project.js
+++ b/static/src/js/actions/project.js
@@ -202,8 +202,6 @@ export const getProjectCollections = () => async (dispatch, getState) => {
     }))
 
     // If we know that the user is unauthorized and we need to redirect to EDL, stop here.
-    console.log('🚀 ~ getProjectCollections ~ error:', error)
-    console.log('🚀 ~ getProjectCollections ~ error.response.status:', error.response.status)
     if (error.response.status === 401) {
       return null
     }

--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
@@ -8,6 +8,7 @@ import { Tooltip, OverlayTrigger } from 'react-bootstrap'
 import { getApplicationConfig, getEnvironmentConfig } from '../../../../../sharedUtils/config'
 
 import { commafy } from '../../util/commafy'
+import { isLoggedIn } from '../../util/isLoggedIn'
 import { stringify } from '../../util/url/url'
 import { locationPropType } from '../../util/propTypes/location'
 
@@ -33,7 +34,6 @@ export const GranuleDownloadButton = (props) => {
 
   const { disableDatabaseComponents } = getApplicationConfig()
   const { apiHost } = getEnvironmentConfig()
-  const isLoggedIn = authToken !== ''
 
   if (tooManyGranules) {
     return (
@@ -126,7 +126,7 @@ export const GranuleDownloadButton = (props) => {
     variant: 'full'
   }
 
-  if (!isLoggedIn) {
+  if (!isLoggedIn(authToken)) {
     const projectPath = `${window.location.protocol}//${window.location.host}/projects${stringifiedProjectParams}`
 
     return (

--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
@@ -108,40 +108,35 @@ export const GranuleDownloadButton = (props) => {
     }
   }
 
+  const stringifiedProjectParams = stringify({
+    ...params,
+    p,
+    pg
+  })
+
+  const downloadButtonProps = {
+    badge,
+    bootstrapVariant: 'primary',
+    className: 'granule-results-actions__download-all',
+    dataTestId: 'granule-results-actions__download-all-button',
+    disabled: granuleCount === 0 || initialLoading || disableDatabaseComponents === 'true',
+    icon: Download,
+    label: buttonText,
+    type: 'button',
+    variant: 'full'
+  }
+
   if (!isLoggedIn) {
-    const projectPath = `${window.location.protocol}//${window.location.host}/projects${stringify({
-      ...params,
-      p,
-      pg
-    })}`
+    const projectPath = `${window.location.protocol}//${window.location.host}/projects${stringifiedProjectParams}`
 
     return (
       <PortalLinkContainer
-        className="granule-results-actions__download-all"
+        {...downloadButtonProps}
         onClick={
           () => {
-            onAddProjectCollection(focusedCollectionId)
-            onChangePath(`${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(projectPath)}`)
+            window.location.href = `${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(projectPath)}`
           }
         }
-        to={
-          {
-            pathname: '/projects',
-            search: stringify({
-              ...params,
-              p,
-              pg
-            })
-          }
-        }
-        type="button"
-        badge={badge}
-        bootstrapVariant="primary"
-        dataTestId="granule-results-actions__download-all-button"
-        disabled={granuleCount === 0 || initialLoading || (disableDatabaseComponents === 'true')}
-        icon={Download}
-        label={buttonText}
-        variant="full"
       >
         {buttonText}
       </PortalLinkContainer>
@@ -150,35 +145,19 @@ export const GranuleDownloadButton = (props) => {
 
   return (
     <PortalLinkContainer
-      className="granule-results-actions__download-all"
+      {...downloadButtonProps}
       onClick={
         () => {
           onAddProjectCollection(focusedCollectionId)
-          onChangePath(`/projects${stringify({
-            ...params,
-            p,
-            pg
-          })}`)
+          onChangePath(`/projects${stringifiedProjectParams}`)
         }
       }
       to={
         {
           pathname: '/projects',
-          search: stringify({
-            ...params,
-            p,
-            pg
-          })
+          search: stringifiedProjectParams
         }
       }
-      type="button"
-      badge={badge}
-      bootstrapVariant="primary"
-      dataTestId="granule-results-actions__download-all-button"
-      disabled={granuleCount === 0 || initialLoading || (disableDatabaseComponents === 'true')}
-      icon={Download}
-      label={buttonText}
-      variant="full"
     >
       {buttonText}
     </PortalLinkContainer>

--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
@@ -5,7 +5,7 @@ import { Download } from '@edsc/earthdata-react-icons/horizon-design-system/hds/
 import { parse } from 'qs'
 import { Tooltip, OverlayTrigger } from 'react-bootstrap'
 
-import { getApplicationConfig } from '../../../../../sharedUtils/config'
+import { getApplicationConfig, getEnvironmentConfig } from '../../../../../sharedUtils/config'
 
 import { commafy } from '../../util/commafy'
 import { stringify } from '../../util/url/url'
@@ -16,8 +16,10 @@ import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLink
 
 export const GranuleDownloadButton = (props) => {
   const {
+    authToken,
     badge,
     buttonText,
+    earthdataEnvironment,
     focusedCollectionId,
     granuleCount,
     granuleLimit,
@@ -30,6 +32,8 @@ export const GranuleDownloadButton = (props) => {
   } = props
 
   const { disableDatabaseComponents } = getApplicationConfig()
+  const { apiHost } = getEnvironmentConfig()
+  const isLoggedIn = authToken !== ''
 
   if (tooManyGranules) {
     return (
@@ -104,6 +108,46 @@ export const GranuleDownloadButton = (props) => {
     }
   }
 
+  if (!isLoggedIn) {
+    const projectPath = `${window.location.protocol}//${window.location.host}/projects${stringify({
+      ...params,
+      p,
+      pg
+    })}`
+
+    return (
+      <PortalLinkContainer
+        className="granule-results-actions__download-all"
+        onClick={
+          () => {
+            onAddProjectCollection(focusedCollectionId)
+            onChangePath(`${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(projectPath)}`)
+          }
+        }
+        to={
+          {
+            pathname: '/projects',
+            search: stringify({
+              ...params,
+              p,
+              pg
+            })
+          }
+        }
+        type="button"
+        badge={badge}
+        bootstrapVariant="primary"
+        dataTestId="granule-results-actions__download-all-button"
+        disabled={granuleCount === 0 || initialLoading || (disableDatabaseComponents === 'true')}
+        icon={Download}
+        label={buttonText}
+        variant="full"
+      >
+        {buttonText}
+      </PortalLinkContainer>
+    )
+  }
+
   return (
     <PortalLinkContainer
       className="granule-results-actions__download-all"
@@ -148,11 +192,13 @@ GranuleDownloadButton.defaultProps = {
 }
 
 GranuleDownloadButton.propTypes = {
+  authToken: PropTypes.string.isRequired,
   badge: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node
   ]),
   buttonText: PropTypes.string.isRequired,
+  earthdataEnvironment: PropTypes.string.isRequired,
   focusedCollectionId: PropTypes.string.isRequired,
   granuleCount: PropTypes.number,
   granuleLimit: PropTypes.number,

--- a/static/src/js/components/GranuleResults/GranuleResultsActions.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsActions.jsx
@@ -39,7 +39,9 @@ import './GranuleResultsActions.scss'
  * @param {Function} onRemoveCollectionFromProject - Callback to remove the collection from the project.
  */
 const GranuleResultsActions = ({
+  authToken,
   addedGranuleIds,
+  earthdataEnvironment,
   focusedCollectionId,
   focusedProjectCollection,
   granuleLimit,
@@ -119,8 +121,10 @@ const GranuleResultsActions = ({
 
   const downloadButton = (
     <GranuleDownloadButton
+      authToken={authToken}
       badge={badge}
       buttonText={buttonText}
+      earthdataEnvironment={earthdataEnvironment}
       focusedCollectionId={focusedCollectionId}
       granuleCount={granuleCount}
       granuleLimit={granuleLimit}
@@ -230,7 +234,9 @@ GranuleResultsActions.defaultProps = {
 }
 
 GranuleResultsActions.propTypes = {
+  authToken: PropTypes.string.isRequired,
   addedGranuleIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  earthdataEnvironment: PropTypes.string.isRequired,
   focusedCollectionId: PropTypes.string.isRequired,
   focusedProjectCollection: PropTypes.shape({}).isRequired,
   granuleLimit: PropTypes.number,

--- a/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
@@ -81,17 +81,20 @@ describe('GranuleDownloadButton component', () => {
     describe('when there are no other pg parameters in the URL', () => {
       describe('when the user is not logged in', () => {
         test('clicking the button calls onAddProjectCollection and onChangePath to EDL', () => {
-          const { enzymeWrapper, props } = setup({ authToken: '' })
+          const { enzymeWrapper } = setup({ authToken: '' })
           const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+          delete window.location
+          window.location = {
+            href: 'http://localhost',
+            protocol: 'http:',
+            host: 'localhost'
+          }
 
           expect(portalLinkContainer.props().disabled).toBeFalsy()
 
           portalLinkContainer.props().onClick()
-
-          expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
-          expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
-          expect(props.onChangePath).toHaveBeenCalledTimes(1)
-          expect(props.onChangePath).toHaveBeenCalledWith('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26ff%3DMap%2520Imagery%26pg%5B1%5D%5Bv%5D%3Dt')
+          expect(window.location.href).toEqual('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26ff%3DMap%2520Imagery%26pg%5B1%5D%5Bv%5D%3Dt')
         })
       })
 
@@ -114,7 +117,7 @@ describe('GranuleDownloadButton component', () => {
     describe('when there are some pg parameters in the URL', () => {
       describe('when the user is not logged in', () => {
         test('clicking the button calls onAddProjectCollection and onChangePath to EDL', () => {
-          const { enzymeWrapper, props } = setup({
+          const { enzymeWrapper } = setup({
             authToken: '',
             location: {
               pathname: '/search/granules',
@@ -123,14 +126,18 @@ describe('GranuleDownloadButton component', () => {
           })
           const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
 
+          delete window.location
+          window.location = {
+            href: 'http://localhost',
+            protocol: 'http:',
+            host: 'localhost'
+          }
+
           expect(portalLinkContainer.props().disabled).toBeFalsy()
 
           portalLinkContainer.props().onClick()
 
-          expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
-          expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
-          expect(props.onChangePath).toHaveBeenCalledTimes(1)
-          expect(props.onChangePath).toHaveBeenCalledWith('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26pg%5B1%5D%5Bgsk%5D%3Dstart_date%26pg%5B1%5D%5Bv%5D%3Dt%26ff%3DMap%2520Imagery')
+          expect(window.location.href).toEqual('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26pg%5B1%5D%5Bgsk%5D%3Dstart_date%26pg%5B1%5D%5Bv%5D%3Dt%26ff%3DMap%2520Imagery')
         })
       })
 

--- a/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleDownloadButton.test.js
@@ -11,8 +11,10 @@ Enzyme.configure({ adapter: new Adapter() })
 
 function setup(overrideProps) {
   const props = {
+    authToken: 'token',
     badge: '294 Granules',
     buttonText: 'Download All',
+    earthdataEnvironment: 'prod',
     focusedCollectionId: 'collectionId',
     granuleCount: 294,
     granuleLimit: 1000000,
@@ -77,6 +79,22 @@ describe('GranuleDownloadButton component', () => {
 
   describe('when the collection is not in the project', () => {
     describe('when there are no other pg parameters in the URL', () => {
+      describe('when the user is not logged in', () => {
+        test('clicking the button calls onAddProjectCollection and onChangePath to EDL', () => {
+          const { enzymeWrapper, props } = setup({ authToken: '' })
+          const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+          expect(portalLinkContainer.props().disabled).toBeFalsy()
+
+          portalLinkContainer.props().onClick()
+
+          expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
+          expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
+          expect(props.onChangePath).toHaveBeenCalledTimes(1)
+          expect(props.onChangePath).toHaveBeenCalledWith('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26ff%3DMap%2520Imagery%26pg%5B1%5D%5Bv%5D%3Dt')
+        })
+      })
+
       test('clicking the button calls onAddProjectCollection and onChangePath', () => {
         const { enzymeWrapper, props } = setup()
 
@@ -94,6 +112,28 @@ describe('GranuleDownloadButton component', () => {
     })
 
     describe('when there are some pg parameters in the URL', () => {
+      describe('when the user is not logged in', () => {
+        test('clicking the button calls onAddProjectCollection and onChangePath to EDL', () => {
+          const { enzymeWrapper, props } = setup({
+            authToken: '',
+            location: {
+              pathname: '/search/granules',
+              search: '?p=collectionId&pg[0][gsk]=start_date&ff=Map%20Imagery'
+            }
+          })
+          const portalLinkContainer = enzymeWrapper.find(PortalLinkContainer)
+
+          expect(portalLinkContainer.props().disabled).toBeFalsy()
+
+          portalLinkContainer.props().onClick()
+
+          expect(props.onAddProjectCollection).toHaveBeenCalledTimes(1)
+          expect(props.onAddProjectCollection).toHaveBeenCalledWith('collectionId')
+          expect(props.onChangePath).toHaveBeenCalledTimes(1)
+          expect(props.onChangePath).toHaveBeenCalledWith('http://localhost:3000/login?ee=prod&state=http%3A%2F%2Flocalhost%2Fprojects%3Fp%3DcollectionId!collectionId%26pg%5B1%5D%5Bgsk%5D%3Dstart_date%26pg%5B1%5D%5Bv%5D%3Dt%26ff%3DMap%2520Imagery')
+        })
+      })
+
       test('clicking the button calls onAddProjectCollection and onChangePath', () => {
         const { enzymeWrapper, props } = setup({
           location: {

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsActions.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsActions.test.js
@@ -10,6 +10,7 @@ Enzyme.configure({ adapter: new Adapter() })
 
 function setup(overrideProps) {
   const props = {
+    authToken: 'token',
     addedGranuleIds: [],
     focusedProjectCollection: {
       granules: {
@@ -19,6 +20,7 @@ function setup(overrideProps) {
     },
     removedGranuleIds: [],
     allGranulesInProject: false,
+    earthdataEnvironment: 'prod',
     focusedCollectionId: 'collectionId',
     granuleLimit: 10000000,
     searchGranuleCount: 5000,

--- a/static/src/js/components/OrderStatus/OrderStatus.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatus.jsx
@@ -22,7 +22,7 @@ import './OrderStatus.scss'
 /**
  * Renders a RelatedCollection.
  * @param {Object} props - The props passed into the component.
- * @param {String} props.authToken - The accessMethods of the current collection.
+ * @param {String} props.authToken - The authToken for the logged in user.
  * @param {String} props.earthdataEnvironment - The accessMethods of the current collection.
  * @param {Object} props.granuleDownload - Data pertaining to the status of the granule download for a retrieval collection.
  * @param {Object} props.location - Location passed from react router.

--- a/static/src/js/components/SearchPanels/SearchPanels.jsx
+++ b/static/src/js/components/SearchPanels/SearchPanels.jsx
@@ -18,6 +18,7 @@ import Helmet from 'react-helmet'
 
 import { commafy } from '../../util/commafy'
 import { pluralize } from '../../util/pluralize'
+import { isLoggedIn } from '../../util/isLoggedIn'
 import { getHandoffLinks } from '../../util/handoffs/getHandoffLinks'
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
 import { collectionSortKeys } from '../../constants/collectionSortKeys'
@@ -170,7 +171,7 @@ class SearchPanels extends PureComponent {
       preferences
     } = this.props
 
-    const isLoggedIn = !(authToken === null || authToken === '')
+    const loggedIn = isLoggedIn(authToken)
 
     const {
       pageNum: granulesPageNum = 1,
@@ -363,7 +364,7 @@ class SearchPanels extends PureComponent {
         }
       ])
 
-      return isLoggedIn && (
+      return loggedIn && (
         <div className="search-panels__actions">
           <PortalFeatureContainer authentication>
             <AuthRequiredContainer noRedirect>
@@ -393,7 +394,7 @@ class SearchPanels extends PureComponent {
 
     let subscriptionsMoreActionsItem = []
 
-    if (isLoggedIn) {
+    if (loggedIn) {
       subscriptionsMoreActionsItem = [
         {
           title: 'Subscriptions',

--- a/static/src/js/containers/GranuleResultsActionsContainer/GranuleResultsActionsContainer.jsx
+++ b/static/src/js/containers/GranuleResultsActionsContainer/GranuleResultsActionsContainer.jsx
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom'
 
 import actions from '../../actions'
 
+import { getEarthdataEnvironment } from '../../selectors/earthdataEnvironment'
 import { getFocusedCollectionGranuleQuery } from '../../selectors/query'
 import { getFocusedCollectionGranuleResults } from '../../selectors/collectionResults'
 import { getFocusedCollectionId } from '../../selectors/focusedCollection'
@@ -34,8 +35,10 @@ export const mapDispatchToProps = (dispatch) => ({
 })
 
 export const mapStateToProps = (state) => ({
+  authToken: state.authToken,
   collectionMetadata: getFocusedCollectionMetadata(state),
   collectionQuery: state.query.collection,
+  earthdataEnvironment: getEarthdataEnvironment(state),
   focusedCollectionId: getFocusedCollectionId(state),
   focusedProjectCollection: getFocusedProjectCollection(state),
   granuleQuery: getFocusedCollectionGranuleQuery(state),
@@ -47,8 +50,10 @@ export const mapStateToProps = (state) => ({
 
 export const GranuleResultsActionsContainer = (props) => {
   const {
+    authToken,
     collectionMetadata,
     collectionQuery,
+    earthdataEnvironment,
     focusedCollectionId,
     focusedProjectCollection,
     granuleQuery,
@@ -103,7 +108,9 @@ export const GranuleResultsActionsContainer = (props) => {
 
   return (
     <GranuleResultsActions
+      authToken={authToken}
       addedGranuleIds={addedGranuleIds}
+      earthdataEnvironment={earthdataEnvironment}
       focusedCollectionId={focusedCollectionId}
       focusedProjectCollection={focusedProjectCollection}
       granuleLimit={granuleLimit}
@@ -125,8 +132,10 @@ export const GranuleResultsActionsContainer = (props) => {
 }
 
 GranuleResultsActionsContainer.propTypes = {
+  authToken: PropTypes.string.isRequired,
   collectionMetadata: PropTypes.shape({}).isRequired,
   collectionQuery: PropTypes.shape({}).isRequired,
+  earthdataEnvironment: PropTypes.string.isRequired,
   focusedCollectionId: PropTypes.string.isRequired,
   focusedProjectCollection: PropTypes.shape({
     granules: PropTypes.shape({})

--- a/static/src/js/containers/GranuleResultsActionsContainer/__tests__/GranuleResultsActionsContainer.test.js
+++ b/static/src/js/containers/GranuleResultsActionsContainer/__tests__/GranuleResultsActionsContainer.test.js
@@ -14,6 +14,7 @@ Enzyme.configure({ adapter: new Adapter() })
 
 function setup() {
   const props = {
+    authToken: 'token',
     location: {
       search: 'value'
     },
@@ -21,6 +22,7 @@ function setup() {
       mock: 'data'
     },
     collectionQuery: {},
+    earthdataEnvironment: 'prod',
     focusedCollectionId: 'focusedCollection',
     focusedProjectCollection: {
       accessMethods: {},
@@ -142,6 +144,7 @@ describe('mapDispatchToProps', () => {
 describe('mapStateToProps', () => {
   test('returns the correct state', () => {
     const store = {
+      authToken: 'token',
       metadata: {
         collections: {
           collectionId: {
@@ -149,6 +152,7 @@ describe('mapStateToProps', () => {
           }
         }
       },
+      earthdataEnvironment: 'prod',
       focusedCollection: 'collectionId',
       focusedGranule: 'granuleId',
       query: {
@@ -162,10 +166,12 @@ describe('mapStateToProps', () => {
     }
 
     const expectedState = {
+      authToken: 'token',
       collectionMetadata: {
         subscriptions: []
       },
       collectionQuery: {},
+      earthdataEnvironment: 'prod',
       focusedCollectionId: 'collectionId',
       focusedProjectCollection: {},
       granuleQuery: {},

--- a/static/src/js/util/__tests__/isLoggedIn.test.js
+++ b/static/src/js/util/__tests__/isLoggedIn.test.js
@@ -1,0 +1,21 @@
+import { isLoggedIn } from '../isLoggedIn'
+
+describe('isLoggedIn', () => {
+  describe('when provided an empty string', () => {
+    test('returns false', () => {
+      expect(isLoggedIn('')).toEqual(false)
+    })
+  })
+
+  describe('when provided non empty string', () => {
+    test('returns true', () => {
+      expect(isLoggedIn('token')).toEqual(true)
+    })
+  })
+
+  describe('when provided null', () => {
+    test('returns false', () => {
+      expect(isLoggedIn(null)).toEqual(false)
+    })
+  })
+})

--- a/static/src/js/util/isLoggedIn.js
+++ b/static/src/js/util/isLoggedIn.js
@@ -1,0 +1,8 @@
+/**
+ * Returns true if the authToken is not empty
+ * @return {boolean}
+ */
+
+export const isLoggedIn = (authToken) => !(authToken === null || authToken === '')
+
+export default isLoggedIn

--- a/static/src/js/util/isLoggedIn.js
+++ b/static/src/js/util/isLoggedIn.js
@@ -1,5 +1,6 @@
 /**
- * Returns true if the authToken is not empty
+ * Returns true if the authToken is not empty.
+ * @param {String} authToken - The authToken for the logged in user.
  * @return {boolean}
  */
 


### PR DESCRIPTION
# Overview

### What is the feature?

When a user is unauthorized, either because they are not logged in or otherwise, and they select granule filters and attempt to downloaded, upon redirect to the project page then subsequent redirect to EDL then again back to the project, the filters they had selected can be dropped.

### What is the Solution?

Refactored the granule download button to send the user to a login page directly when they are trying to download granules while not logged in, instead of relying on failed subsequent calls on the project page that required authentication.

### What areas of the application does this impact?

Granule download button.

# Testing

### Reproduction steps

In any environment,

1. Select some granules from download while not logged in.
2. Press the download button to progress to the project page.
3. Once redirected to EDL login, enter in credentials and submit (to be redirected back)
4. Verify your granule filters are intact(or that they are not there if fix is not in).

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
