### PR TITLE
EDSC-4240: Improve the granule filters tool-tips accessibility and content

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -206,7 +206,6 @@ custom:
     external: ['knex', 'pg', 'sharp']
     bundle: true
     minify: ${self:custom.minifyBuild.${self:provider.stage}}
-    # exclude: ['./node_modules/*', '*.test.js']
     watch:
       ignore: ['.esbuild', 'dist', 'node_modules', '.build', 'static', "*.test.js"]
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -206,6 +206,9 @@ custom:
     external: ['knex', 'pg', 'sharp']
     bundle: true
     minify: ${self:custom.minifyBuild.${self:provider.stage}}
+    # exclude: ['./node_modules/*', '*.test.js']
+    watch:
+      ignore: ['.esbuild', 'dist', 'node_modules', '.build', 'static', "*.test.js"]
 
   # Manage resource count (Maximum of 200) by splitting up the cloudformation templates
   splitStacks:

--- a/serverless.yml
+++ b/serverless.yml
@@ -207,7 +207,7 @@ custom:
     bundle: true
     minify: ${self:custom.minifyBuild.${self:provider.stage}}
     watch:
-      ignore: ['.esbuild', 'dist', 'node_modules', '.build', 'static', "*.test.js"]
+      ignore: ['.esbuild', 'dist', 'node_modules', '.build', 'static', '*.test.js']
 
   # Manage resource count (Maximum of 200) by splitting up the cloudformation templates
   splitStacks:

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -273,7 +273,7 @@ export const GranuleFiltersForm = (props) => {
                 <Form.Group
                   controlId="granule-filters_granule-search"
                 >
-                  <Form.Label className="mb-1" sm="auto">
+                  <Form.Label className="mb-1" sm="auto" aria-describedby="View more info on granule id filter">
                     Granule ID(s)
                   </Form.Label>
                   <OverlayTrigger
@@ -322,7 +322,7 @@ export const GranuleFiltersForm = (props) => {
                       )
                     }
                   >
-                    <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" aria-label="View more info on granule id filter" role="img" />
+                    <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" aria-label="A question mark in a circle" role="img" />
                   </OverlayTrigger>
                   <Form.Control
                     name="readableGranuleName"
@@ -700,7 +700,6 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
-                            aria-label="Set minimum orbit number"
                             name="orbitNumber.min"
                             data-testid="granule-filters__orbit-number-min"
                             type="text"
@@ -732,7 +731,6 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
-                            aria-label="Set maximum orbit number"
                             name="orbitNumber.max"
                             data-testid="granule-filters__orbit-number-max"
                             type="text"
@@ -754,7 +752,6 @@ export const GranuleFiltersForm = (props) => {
                         </Col>
                       </Form.Group>
                     </SidebarFiltersItem>
-
                     <SidebarFiltersItem
                       heading="Equatorial Crossing Longitude"
                     >
@@ -770,7 +767,6 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.min"
-                            aria-label="Set minimum equator crossing longitude"
                             data-testid="granule-filters__equatorial-crossing-longitude-min"
                             type="text"
                             size="sm"
@@ -804,7 +800,6 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.max"
-                            aria-label="Set maximum equator crossing longitude"
                             data-testid="granule-filters__equatorial-crossing-longitude-max"
                             type="text"
                             size="sm"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -573,7 +573,6 @@ export const GranuleFiltersForm = (props) => {
                       <Col>
                         <Form.Group controlId="granule-filters__day-night-flag">
                           <Form.Control
-                            aria-label="Select day/night flag"
                             name="dayNightFlag"
                             data-testid="granule-filters__day-night-flag"
                             as="select"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -273,7 +273,7 @@ export const GranuleFiltersForm = (props) => {
                 <Form.Group
                   controlId="granule-filters_granule-search"
                 >
-                  <Form.Label className="mb-1" sm="auto" aria-describedby="View more info on granule id filter">
+                  <Form.Label className="mb-1" sm="auto">
                     Granule ID(s)
                   </Form.Label>
                   <OverlayTrigger
@@ -751,6 +751,7 @@ export const GranuleFiltersForm = (props) => {
                         </Col>
                       </Form.Group>
                     </SidebarFiltersItem>
+
                     <SidebarFiltersItem
                       heading="Equatorial Crossing Longitude"
                     >
@@ -826,7 +827,7 @@ export const GranuleFiltersForm = (props) => {
                     <SidebarFiltersItem
                       heading="Equatorial Crossing Date"
                     >
-                      <Form.Group aria-label="Set granule equatorial crossing date" controlId="granule-filters__equatorial-crossing-date">
+                      <Form.Group controlId="granule-filters__equatorial-crossing-date">
                         <Form.Control
                           as="div"
                           className="form-control-basic"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -10,7 +10,6 @@ import {
 } from 'react-bootstrap'
 import { FaQuestionCircle } from 'react-icons/fa'
 import moment from 'moment'
-import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
 import { findGridByName } from '../../util/grid'
 import { getTemporalDateFormat } from '../../../../../sharedUtils/edscDate'
@@ -21,6 +20,7 @@ import SidebarFiltersItem from '../Sidebar/SidebarFiltersItem'
 import SidebarFiltersList from '../Sidebar/SidebarFiltersList'
 import TemporalSelection from '../TemporalSelection/TemporalSelection'
 import Button from '../Button/Button'
+import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
 import './GranuleFiltersForm.scss'
 
@@ -281,7 +281,7 @@ export const GranuleFiltersForm = (props) => {
                     overlay={
                       (
                         <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">
-                          <p className="font-weight-lighter">
+                          <p>
                             Filter granules by using a granule ID.
                             Enter an ID to find an exact match or use a wildcard
                             and/or delimiter to search using a more complex query.
@@ -290,14 +290,14 @@ export const GranuleFiltersForm = (props) => {
                             Search granules using wildcard characters
                           </strong>
                           <ul className="m-0 font-size granule-filters-form__readable-granule-name-tooltip-list">
-                            <li className="font-weight-lighter">
+                            <li>
                               Question marks
                               {' ('}
                               <strong className="font-weight-bold">?</strong>
                               {') '}
                               match a single character in that location
                             </li>
-                            <li className="font-weight-lighter">
+                            <li>
                               Asterisks
                               {' ('}
                               <strong className="font-weight-bold">*</strong>
@@ -310,7 +310,7 @@ export const GranuleFiltersForm = (props) => {
                             Search granules using multiple IDs
                           </strong>
                           <ul className="m-0 granule-filters-form__readable-granule-name-tooltip-list">
-                            <li className="font-weight-lighter">
+                            <li>
                               Commas
                               {' ('}
                               <strong className="font-weight-bold">,</strong>

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -283,7 +283,7 @@ export const GranuleFiltersForm = (props) => {
                     overlay={
                       (
                         <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">
-                          <p>
+                          <p className="font-weight-lighter">
                             Filter granules by using a granule ID.
                             Enter an ID to find an exact match or use a wildcard
                             and/or delimiter to search using a more complex query.
@@ -291,12 +291,20 @@ export const GranuleFiltersForm = (props) => {
                           <strong className="granule-filters-form__readable-granule-name-tooltip-title">
                             Search granules using wildcard characters
                           </strong>
-                          <ul className="m-0 granule-filters-form__readable-granule-name-tooltip-list">
-                            <li>
-                              Question marks (?) match a single character in that location
+                          <ul className="m-0 font-size granule-filters-form__readable-granule-name-tooltip-list">
+                            <li className="font-weight-lighter">
+                              Question marks
+                              {' ('}
+                              <strong className="font-weight-bold">?</strong>
+                              {') '}
+                              match a single character in that location
                             </li>
-                            <li>
-                              Asterisks (*) match any number of characters in that location
+                            <li className="font-weight-lighter">
+                              Asterisks
+                              {' ('}
+                              <strong className="font-weight-bold">*</strong>
+                              {') '}
+                              match any number of characters in that location
                             </li>
                           </ul>
                           <br />
@@ -304,8 +312,12 @@ export const GranuleFiltersForm = (props) => {
                             Search granules using multiple IDs
                           </strong>
                           <ul className="m-0 granule-filters-form__readable-granule-name-tooltip-list">
-                            <li>
-                              Commas (,) are used separate multiple searches
+                            <li className="font-weight-lighter">
+                              Commas
+                              {' ('}
+                              <strong className="font-weight-bold">,</strong>
+                              {') '}
+                              are used to separate multiple searches
                             </li>
                           </ul>
                         </Tooltip>

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -279,25 +279,35 @@ export const GranuleFiltersForm = (props) => {
 
                   <OverlayTrigger
                     placement="top"
+                    show
                     overlay={
                       (
                         <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">
-                          Filter granules by name
-                          <br />
-                          <strong>Wildcards:</strong>
-                          {' '}
-                          <ul className="m-0">
+                          <p>
+                            Filter granules by using a granule ID.
+                            Enter an ID to find an exact match or use a wildcard
+                            and/or delimiter to search using a more complex query.
+                          </p>
+                          <strong className="granule-filters-form__readable-granule-name-tooltip-title">
+                            Search granules using wildcard characters
+                          </strong>
+                          <ul className="m-0 granule-filters-form__readable-granule-name-tooltip-list">
                             <li>
-                              * (asterisk) matches any number of characters
+                              Question marks (?) match a single character in that location
                             </li>
                             <li>
-                              ? (question mark) matches exactly one character.
+                              Asterisks (*) match any number of characters in that location
                             </li>
                           </ul>
                           <br />
-                          <strong>Delimiters:</strong>
-                          {' '}
-                          Separate multiple granule IDs by commas.
+                          <strong className="granule-filters-form__readable-granule-name-tooltip-title">
+                            Search granules using multiple IDs
+                          </strong>
+                          <ul className="m-0 granule-filters-form__readable-granule-name-tooltip-list">
+                            <li>
+                              Commas (,) are used separate multiple searches
+                            </li>
+                          </ul>
                         </Tooltip>
                       )
                     }
@@ -309,7 +319,7 @@ export const GranuleFiltersForm = (props) => {
                     data-testid="granule-filters__readable-granule-name"
                     size="sm"
                     type="text"
-                    placeholder="Search Single or Multiple Granule IDs..."
+                    placeholder="Example: *_20240101_*,*_20240101_*"
                     value={readableGranuleName}
                     onChange={handleChange}
                     onBlur={submitOnBlur}

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -279,7 +279,6 @@ export const GranuleFiltersForm = (props) => {
 
                   <OverlayTrigger
                     placement="top"
-                    show
                     overlay={
                       (
                         <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -283,7 +283,6 @@ export const GranuleFiltersForm = (props) => {
                       (
                         <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">
                           Filter granules by name
-                          example: UA_bonan*
                           <br />
                           <strong>Wildcards:</strong>
                           {' '}
@@ -303,7 +302,7 @@ export const GranuleFiltersForm = (props) => {
                       )
                     }
                   >
-                    <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" />
+                    <EDSCIcon title="granule-name-filter-more-info" icon={FaQuestionCircle} size="0.625rem" variant="more-info" />
                   </OverlayTrigger>
                   <Form.Control
                     name="readableGranuleName"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -276,7 +276,6 @@ export const GranuleFiltersForm = (props) => {
                   <Form.Label className="mb-1" sm="auto">
                     Granule ID(s)
                   </Form.Label>
-
                   <OverlayTrigger
                     placement="top"
                     overlay={
@@ -323,14 +322,14 @@ export const GranuleFiltersForm = (props) => {
                       )
                     }
                   >
-                    <EDSCIcon title="granule-name-filter-more-info" icon={FaQuestionCircle} size="0.625rem" variant="more-info" />
+                    <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" aria-label="View more info on granule id filter" role="img" />
                   </OverlayTrigger>
                   <Form.Control
                     name="readableGranuleName"
                     data-testid="granule-filters__readable-granule-name"
                     size="sm"
                     type="text"
-                    placeholder="Example: *_20240101_*,*_20240101_*"
+                    placeholder="Example: *_20240101_*,*_20240102_*"
                     value={readableGranuleName}
                     onChange={handleChange}
                     onBlur={submitOnBlur}

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -8,8 +8,9 @@ import {
   Tooltip,
   Row
 } from 'react-bootstrap'
-
+import { FaQuestionCircle } from 'react-icons/fa'
 import moment from 'moment'
+import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
 import { findGridByName } from '../../util/grid'
 import { getTemporalDateFormat } from '../../../../../sharedUtils/edscDate'
@@ -275,14 +276,15 @@ export const GranuleFiltersForm = (props) => {
                   <Form.Label className="mb-1" sm="auto">
                     Granule ID(s)
                   </Form.Label>
+
                   <OverlayTrigger
-                    placement="bottom"
+                    placement="top"
                     overlay={
                       (
-                        <Tooltip
-                          id="tooltip__granule-search"
-                          className="tooltip--large tooltip--ta-left tooltip--wide"
-                        >
+                        <Tooltip id="granule-filters-form-id-filter-tooltip" className="tooltip--ta-left tooltip--wide">
+                          Filter granules by name
+                          example: UA_bonan*
+                          <br />
                           <strong>Wildcards:</strong>
                           {' '}
                           <ul className="m-0">
@@ -301,18 +303,19 @@ export const GranuleFiltersForm = (props) => {
                       )
                     }
                   >
-                    <Form.Control
-                      name="readableGranuleName"
-                      data-testid="granule-filters__readable-granule-name"
-                      size="sm"
-                      type="text"
-                      placeholder="Search Single or Multiple Granule IDs..."
-                      value={readableGranuleName}
-                      onChange={handleChange}
-                      onBlur={submitOnBlur}
-                      onKeyPress={submitOnKeypress}
-                    />
+                    <EDSCIcon icon={FaQuestionCircle} size="0.625rem" variant="more-info" />
                   </OverlayTrigger>
+                  <Form.Control
+                    name="readableGranuleName"
+                    data-testid="granule-filters__readable-granule-name"
+                    size="sm"
+                    type="text"
+                    placeholder="Search Single or Multiple Granule IDs..."
+                    value={readableGranuleName}
+                    onChange={handleChange}
+                    onBlur={submitOnBlur}
+                    onKeyPress={submitOnKeypress}
+                  />
                   {
                     readableGranuleNameTouched && (
                       <Form.Control.Feedback type="invalid">

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -554,6 +554,7 @@ export const GranuleFiltersForm = (props) => {
                       <Col>
                         <Form.Group controlId="granule-filters__day-night-flag">
                           <Form.Control
+                            aria-label="day-night-flag"
                             name="dayNightFlag"
                             data-testid="granule-filters__day-night-flag"
                             as="select"
@@ -680,6 +681,7 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
+                            aria-label="orbit-number-minimum"
                             name="orbitNumber.min"
                             data-testid="granule-filters__orbit-number-min"
                             type="text"
@@ -711,6 +713,7 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
+                            aria-label="orbit-number-maximum"
                             name="orbitNumber.max"
                             data-testid="granule-filters__orbit-number-max"
                             type="text"
@@ -748,6 +751,7 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.min"
+                            aria-label="equator-crossing-longitude-minimum"
                             data-testid="granule-filters__equatorial-crossing-longitude-min"
                             type="text"
                             size="sm"
@@ -781,6 +785,7 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.max"
+                            aria-label="equator-crossing-longitude-maximum"
                             data-testid="granule-filters__equatorial-crossing-longitude-max"
                             type="text"
                             size="sm"
@@ -808,7 +813,7 @@ export const GranuleFiltersForm = (props) => {
                     <SidebarFiltersItem
                       heading="Equatorial Crossing Date"
                     >
-                      <Form.Group controlId="granule-filters__equatorial-crossing-date">
+                      <Form.Group aria-label="granule-filters-equatorial-crossing-date" controlId="granule-filters__equatorial-crossing-date">
                         <Form.Control
                           as="div"
                           className="form-control-basic"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -574,7 +574,7 @@ export const GranuleFiltersForm = (props) => {
                       <Col>
                         <Form.Group controlId="granule-filters__day-night-flag">
                           <Form.Control
-                            aria-label="day-night-flag"
+                            aria-label="Select day/night flag"
                             name="dayNightFlag"
                             data-testid="granule-filters__day-night-flag"
                             as="select"
@@ -701,7 +701,7 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
-                            aria-label="orbit-number-minimum"
+                            aria-label="Set minimum orbit number"
                             name="orbitNumber.min"
                             data-testid="granule-filters__orbit-number-min"
                             type="text"
@@ -733,7 +733,7 @@ export const GranuleFiltersForm = (props) => {
                         </Form.Label>
                         <Col sm={7}>
                           <Form.Control
-                            aria-label="orbit-number-maximum"
+                            aria-label="Set maximum orbit number"
                             name="orbitNumber.max"
                             data-testid="granule-filters__orbit-number-max"
                             type="text"
@@ -771,7 +771,7 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.min"
-                            aria-label="equator-crossing-longitude-minimum"
+                            aria-label="Set minimum equator crossing longitude"
                             data-testid="granule-filters__equatorial-crossing-longitude-min"
                             type="text"
                             size="sm"
@@ -805,7 +805,7 @@ export const GranuleFiltersForm = (props) => {
                         <Col sm={7}>
                           <Form.Control
                             name="equatorCrossingLongitude.max"
-                            aria-label="equator-crossing-longitude-maximum"
+                            aria-label="Set maximum equator crossing longitude"
                             data-testid="granule-filters__equatorial-crossing-longitude-max"
                             type="text"
                             size="sm"
@@ -833,7 +833,7 @@ export const GranuleFiltersForm = (props) => {
                     <SidebarFiltersItem
                       heading="Equatorial Crossing Date"
                     >
-                      <Form.Group aria-label="granule-filters-equatorial-crossing-date" controlId="granule-filters__equatorial-crossing-date">
+                      <Form.Group aria-label="Set granule equatorial crossing date" controlId="granule-filters__equatorial-crossing-date">
                         <Form.Control
                           as="div"
                           className="form-control-basic"

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.scss
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.scss
@@ -25,4 +25,14 @@
     font-size: 0.775rem;
     margin-bottom: 0;
   }
+  
+  &__readable-granule-name-tooltip-title {
+    color: $color__carbon--40;
+    font-size: 0.825rem;
+  }
+
+  &__readable-granule-name-tooltip-list {
+    list-style-position: inside;
+    padding-left: 0.5rem;
+  }
 }

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.scss
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.scss
@@ -27,7 +27,7 @@
   }
   
   &__readable-granule-name-tooltip-title {
-    color: $color__carbon--40;
+    color: $color__carbon--30;
     font-size: 0.825rem;
   }
 

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -103,7 +103,6 @@ describe('GranuleFiltersForm component', () => {
       })
 
       describe('when a single granule is filtered', () => {
-        // TODO: This test is kind of a repeat now
         test('displays the correct status text', () => {
           setup({
             excludedGranuleIds: ['GRAN_ID_1']
@@ -147,17 +146,19 @@ describe('GranuleFiltersForm component', () => {
   describe('Form', () => {
     test('shows granule search by default', () => {
       setup()
+
       expect(screen.getByRole('heading', { name: 'Granule Search' })).toBeInTheDocument()
-      // Expect(enzymeWrapper.find(SidebarFiltersItem).at(0).prop('heading')).toEqual('Granule Search')
     })
 
     test('shows temporal by default', () => {
       setup()
+
       expect(screen.getByRole('heading', { name: 'Temporal' })).toBeInTheDocument()
     })
 
     test('shows data access by default', () => {
       setup()
+
       expect(screen.getByRole('heading', { name: 'Data Access' })).toBeInTheDocument()
     })
 
@@ -175,11 +176,10 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField.value).toEqual('2019-08-14 00:00:00')
+          expect(startDateTextField).toHaveValue('2019-08-14 00:00:00')
 
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
-          // TODO type had changed diff in tests this on is '' not undefined
-          expect(endDateTextField.value).toEqual('')
+          expect(endDateTextField).toHaveValue('')
         })
 
         test('displays correctly when only end date is set', () => {
@@ -192,10 +192,10 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField.value).toEqual('')
+          expect(startDateTextField).toHaveValue('')
 
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
-          expect(endDateTextField.value).toEqual('2019-08-14 00:00:00')
+          expect(endDateTextField).toHaveValue('2019-08-14 00:00:00')
         })
 
         test('displays correctly when both dates are set', () => {
@@ -209,10 +209,10 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField.value).toEqual('2019-08-13 00:00:00')
+          expect(startDateTextField).toHaveValue('2019-08-13 00:00:00')
 
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
-          expect(endDateTextField.value).toEqual('2019-08-14 00:00:00')
+          expect(endDateTextField).toHaveValue('2019-08-14 00:00:00')
         })
 
         test('calls the correct callbacks on startDate submit', async () => {
@@ -224,26 +224,16 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
+
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          // Await user.type(startDateTextField, '2019-08-13T00:00:00:000Z')
           await user.click(startDateTextField)
           await user.tab(startDateTextField)
-          // Await act(async () => {
-          // })
-          // TODO 24 is equal to the length of the string
+
           expect(setFieldTouched).toHaveBeenCalledTimes(1)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
 
           expect(setFieldValue).toHaveBeenCalledTimes(1)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2019-08-13T00:00:00.000Z')
-
-          // Const temporalSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
-          // temporalSection.find(TemporalSelection).prop('onSubmitStart')(moment('2019-08-13T00:00:00:000Z', 'YYYY-MM-DDTHH:m:s.SSSZ', true))
-
-          // expect(props.setFieldTouched).toHaveBeenCalledTimes(1)
-          // expect(props.setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
-          // expect(props.setFieldValue).toHaveBeenCalledTimes(1)
-          // expect(props.setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2019-08-13T00:00:00:000Z')
         })
 
         test('calls the correct callbacks on endDate submit', async () => {
@@ -256,6 +246,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
+
           await user.click(endDateTextField)
           await user.tab(endDateTextField)
 
@@ -275,7 +266,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          // TODO consider aria label to improve accessibility
+
           const isRecurringCheckbox = screen.getByRole('checkbox', { name: 'Recurring?' })
           expect(isRecurringCheckbox.checked).toBe(false)
 
@@ -334,7 +325,7 @@ describe('GranuleFiltersForm component', () => {
         })
 
         const anytimeOption = screen.getByRole('option', { name: 'Anytime' })
-        expect(anytimeOption.value).toBe('')
+        expect(anytimeOption).toHaveValue('')
       })
 
       test('displays selected item', async () => {
@@ -391,9 +382,6 @@ describe('GranuleFiltersForm component', () => {
 
           const browseOnlyToggle = screen.getByRole('checkbox', { name: 'Find only granules that have browse images' })
           expect(browseOnlyToggle.checked).toBe(false)
-
-          // Const dataAccessSection = enzymeWrapper.find(SidebarFiltersItem).at(2)
-          // expect(dataAccessSection.find(Form.Check).at(0).prop('value')).toEqual(false)
         })
 
         test('displays selected item', () => {
@@ -420,8 +408,6 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
-          // Expect(handleChange.mock.calls[0]).toBe({ event: 'test' })
-          // expect(handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
 
@@ -429,6 +415,7 @@ describe('GranuleFiltersForm component', () => {
         test('defaults to an empty value', () => {
           setup()
           const onlineOnlyToggle = screen.getByRole('checkbox', { name: 'Find only granules that are available online' })
+
           expect(onlineOnlyToggle.checked).toBe(false)
         })
 
@@ -473,8 +460,9 @@ describe('GranuleFiltersForm component', () => {
           })
 
           expect(screen.getByRole('heading', { name: 'Cloud Cover' })).toBeInTheDocument()
+          const minCloudCover = screen.getByRole('textbox', { name: 'Minimum' })
 
-          // Expect(screen.queryByRole('heading', { name: 'Cloud Cover' })).not.toBeInTheDocument()
+          expect(minCloudCover).toHaveValue('')
         })
 
         test('calls handleChange on change', async () => {
@@ -498,12 +486,6 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
-          // TODO: Need to get called with
-          // expect(screen.findByRole('textbox', { name: 'Minimum' })).toHaveValue('1')
-          // Const cloudCoverSection = enzymeWrapper.find(SidebarFiltersItem).at(3)
-          // cloudCoverSection.find(Form.Control).at(0).prop('onChange')({ event: 'test' })
-          // expect(props.handleChange).toHaveBeenCalledTimes(1)
-          // expect(props.handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
 
@@ -520,9 +502,9 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minCloudCover = screen.getByRole('textbox', { name: 'Maximum' })
+          const maxCloudCover = screen.getByRole('textbox', { name: 'Maximum' })
 
-          expect(minCloudCover).toHaveValue('')
+          expect(maxCloudCover).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
         })
 
@@ -541,13 +523,10 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const maxCloudCover = screen.getByRole('textbox', { name: 'Maximum' })
+
           await user.type(maxCloudCover, '9')
+
           expect(handleChange).toHaveBeenCalledTimes(1)
-          // Expect(handleChange).toHaveBeenCalledWith('9')
-          // TODO comment
-          // TODO ALT is  handleBlur: (event) => {
-          //   handleBlur(event.target.value)
-          // }
           expect(handleChange).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onChange'
@@ -565,20 +544,12 @@ describe('GranuleFiltersForm component', () => {
             })
           )
 
-          // Expect(handleSubmit).toHaveBeenCalledWith('')
-
           expect(handleBlur).toHaveBeenCalledTimes(1)
           expect(handleBlur).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onBlur'
             })
           )
-          // THis value is very strange
-
-          // const cloudCoverSection = enzymeWrapper.find(SidebarFiltersItem).at(3)
-          // cloudCoverSection.find(Form.Control).at(1).prop('onChange')({ event: 'test' })
-          // expect(props.handleChange).toHaveBeenCalledTimes(1)
-          // expect(props.handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
     })
@@ -598,11 +569,8 @@ describe('GranuleFiltersForm component', () => {
           })
 
           // TODO make sure its the right one
-          const orbitNumberSection = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
-          console.log('🚀 ~ file: GranuleFiltersForm.test.js:575 ~ orbitNumberSection:', orbitNumberSection)
-          expect(orbitNumberSection).toHaveValue('')
-          // Const orbitNumberSection = enzymeWrapper.find(SidebarFiltersItem).at(3)
-          // expect(orbitNumberSection.find(Form.Control).at(0).prop('value')).toEqual('')
+          const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
+          expect(minOrbitNumber).toHaveValue('')
         })
 
         test('calls handleChange on change', async () => {
@@ -626,11 +594,6 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
-
-          // Const orbitNumberSection = enzymeWrapper.find(SidebarFiltersItem).at(3)
-          // orbitNumberSection.find(Form.Control).at(0).prop('onChange')({ event: 'test' })
-          // expect(props.handleChange).toHaveBeenCalledTimes(1)
-          // expect(props.handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
 
@@ -647,9 +610,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          // TODO make sure its the right one
-          const orbitNumberMinimum = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
-          expect(orbitNumberMinimum).toHaveValue('')
+          const orbitNumberMaximum = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
+          expect(orbitNumberMaximum).toHaveValue('')
         })
 
         test('calls handleChange on change', async () => {
@@ -666,16 +628,13 @@ describe('GranuleFiltersForm component', () => {
 
           const maxOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
           await user.type(maxOrbitNumber, '9')
+
           expect(handleChange).toHaveBeenCalledTimes(1)
           expect(handleChange).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onChange'
             })
           )
-          // Const orbitNumberSection = enzymeWrapper.find(SidebarFiltersItem).at(3)
-          // orbitNumberSection.find(Form.Control).at(1).prop('onChange')({ event: 'test' })
-          // expect(props.handleChange).toHaveBeenCalledTimes(1)
-          // expect(props.handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
     })
@@ -694,6 +653,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
           const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
+
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
         })
@@ -713,19 +673,13 @@ describe('GranuleFiltersForm component', () => {
           const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
-          expect(handleChange).toHaveBeenCalledTimes(1)
 
+          expect(handleChange).toHaveBeenCalledTimes(1)
           expect(handleChange).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onChange'
             })
           )
-          // Expect(handleChange).toBeCalledWith()
-
-          // Const equatorCrossingLongitudeSection = enzymeWrapper.find(SidebarFiltersItem).at(4)
-          // equatorCrossingLongitudeSection.find(Form.Control).at(0).prop('onChange')({ event: 'test' })
-          // expect(props.handleChange).toHaveBeenCalledTimes(1)
-          // expect(props.handleChange).toHaveBeenCalledWith({ event: 'test' })
         })
       })
 
@@ -743,6 +697,7 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
         })
@@ -759,10 +714,12 @@ describe('GranuleFiltersForm component', () => {
             }
           })
           const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
+          // TODO why aren't these values updating?
+          expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(1)
-
           expect(handleChange).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onChange'
@@ -798,10 +755,6 @@ describe('GranuleFiltersForm component', () => {
 
         expect(equatorCrossingStartDateTextField).toHaveValue('2019-06-01 00:00:00')
         expect(equatorCrossingEndDateTextField).toHaveValue('')
-        // Const equatorCrossingDateSection = enzymeWrapper.find(SidebarFiltersItem).at(5)
-        // // TODO USE WITHIN TO find the value inside of this
-        // expect(equatorCrossingDateSection.find(TemporalSelection).prop('temporal').startDate).toEqual('2019-08-14T00:00:00:000Z')
-        // expect(equatorCrossingDateSection.find(TemporalSelection).prop('temporal').endDate).toEqual(undefined)
       })
 
       test('displays correctly when only end date is set', () => {
@@ -875,9 +828,6 @@ describe('GranuleFiltersForm component', () => {
         const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
         const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
 
-        // Const equatorCrossingDateSection = enzymeWrapper.find(SidebarFiltersItem).at(5)
-        // equatorCrossingDateSection.find(TemporalSelection).prop('onSubmitStart')(moment('2019-08-13T00:00:00:000Z', 'YYYY-MM-DDTHH:m:s.SSSZ', true))
-
         await user.click(equatorCrossingStartDateTextField)
         await user.type(equatorCrossingStartDateTextField, '2019-08-13')
         await user.tab(equatorCrossingStartDateTextField)
@@ -909,14 +859,11 @@ describe('GranuleFiltersForm component', () => {
         })
 
         const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
-        const equatorCrossingEndStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
+        const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
 
-        // Const equatorCrossingDateSection = enzymeWrapper.find(SidebarFiltersItem).at(5)
-        // equatorCrossingDateSection.find(TemporalSelection).prop('onSubmitStart')(moment('2019-08-13T00:00:00:000Z', 'YYYY-MM-DDTHH:m:s.SSSZ', true))
-
-        await user.click(equatorCrossingEndStartDateTextField)
-        await user.type(equatorCrossingEndStartDateTextField, '2019-08-14')
-        await user.tab(equatorCrossingEndStartDateTextField)
+        await user.click(equatorCrossingEndDateTextField)
+        await user.type(equatorCrossingEndDateTextField, '2019-08-14')
+        await user.tab(equatorCrossingEndDateTextField)
 
         expect(setFieldTouched).toHaveBeenCalledTimes(10)
         expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.endDate')
@@ -931,6 +878,7 @@ describe('GranuleFiltersForm component', () => {
   describe('Grid Coordinates section', () => {
     test('does not render if no gridName is applied', () => {
       setup()
+
       expect(screen.queryByText('Tiling System')).not.toBeInTheDocument()
       expect(screen.queryByRole('combobox', 'tilingSystem')).not.toBeInTheDocument()
     })
@@ -955,7 +903,9 @@ describe('GranuleFiltersForm component', () => {
       })
 
       expect(screen.getByLabelText('Tiling System')).toBeInTheDocument()
-      expect(screen.getByRole('option', { name: 'MISR' })).toBeInTheDocument()
+      // TODO update this test slightly
+      const tileOptions = screen.getByRole('combobox', 'tilingSystem')
+      expect(tileOptions).toHaveValue('')
       // Const gridCoordsSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
       // expect(gridCoordsSection.find(Form.Control).at(0).prop('value')).toEqual('')
     })
@@ -980,12 +930,15 @@ describe('GranuleFiltersForm component', () => {
       })
 
       const tileOptions = screen.getByRole('combobox', 'tilingSystem')
+
       await user.selectOptions(tileOptions, 'MISR')
 
       expect(handleChange).toHaveBeenCalledTimes(1)
-      // Const gridCoordsSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
-      // gridCoordsSection.find(Form.Control).prop('onChange')({ target: { value: 'MISR' } })
-      // expect(props.handleChange).toHaveBeenCalledWith({ target: { value: 'MISR' } })
+      expect(handleChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _reactName: 'onChange'
+        })
+      )
     })
 
     test('tiling system onchange displays grid coordinates', async () => {
@@ -1018,10 +971,6 @@ describe('GranuleFiltersForm component', () => {
       await user.click(misrTileOption)
 
       expect(screen.getByText(gridCoordinatesMessage)).toBeVisible()
-
-      // Const gridCoordsSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
-      // expect(gridCoordsSection.find(Form.Control).length).toBe(2)
-      // expect(gridCoordsSection.find(Form.Text).at(0).text()).toEqual('Enter path (min: 1, max: 233) and block (min: 1, max: 183) coordinates separated by spaces, e.g. "2,3 5,7"')
     })
   })
 })

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -376,7 +376,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        expect(screen.getByRole('combobox', { name: 'day-night-flag' })).toHaveValue('')
+        expect(screen.getByRole('combobox', { name: 'Select day/night flag' })).toHaveValue('')
       })
 
       test('displays selected item', async () => {
@@ -394,7 +394,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        expect(screen.getByRole('combobox', { name: 'day-night-flag' })).toHaveValue('NIGHT')
+        expect(screen.getByRole('combobox', { name: 'Select day/night flag' })).toHaveValue('NIGHT')
       })
 
       test('calls handleChange on change', async () => {
@@ -412,7 +412,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const dayNightSelection = screen.getByRole('combobox', { name: 'day-night-flag' })
+        const dayNightSelection = screen.getByRole('combobox', { name: 'Select day/night flag' })
 
         await user.selectOptions(dayNightSelection, 'Day')
         await user.selectOptions(dayNightSelection, 'Both')
@@ -615,7 +615,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
+          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
           expect(minOrbitNumber).toHaveValue('')
         })
 
@@ -630,7 +630,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
+          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
 
           await user.type(minOrbitNumber, '9')
 
@@ -656,7 +656,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
+          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
 
           await user.type(minOrbitNumber, '9')
 
@@ -699,7 +699,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberMaximum = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
+          const orbitNumberMaximum = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
           expect(orbitNumberMaximum).toHaveValue('')
         })
 
@@ -715,7 +715,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
+          const maxOrbitNumber = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
           await user.type(maxOrbitNumber, '9')
 
           expect(handleChange).toHaveBeenCalledTimes(1)
@@ -740,7 +740,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
+          const maxOrbitNumber = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
 
           await user.type(maxOrbitNumber, '9')
 
@@ -784,7 +784,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
+          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
 
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -802,7 +802,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
+          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
 
@@ -826,7 +826,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
+          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
 
           await user.type(minEquatorCrossingLongitude, '1')
 
@@ -863,7 +863,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
 
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -880,7 +880,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
@@ -906,7 +906,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
 
           await user.type(maxEquatorCrossingLongitude, '1')
 
@@ -951,7 +951,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
+        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
         const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
         const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
 
@@ -976,7 +976,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
+        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
         const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
         const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
 
@@ -1002,7 +1002,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
+        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
         const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
         const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
 
@@ -1027,7 +1027,7 @@ describe('GranuleFiltersForm component', () => {
             }
           }
         })
-        const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
+        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
         const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
 
         await user.click(equatorCrossingStartDateTextField)
@@ -1060,7 +1060,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('granule-filters-equatorial-crossing-date')
+        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
         const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
 
         await user.click(equatorCrossingEndDateTextField)

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -805,7 +805,10 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+
+          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -822,7 +825,10 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+
+          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
@@ -846,7 +852,11 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
+
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+
+          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           await user.type(minEquatorCrossingLongitude, '1')
 
@@ -882,7 +892,10 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+
+          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -899,7 +912,10 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+
+          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
@@ -924,7 +940,10 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
+          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+
+          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           await user.type(maxEquatorCrossingLongitude, '1')
 

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -1,21 +1,13 @@
 import React from 'react'
-import moment from 'moment'
-
 import {
-  act,
   render,
-  waitFor,
   screen,
   within
 } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import { Form, FormControl } from 'react-bootstrap'
-
 import GranuleFiltersForm from '../GranuleFiltersForm'
-import SidebarFiltersItem from '../../Sidebar/SidebarFiltersItem'
-import TemporalSelection from '../../TemporalSelection/TemporalSelection'
 
 jest.mock('formik', () => ({
   Form: jest.fn(({ children }) => (
@@ -169,7 +161,6 @@ describe('GranuleFiltersForm component', () => {
       expect(screen.getByRole('heading', { name: 'Data Access' })).toBeInTheDocument()
     })
 
-    // TODO fix  console.warn on the date
     describe('Temporal section', () => {
       describe('displays temporal', () => {
         test('displays correctly when only start date is set', () => {

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -1,9 +1,5 @@
 import React from 'react'
-import {
-  render,
-  screen,
-  within
-} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
@@ -193,18 +189,16 @@ describe('GranuleFiltersForm component', () => {
     describe('Temporal section', () => {
       describe('displays temporal', () => {
         test('displays correctly when only start date is set', () => {
-          // TODO 2024-06-12 00:00:00 this format is now the corrected one
-          // this was the previous time format 2019-08-14T00:00:00:000Z
           setup({
             values: {
               temporal: {
-                startDate: '2019-08-14 00:00:00'
+                startDate: '2019-08-14T00:00:00:000Z'
               }
             }
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField).toHaveValue('2019-08-14 00:00:00')
+          expect(startDateTextField).toHaveValue('2019-08-14T00:00:00:000Z')
 
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
           expect(endDateTextField).toHaveValue('')
@@ -214,33 +208,33 @@ describe('GranuleFiltersForm component', () => {
           setup({
             values: {
               temporal: {
-                endDate: '2019-08-14 00:00:00'
+                endDate: '2019-08-14T00:00:00:000Z'
               }
             }
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField).toHaveValue('')
-
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
-          expect(endDateTextField).toHaveValue('2019-08-14 00:00:00')
+
+          expect(startDateTextField).toHaveValue('')
+          expect(endDateTextField).toHaveValue('2019-08-14T00:00:00:000Z')
         })
 
         test('displays correctly when both dates are set', () => {
           setup({
             values: {
               temporal: {
-                startDate: '2019-08-13 00:00:00',
-                endDate: '2019-08-14 00:00:00'
+                startDate: '2019-08-13T00:00:00:000Z',
+                endDate: '2019-08-14T23:59:59:999Z'
               }
             }
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          expect(startDateTextField).toHaveValue('2019-08-13 00:00:00')
-
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
-          expect(endDateTextField).toHaveValue('2019-08-14 00:00:00')
+
+          expect(startDateTextField).toHaveValue('2019-08-13T00:00:00:000Z')
+          expect(endDateTextField).toHaveValue('2019-08-14T23:59:59:999Z')
         })
 
         test('calls the correct callbacks on startDate submit', async () => {
@@ -249,26 +243,30 @@ describe('GranuleFiltersForm component', () => {
           } = setup({
             values: {
               temporal: {
-                startDate: '2019-08-13 00:00:00',
-                endDate: '2019-08-14 23:59:59'
+                startDate: '',
+                endDate: '2019-08-14T23:59:59:999Z'
               }
             }
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
-          await user.click(startDateTextField)
-          await user.tab(startDateTextField)
 
-          expect(setFieldTouched).toHaveBeenCalledTimes(1)
+          await user.click(startDateTextField)
+          await user.type(startDateTextField, '2019-08-13')
+
+          await user.tab(startDateTextField)
+          expect(setFieldTouched).toHaveBeenCalledTimes(10)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
 
-          expect(setFieldValue).toHaveBeenCalledTimes(1)
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2019-08-13T00:00:00.000Z')
+          expect(setFieldValue).toHaveBeenCalledTimes(10)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '0')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '1')
 
-          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(10)
           expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
             type: 'Set Start Date',
-            value: '2019-08-13T00:00:00.000Z'
+            value: '2'
           })
         })
 
@@ -278,26 +276,29 @@ describe('GranuleFiltersForm component', () => {
           } = setup({
             values: {
               temporal: {
-                startDate: '2019-08-13 00:00:00',
-                endDate: '2019-08-14 23:59:59'
+                startDate: '2019-08-13T00:00:00:000Z',
+                endDate: ''
               }
             }
           })
           const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
 
           await user.click(endDateTextField)
+          await user.type(endDateTextField, '2019-08-14')
           await user.tab(endDateTextField)
 
-          expect(setFieldTouched).toHaveBeenCalledTimes(1)
+          expect(setFieldTouched).toHaveBeenCalledTimes(10)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.endDate')
 
-          expect(setFieldValue).toHaveBeenCalledTimes(1)
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2019-08-14T23:59:59.999Z')
+          expect(setFieldValue).toHaveBeenCalledTimes(10)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '0')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '1')
 
-          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(10)
           expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
             type: 'Set End Date',
-            value: '2019-08-14T23:59:59.999Z'
+            value: '2'
           })
         })
 
@@ -615,7 +616,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
+          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
+
           expect(minOrbitNumber).toHaveValue('')
         })
 
@@ -630,7 +632,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
+          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
 
           await user.type(minOrbitNumber, '9')
 
@@ -656,7 +658,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getByRole('textbox', { name: 'Set minimum orbit number' })
+          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
 
           await user.type(minOrbitNumber, '9')
 
@@ -699,7 +701,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberMaximum = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
+          const orbitNumberMaximum = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
           expect(orbitNumberMaximum).toHaveValue('')
         })
 
@@ -715,7 +717,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
+          const maxOrbitNumber = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
           await user.type(maxOrbitNumber, '9')
 
           expect(handleChange).toHaveBeenCalledTimes(1)
@@ -740,7 +742,7 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getByRole('textbox', { name: 'Set maximum orbit number' })
+          const maxOrbitNumber = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
 
           await user.type(maxOrbitNumber, '9')
 
@@ -784,7 +786,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
+          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -801,8 +803,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
+          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
 
@@ -825,8 +827,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-
-          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set minimum equator crossing longitude' })
+          const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           await user.type(minEquatorCrossingLongitude, '1')
 
@@ -862,8 +863,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
+          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -880,11 +880,11 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
+          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
-          // TODO why aren't these values updating?
+
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(1)
           expect(handleChange).toHaveBeenCalledWith(
@@ -905,8 +905,7 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-
-          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'Set maximum equator crossing longitude' })
+          const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           await user.type(maxEquatorCrossingLongitude, '1')
 
@@ -946,16 +945,15 @@ describe('GranuleFiltersForm component', () => {
           },
           values: {
             equatorCrossingDate: {
-              startDate: '2019-06-01 00:00:00'
+              startDate: '2019-08-14T00:00:00:000Z'
             }
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
-        const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
-        const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
+        const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
+        const equatorCrossingEndDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
 
-        expect(equatorCrossingStartDateTextField).toHaveValue('2019-06-01 00:00:00')
+        expect(equatorCrossingStartDateTextField).toHaveValue('2019-08-14T00:00:00:000Z')
         expect(equatorCrossingEndDateTextField).toHaveValue('')
       })
 
@@ -971,17 +969,16 @@ describe('GranuleFiltersForm component', () => {
           },
           values: {
             equatorCrossingDate: {
-              endDate: '2019-08-14 00:00:00'
+              endDate: '2019-08-14T00:00:00:000Z'
             }
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
-        const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
-        const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
+        const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
+        const equatorCrossingEndDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
 
         expect(equatorCrossingStartDateTextField).toHaveValue('')
-        expect(equatorCrossingEndDateTextField).toHaveValue('2019-08-14 00:00:00')
+        expect(equatorCrossingEndDateTextField).toHaveValue('2019-08-14T00:00:00:000Z')
       })
 
       test('displays correctly when both dates are set', () => {
@@ -996,18 +993,17 @@ describe('GranuleFiltersForm component', () => {
           },
           values: {
             equatorCrossingDate: {
-              startDate: '2019-08-13 00:00:00',
-              endDate: '2019-08-14 59:59:999'
+              startDate: '2019-08-13T00:00:00:000Z',
+              endDate: '2019-08-14T23:59:59:999Z'
             }
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
-        const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
-        const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
+        const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
+        const equatorCrossingEndDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
 
-        expect(equatorCrossingStartDateTextField).toHaveValue('2019-08-13 00:00:00')
-        expect(equatorCrossingEndDateTextField).toHaveValue('2019-08-14 59:59:999')
+        expect(equatorCrossingStartDateTextField).toHaveValue('2019-08-13T00:00:00:000Z')
+        expect(equatorCrossingEndDateTextField).toHaveValue('2019-08-14T23:59:59:999Z')
       })
 
       test('calls the correct callbacks on startDate submit', async () => {
@@ -1023,12 +1019,11 @@ describe('GranuleFiltersForm component', () => {
           values: {
             equatorCrossingDate: {
               startDate: '',
-              endDate: '2019-08-14 59:59:999'
+              endDate: '2019-08-14T23:59:59:999Z'
             }
           }
         })
-        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
-        const equatorCrossingStartDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'Start Date' })
+        const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
 
         await user.click(equatorCrossingStartDateTextField)
         await user.type(equatorCrossingStartDateTextField, '2019-08-13')
@@ -1054,14 +1049,13 @@ describe('GranuleFiltersForm component', () => {
           },
           values: {
             equatorCrossingDate: {
-              startDate: '2019-08-13 00:00:00',
+              startDate: '2019-08-13T00:00:00:000Z',
               endDate: ''
             }
           }
         })
 
-        const equatorCrossingDateSection = screen.getByLabelText('Set granule equatorial crossing date')
-        const equatorCrossingEndDateTextField = within(equatorCrossingDateSection).getByRole('textbox', { name: 'End Date' })
+        const equatorCrossingEndDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
 
         await user.click(equatorCrossingEndDateTextField)
         await user.type(equatorCrossingEndDateTextField, '2019-08-14')

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -625,10 +625,7 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          console.log('🚀 ~ file: GranuleFiltersForm.test.js:628 ~ orbitNumberSectionHeader:', orbitNumberSectionHeader)
-
           const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Minimum' })
-          // Const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
 
           expect(minOrbitNumber).toHaveValue('')
         })

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -1,5 +1,9 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within
+} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
@@ -377,7 +381,9 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        expect(screen.getByRole('combobox', { name: 'Select day/night flag' })).toHaveValue('')
+        const dayNightSideBarItem = screen.getByText('Day/Night').parentElement.parentElement
+
+        expect(within(dayNightSideBarItem).getByRole('combobox')).toHaveValue('')
       })
 
       test('displays selected item', async () => {
@@ -395,7 +401,9 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        expect(screen.getByRole('combobox', { name: 'Select day/night flag' })).toHaveValue('NIGHT')
+        const dayNightSideBarItem = screen.getByText('Day/Night').parentElement.parentElement
+
+        expect(within(dayNightSideBarItem).getByRole('combobox')).toHaveValue('NIGHT')
       })
 
       test('calls handleChange on change', async () => {
@@ -412,8 +420,8 @@ describe('GranuleFiltersForm component', () => {
             dayNightFlag: 'NIGHT'
           }
         })
-
-        const dayNightSelection = screen.getByRole('combobox', { name: 'Select day/night flag' })
+        const dayNightSideBarItem = screen.getByText('Day/Night').parentElement.parentElement
+        const dayNightSelection = within(dayNightSideBarItem).getByRole('combobox')
 
         await user.selectOptions(dayNightSelection, 'Day')
         await user.selectOptions(dayNightSelection, 'Both')

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -624,7 +624,11 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          console.log('🚀 ~ file: GranuleFiltersForm.test.js:628 ~ orbitNumberSectionHeader:', orbitNumberSectionHeader)
+
+          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          // Const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
 
           expect(minOrbitNumber).toHaveValue('')
         })
@@ -640,7 +644,9 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
+
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(minOrbitNumber, '9')
 
@@ -666,11 +672,10 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const minOrbitNumber = screen.getAllByRole('textbox', { name: 'Minimum' })[0]
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Minimum' })
 
           await user.type(minOrbitNumber, '9')
-
-          // Submit the form call
           await user.tab(minOrbitNumber)
 
           expect(handleSubmit).toHaveBeenCalledTimes(1)
@@ -709,7 +714,10 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberMaximum = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
+          // Const orbitNumberMaximum = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          const orbitNumberMaximum = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+
           expect(orbitNumberMaximum).toHaveValue('')
         })
 
@@ -725,7 +733,9 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          const maxOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+
           await user.type(maxOrbitNumber, '9')
 
           expect(handleChange).toHaveBeenCalledTimes(1)
@@ -750,7 +760,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const maxOrbitNumber = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
+          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
+          const maxOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(maxOrbitNumber, '9')
 

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -162,7 +162,7 @@ describe('GranuleFiltersForm component', () => {
       expect(screen.getByRole('heading', { name: 'Data Access' })).toBeInTheDocument()
     })
 
-    describe('when `Enter` is pressed in the text field', () => {
+    describe('when `Enter` is pressed in the Granule ID(s) text field', () => {
       test('calls onSubmit', async () => {
         const { onMetricsGranuleFilter, handleSubmit, user } = setup({
           values: {
@@ -655,7 +655,7 @@ describe('GranuleFiltersForm component', () => {
           )
         })
 
-        test('calls onBlur when the filter is submitted ', async () => {
+        test('calls onBlur when the filter is submitted', async () => {
           const {
             handleBlur, handleSubmit, onMetricsGranuleFilter, user
           } = setup({
@@ -742,7 +742,7 @@ describe('GranuleFiltersForm component', () => {
           )
         })
 
-        test('calls onBlur when the filter is submitted ', async () => {
+        test('calls onBlur when the filter is submitted', async () => {
           const {
             handleBlur, handleSubmit, onMetricsGranuleFilter, user
           } = setup({
@@ -834,7 +834,9 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls onBlur when the filter is submitted ', async () => {
-          const { handleBlur, handleSubmit, user } = setup({
+          const {
+            onMetricsGranuleFilter, handleBlur, handleSubmit, user
+          } = setup({
             collectionMetadata: {
               isOpenSearch: false,
               tags: {
@@ -865,6 +867,12 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onBlur'
             })
           )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'equatorCrossingLongitude.min',
+            value: ''
+          })
         })
       })
 
@@ -914,7 +922,9 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls onBlur when the filter is submitted ', async () => {
-          const { handleBlur, handleSubmit, user } = setup({
+          const {
+            onMetricsGranuleFilter, handleBlur, handleSubmit, user
+          } = setup({
             collectionMetadata: {
               isOpenSearch: false,
               tags: {
@@ -944,6 +954,12 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onBlur'
             })
           )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'equatorCrossingLongitude.max',
+            value: ''
+          })
         })
       })
     })
@@ -1122,7 +1138,7 @@ describe('GranuleFiltersForm component', () => {
     })
 
     test('calls handleChange on change', async () => {
-      const { handleChange, user } = setup({
+      const { onMetricsGranuleFilter, handleChange, user } = setup({
         collectionMetadata: {
           tilingIdentificationSystems: [
             {
@@ -1149,6 +1165,14 @@ describe('GranuleFiltersForm component', () => {
         expect.objectContaining({
           _reactName: 'onChange'
         })
+      )
+
+      expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+      expect(onMetricsGranuleFilter).toHaveBeenCalledWith(
+        {
+          type: 'tilingSystem',
+          value: 'MISR'
+        }
       )
     })
 

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -714,7 +714,6 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          // Const orbitNumberMaximum = screen.getAllByRole('textbox', { name: 'Maximum' })[0]
           const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
           const orbitNumberMaximum = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
 
@@ -808,8 +807,6 @@ describe('GranuleFiltersForm component', () => {
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
 
-          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
-
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
         })
@@ -827,8 +824,6 @@ describe('GranuleFiltersForm component', () => {
           })
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
-
-          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
 
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
@@ -856,11 +851,7 @@ describe('GranuleFiltersForm component', () => {
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
 
-          // Const minEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Minimum' })[1]
-
           await user.type(minEquatorCrossingLongitude, '1')
-
-          // Submit the form call
           await user.tab(minEquatorCrossingLongitude)
 
           expect(handleSubmit).toHaveBeenCalledTimes(1)
@@ -895,8 +886,6 @@ describe('GranuleFiltersForm component', () => {
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
 
-          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
-
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
         })
@@ -914,8 +903,6 @@ describe('GranuleFiltersForm component', () => {
           })
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
-
-          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
@@ -943,11 +930,7 @@ describe('GranuleFiltersForm component', () => {
           const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
           const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
 
-          // Const maxEquatorCrossingLongitude = screen.getAllByRole('textbox', { name: 'Maximum' })[1]
-
           await user.type(maxEquatorCrossingLongitude, '1')
-
-          // Submit the form call
           await user.tab(maxEquatorCrossingLongitude)
 
           expect(handleSubmit).toHaveBeenCalledTimes(1)

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -162,6 +162,34 @@ describe('GranuleFiltersForm component', () => {
       expect(screen.getByRole('heading', { name: 'Data Access' })).toBeInTheDocument()
     })
 
+    describe('when `Enter` is pressed in the text field', () => {
+      test('calls onSubmit', async () => {
+        const { onMetricsGranuleFilter, handleSubmit, user } = setup({
+          values: {
+            readableGranuleName: ''
+          }
+        })
+
+        expect(screen.getByRole('heading', { name: 'Granule Search' })).toBeInTheDocument()
+        const readableGranuleNameTextField = screen.getByRole('textbox', { name: 'Granule ID(s)' })
+        await user.type(readableGranuleNameTextField, '{testGranuleName}')
+        await user.type(readableGranuleNameTextField, '{Enter}')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(1)
+        expect(handleSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            _reactName: 'onKeyPress'
+          })
+        )
+
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+          type: 'readableGranuleName',
+          value: ''
+        })
+      })
+    })
+
     describe('Temporal section', () => {
       describe('displays temporal', () => {
         test('displays correctly when only start date is set', () => {
@@ -216,7 +244,9 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls the correct callbacks on startDate submit', async () => {
-          const { setFieldTouched, setFieldValue, user } = setup({
+          const {
+            onMetricsGranuleFilter, setFieldTouched, setFieldValue, user
+          } = setup({
             values: {
               temporal: {
                 startDate: '2019-08-13 00:00:00',
@@ -234,10 +264,18 @@ describe('GranuleFiltersForm component', () => {
 
           expect(setFieldValue).toHaveBeenCalledTimes(1)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2019-08-13T00:00:00.000Z')
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set Start Date',
+            value: '2019-08-13T00:00:00.000Z'
+          })
         })
 
         test('calls the correct callbacks on endDate submit', async () => {
-          const { setFieldTouched, setFieldValue, user } = setup({
+          const {
+            onMetricsGranuleFilter, setFieldTouched, setFieldValue, user
+          } = setup({
             values: {
               temporal: {
                 startDate: '2019-08-13 00:00:00',
@@ -255,14 +293,22 @@ describe('GranuleFiltersForm component', () => {
 
           expect(setFieldValue).toHaveBeenCalledTimes(1)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2019-08-14T23:59:59.999Z')
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set End Date',
+            value: '2019-08-14T23:59:59.999Z'
+          })
         })
 
         test('calls the correct callbacks on onRecurringToggle', async () => {
-          const { user, setFieldTouched, setFieldValue } = setup({
+          const {
+            onMetricsGranuleFilter, user, setFieldTouched, setFieldValue
+          } = setup({
             values: {
               temporal: {
-                startDate: '2019-08-13 00:00:00',
-                endDate: '2019-08-14 23:59:59'
+                startDate: '2019-08-13T00:00:00.000Z',
+                endDate: '2019-08-14T23:59:59.999Z'
               }
             }
           })
@@ -279,10 +325,14 @@ describe('GranuleFiltersForm component', () => {
           expect(setFieldValue).toHaveBeenCalledWith('temporal.isRecurring', true)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 225)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 226)
-          // TODO remote is getting `226`
-          // expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 227)
 
           expect(isRecurringCheckbox.checked).toBe(true)
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set Recurring',
+            value: true
+          })
         })
 
         test('calls the correct callbacks on onRecurringToggle when a leap day is involved', async () => {
@@ -326,8 +376,7 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const anytimeOption = screen.getByRole('option', { name: 'Anytime' })
-        expect(anytimeOption).toHaveValue('')
+        expect(screen.getByRole('combobox', { name: 'day-night-flag' })).toHaveValue('')
       })
 
       test('displays selected item', async () => {
@@ -399,7 +448,7 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls handleChange on change', async () => {
-          const { handleChange, user } = setup()
+          const { onMetricsGranuleFilter, handleChange, user } = setup()
           const browseOnlyToggle = screen.getByRole('checkbox', { name: 'Find only granules that have browse images' })
 
           await user.click(browseOnlyToggle)
@@ -410,6 +459,12 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'browseOnly',
+            value: true
+          })
         })
       })
 
@@ -433,7 +488,7 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls handleChange on change', async () => {
-          const { handleChange, user } = setup()
+          const { onMetricsGranuleFilter, handleChange, user } = setup()
           const onlineOnlyToggle = screen.getByRole('checkbox', { name: 'Find only granules that are available online' })
           await user.click(onlineOnlyToggle)
 
@@ -443,6 +498,12 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'onlineOnly',
+            value: true
+          })
         })
       })
     })
@@ -462,6 +523,8 @@ describe('GranuleFiltersForm component', () => {
           })
 
           expect(screen.getByRole('heading', { name: 'Cloud Cover' })).toBeInTheDocument()
+          expect(screen.getByRole('textbox', { name: 'Minimum' })).toBeInTheDocument()
+
           const minCloudCover = screen.getByRole('textbox', { name: 'Minimum' })
 
           expect(minCloudCover).toHaveValue('')
@@ -512,7 +575,7 @@ describe('GranuleFiltersForm component', () => {
 
         test('calls handleChange on change', async () => {
           const {
-            handleChange, handleSubmit, handleBlur, user
+            handleChange, user
           } = setup({
             collectionMetadata: {
               isOpenSearch: false,
@@ -534,24 +597,6 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
-
-          // Submit the form call
-          await user.tab(maxCloudCover)
-
-          expect(handleSubmit).toHaveBeenCalledTimes(1)
-
-          expect(handleSubmit).toHaveBeenCalledWith(
-            expect.objectContaining({
-              _reactName: 'onBlur'
-            })
-          )
-
-          expect(handleBlur).toHaveBeenCalledTimes(1)
-          expect(handleBlur).toHaveBeenCalledWith(
-            expect.objectContaining({
-              _reactName: 'onBlur'
-            })
-          )
         })
       })
     })
@@ -570,7 +615,6 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          // TODO make sure its the right one
           const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
           expect(minOrbitNumber).toHaveValue('')
         })
@@ -596,6 +640,49 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
+        })
+
+        test('calls onBlur when the filter is submitted ', async () => {
+          const {
+            handleBlur, handleSubmit, onMetricsGranuleFilter, user
+          } = setup({
+            collectionMetadata: {
+              isOpenSearch: false,
+              tags: {
+                'edsc.extra.serverless.collection_capabilities': {
+                  data: { orbit_calculated_spatial_domains: true }
+                }
+              }
+            }
+          })
+
+          const minOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-minimum' })
+
+          await user.type(minOrbitNumber, '9')
+
+          // Submit the form call
+          await user.tab(minOrbitNumber)
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+          expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(handleBlur).toHaveBeenCalledTimes(1)
+          expect(handleBlur).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'orbitNumber.min',
+            value: ''
+          })
         })
       })
 
@@ -637,6 +724,49 @@ describe('GranuleFiltersForm component', () => {
               _reactName: 'onChange'
             })
           )
+        })
+
+        test('calls onBlur when the filter is submitted ', async () => {
+          const {
+            handleBlur, handleSubmit, onMetricsGranuleFilter, user
+          } = setup({
+            collectionMetadata: {
+              isOpenSearch: false,
+              tags: {
+                'edsc.extra.serverless.collection_capabilities': {
+                  data: { orbit_calculated_spatial_domains: true }
+                }
+              }
+            }
+          })
+
+          const maxOrbitNumber = screen.getByRole('textbox', { name: 'orbit-number-maximum' })
+
+          await user.type(maxOrbitNumber, '9')
+
+          // Submit the form call
+          await user.tab(maxOrbitNumber)
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+          expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(handleBlur).toHaveBeenCalledTimes(1)
+          expect(handleBlur).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'orbitNumber.max',
+            value: ''
+          })
         })
       })
     })
@@ -683,6 +813,41 @@ describe('GranuleFiltersForm component', () => {
             })
           )
         })
+
+        test('calls onBlur when the filter is submitted ', async () => {
+          const { handleBlur, handleSubmit, user } = setup({
+            collectionMetadata: {
+              isOpenSearch: false,
+              tags: {
+                'edsc.extra.serverless.collection_capabilities': {
+                  data: { orbit_calculated_spatial_domains: true }
+                }
+              }
+            }
+          })
+
+          const minEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-minimum' })
+
+          await user.type(minEquatorCrossingLongitude, '1')
+
+          // Submit the form call
+          await user.tab(minEquatorCrossingLongitude)
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+          expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(handleBlur).toHaveBeenCalledTimes(1)
+          expect(handleBlur).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+        })
       })
 
       describe('Max', () => {
@@ -725,6 +890,41 @@ describe('GranuleFiltersForm component', () => {
           expect(handleChange).toHaveBeenCalledWith(
             expect.objectContaining({
               _reactName: 'onChange'
+            })
+          )
+        })
+
+        test('calls onBlur when the filter is submitted ', async () => {
+          const { handleBlur, handleSubmit, user } = setup({
+            collectionMetadata: {
+              isOpenSearch: false,
+              tags: {
+                'edsc.extra.serverless.collection_capabilities': {
+                  data: { orbit_calculated_spatial_domains: true }
+                }
+              }
+            }
+          })
+
+          const maxEquatorCrossingLongitude = screen.getByRole('textbox', { name: 'equator-crossing-longitude-maximum' })
+
+          await user.type(maxEquatorCrossingLongitude, '1')
+
+          // Submit the form call
+          await user.tab(maxEquatorCrossingLongitude)
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+
+          expect(handleSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
+            })
+          )
+
+          expect(handleBlur).toHaveBeenCalledTimes(1)
+          expect(handleBlur).toHaveBeenCalledWith(
+            expect.objectContaining({
+              _reactName: 'onBlur'
             })
           )
         })
@@ -905,11 +1105,8 @@ describe('GranuleFiltersForm component', () => {
       })
 
       expect(screen.getByLabelText('Tiling System')).toBeInTheDocument()
-      // TODO update this test slightly
       const tileOptions = screen.getByRole('combobox', 'tilingSystem')
       expect(tileOptions).toHaveValue('')
-      // Const gridCoordsSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
-      // expect(gridCoordsSection.find(Form.Control).at(0).prop('value')).toEqual('')
     })
 
     test('calls handleChange on change', async () => {

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -278,7 +278,9 @@ describe('GranuleFiltersForm component', () => {
           expect(setFieldValue).toHaveBeenCalledTimes(3)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.isRecurring', true)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 225)
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 227)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 226)
+          // TODO remote is getting `226`
+          // expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 227)
 
           expect(isRecurringCheckbox.checked).toBe(true)
         })

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -624,8 +624,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const minOrbitNumber = within(orbitNumberSection).getByRole('textbox', { name: 'Minimum' })
 
           expect(minOrbitNumber).toHaveValue('')
         })
@@ -642,8 +642,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const minOrbitNumber = within(orbitNumberSection).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(minOrbitNumber, '9')
 
@@ -669,8 +669,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const minOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const minOrbitNumber = within(orbitNumberSection).getByRole('textbox', { name: 'Minimum' })
 
           await user.type(minOrbitNumber, '9')
           await user.tab(minOrbitNumber)
@@ -711,8 +711,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const orbitNumberMaximum = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const orbitNumberMaximum = within(orbitNumberSection).getByRole('textbox', { name: 'Maximum' })
 
           expect(orbitNumberMaximum).toHaveValue('')
         })
@@ -729,8 +729,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const maxOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const maxOrbitNumber = within(orbitNumberSection).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(maxOrbitNumber, '9')
 
@@ -756,8 +756,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const orbitNumberSectionHeader = screen.getByText('Orbit Number').parentElement.parentElement
-          const maxOrbitNumber = within(orbitNumberSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const orbitNumberSection = screen.getByText('Orbit Number').parentElement.parentElement
+          const maxOrbitNumber = within(orbitNumberSection).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(maxOrbitNumber, '9')
 
@@ -801,8 +801,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Minimum' })
 
           expect(minEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -819,8 +819,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Minimum' })
 
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
@@ -845,8 +845,8 @@ describe('GranuleFiltersForm component', () => {
             }
           })
 
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Minimum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const minEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Minimum' })
 
           await user.type(minEquatorCrossingLongitude, '1')
           await user.tab(minEquatorCrossingLongitude)
@@ -880,8 +880,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Maximum' })
 
           expect(maxEquatorCrossingLongitude).toHaveValue('')
           expect(handleChange).toHaveBeenCalledTimes(0)
@@ -898,8 +898,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)
@@ -924,8 +924,8 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const equatorialCrossingLatitudeSectionHeader = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
-          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSectionHeader).getByRole('textbox', { name: 'Maximum' })
+          const equatorialCrossingLatitudeSection = screen.getByText('Equatorial Crossing Longitude').parentElement.parentElement
+          const maxEquatorCrossingLongitude = within(equatorialCrossingLatitudeSection).getByRole('textbox', { name: 'Maximum' })
 
           await user.type(maxEquatorCrossingLongitude, '1')
           await user.tab(maxEquatorCrossingLongitude)

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -364,7 +364,7 @@ describe('GranuleFiltersForm component', () => {
         expect(screen.getByRole('combobox', { name: 'day-night-flag' })).toHaveValue('NIGHT')
       })
 
-      test.skip('calls handleChange on change', async () => {
+      test('calls handleChange on change', async () => {
         const { user, handleChange } = setup({
           collectionMetadata: {
             isOpenSearch: false,
@@ -379,20 +379,12 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        let newDayNightSelection = screen.getByRole('option', { name: 'Day' })
+        const dayNightSelection = screen.getByRole('combobox', { name: 'day-night-flag' })
 
-        await user.click(newDayNightSelection)
-        // Const dayNightSection = enzymeWrapper.find(SidebarFiltersItem).at(2)
-        expect(handleChange).toHaveBeenCalledTimes(1)
-        expect(handleChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            _reactName: 'onChange'
-          })
-        )
+        await user.selectOptions(dayNightSelection, 'Day')
+        await user.selectOptions(dayNightSelection, 'Both')
 
-        newDayNightSelection = screen.getByRole('option', { name: 'Both' })
-        await user.click(newDayNightSelection)
-        expect(handleChange).toHaveBeenCalledTimes(1)
+        expect(handleChange).toHaveBeenCalledTimes(2)
         expect(handleChange).toHaveBeenCalledWith(
           expect.objectContaining({
             _reactName: 'onChange'
@@ -977,7 +969,7 @@ describe('GranuleFiltersForm component', () => {
       // expect(gridCoordsSection.find(Form.Control).at(0).prop('value')).toEqual('')
     })
 
-    test.skip('calls handleChange on change', async () => {
+    test('calls handleChange on change', async () => {
       const { handleChange, user } = setup({
         collectionMetadata: {
           tilingIdentificationSystems: [
@@ -997,10 +989,8 @@ describe('GranuleFiltersForm component', () => {
       })
 
       const tileOptions = screen.getByRole('combobox', 'tilingSystem')
-      await user.click(tileOptions)
+      await user.selectOptions(tileOptions, 'MISR')
 
-      const misrTileOption = screen.getByRole('option', { name: 'MISR' })
-      await user.click(misrTileOption)
       expect(handleChange).toHaveBeenCalledTimes(1)
       // Const gridCoordsSection = enzymeWrapper.find(SidebarFiltersItem).at(1)
       // gridCoordsSection.find(Form.Control).prop('onChange')({ target: { value: 'MISR' } })

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -9,6 +9,7 @@ import { Form, FormControl } from 'react-bootstrap'
 import GranuleFiltersForm from '../GranuleFiltersForm'
 import SidebarFiltersItem from '../../Sidebar/SidebarFiltersItem'
 import TemporalSelection from '../../TemporalSelection/TemporalSelection'
+import EDSCIcon from '../../EDSCIcon/EDSCIcon'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -50,6 +51,16 @@ describe('GranuleFiltersForm component', () => {
     const { enzymeWrapper } = setup()
 
     expect(enzymeWrapper.type()).toBe(FormikForm)
+  })
+
+  // TODO finnish test
+  test.only('displays granule name tool-tip', () => {
+    const { enzymeWrapper } = setup()
+
+    const item = enzymeWrapper.find(EDSCIcon)
+    console.log('🚀 ~ file: GranuleFiltersForm.test.js:60 ~ item:', item)
+
+    item.simulate('mouseenter')
   })
 
   describe('Filtered Granules', () => {

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
@@ -244,7 +244,7 @@ describe('GranuleFiltersContainer component', () => {
           }
         })
 
-        const tooltipText = /Filter granules by name/i
+        const tooltipText = /Filter granules by using a granule ID/i
 
         expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
 
@@ -255,7 +255,10 @@ describe('GranuleFiltersContainer component', () => {
           await user.hover(readableGranuleNameTMoreInfo)
         })
 
-        expect(screen.getByText(tooltipText)).toBeVisible()
+        // Ensure Tooltip sections are rendering
+        expect(screen.getByText(/Asterisks/i)).toBeVisible()
+        expect(screen.getByText(/Question marks/i)).toBeVisible()
+        expect(screen.getByText(/Commas/i)).toBeVisible()
       })
     })
   })

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
@@ -247,7 +247,7 @@ describe('GranuleFiltersContainer component', () => {
         const tooltipText = /Filter granules by using a granule ID/i
 
         expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
-        const readableGranuleNameTMoreInfo = screen.getByRole('img', { name: 'View more info on granule id filter' })
+        const readableGranuleNameTMoreInfo = screen.getByRole('img', { name: 'A question mark in a circle' })
 
         // Only show tool-tip on hover
         await act(async () => {

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
@@ -247,8 +247,7 @@ describe('GranuleFiltersContainer component', () => {
         const tooltipText = /Filter granules by using a granule ID/i
 
         expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
-
-        const readableGranuleNameTMoreInfo = screen.getByTitle('granule-name-filter-more-info')
+        const readableGranuleNameTMoreInfo = screen.getByRole('img', { name: 'View more info on granule id filter' })
 
         // Only show tool-tip on hover
         await act(async () => {

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
@@ -217,13 +217,12 @@ describe('GranuleFiltersContainer component', () => {
 
     describe('when the form is submitted', () => {
       test('handle submit is called', async () => {
-        const { handleSubmit } = setup({
+        const { handleSubmit, user } = setup({
           values: {
             test: 'test'
           }
         })
 
-        const user = userEvent.setup()
         const readableGranuleNameTextField = screen.getByRole('textbox', { name: 'Granule ID(s)' })
 
         await act(async () => {
@@ -239,7 +238,7 @@ describe('GranuleFiltersContainer component', () => {
 
     describe('when hovering over the readable granule name field', () => {
       test('displays tool-tip information', async () => {
-        setup({
+        const { user } = setup({
           values: {
             test: 'test'
           }
@@ -249,7 +248,6 @@ describe('GranuleFiltersContainer component', () => {
 
         expect(screen.queryByText(tooltipText)).not.toBeInTheDocument()
 
-        const user = userEvent.setup()
         const readableGranuleNameTMoreInfo = screen.getByTitle('granule-name-filter-more-info')
 
         // Only show tool-tip on hover

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js
@@ -89,7 +89,6 @@ const setup = (overrideProps) => {
     handleSubmit: handleFormSubmit
   })(GranuleFiltersContainer)
 
-  // Rendering formik wrapper https://formik.org/docs/migrating-v2#all-render-props-have-been-deprecated-with-a-console-warning
   render(
     <Provider store={store}>
       <Router history={history}>


### PR DESCRIPTION
# Overview

### What is the feature?

Improve the tool-tip access to further information on the 

### What is the Solution?

Summarize what you changed.

Updates the contents and mechanism we inform the user about this granule filter. Adds tool-tip with precise language

### What areas of the application does this impact?

List impacted areas.

Majority of code changes was technical debt reduction by rewriting the `static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js` and some minor cleanups to `static/src/js/containers/GranuleFiltersContainer/__tests__/GranuleFiltersContainer.test.js`

Updates the `serverless.yml` with setting for `esbuild` to ignore static and test files to improve performance in local development

# Testing

### Reproduction steps

- **Environment for testing:*Any*
- **Collection to test with:*Any*

1. On the Granules page for a selected collection hover over the Granule-Id tooltip on the form ensure text is good
2. Ensure that the placeholder text is accurate
3. Ensure Unit tests are running successfully and code coverage is maintained or improved

### Attachments

Wideview:
![image](https://github.com/user-attachments/assets/b1ff6c1f-9bfc-4955-bb57-e19faa26215b)


Close-up:
![image](https://github.com/user-attachments/assets/6aecb54a-e35d-4271-8e79-8d3bbbeff6bd)


Contract for the headers where setting the color:
![image](https://github.com/user-attachments/assets/39d14add-a9f6-439f-a339-6e892aa7ec63)


Contrast on the main text in the tooltip
![image](https://github.com/user-attachments/assets/22bddb57-f4d3-4fa3-8c65-95676f66e42e)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
