### PR TITLE
EDSC-4199: Granule browse images are not appearing on EDSC (IDN Search Portal)

### DIFF
--- a/static/src/js/components/EDSCImage/EDSCImage.jsx
+++ b/static/src/js/components/EDSCImage/EDSCImage.jsx
@@ -14,7 +14,7 @@ import './EDSCImage.scss'
  * @param {String} props.dataTestId - An optional test id.
  * @param {String} props.className - An optional css class attribute.
  * @param {Integer} props.height - The height of the image.
- * @param {Boolean} props.isBase64Image - If this image needs to be retrieved asynchronously because a header must be passed
+ * @param {Boolean} props.resizeImage - If this image needs to be retrieved asynchronously because a header must be passed
  * @param {String} props.src - The src to be used as the src attribute on the image..
  * @param {Boolean} props.srcSet - The srcSet to be used as the srcSet attribute on the image.
  * @param {Boolean} props.useSpinner - If the spinner should be used for this Image while it is loading
@@ -26,7 +26,7 @@ export const EDSCImage = (props) => {
     className,
     dataTestId,
     height,
-    isBase64Image,
+    resizeImage,
     src,
     srcSet,
     useSpinner,
@@ -61,7 +61,7 @@ export const EDSCImage = (props) => {
 
   useEffect(() => {
     let isMounted = true
-    if (isBase64Image && isMounted) {
+    if (resizeImage && isMounted) {
       parseScaleImageResponse()
     }
 
@@ -88,7 +88,7 @@ export const EDSCImage = (props) => {
       }
       {
         // If src is a standard image endpoint
-        !isErrored && !isBase64Image && (
+        !isErrored && !resizeImage && (
           <img
             className="edsc-image__image"
             alt={alt}
@@ -102,7 +102,7 @@ export const EDSCImage = (props) => {
         )
       }
       {
-        !isErrored && isLoaded && isBase64Image && (
+        !isErrored && isLoaded && resizeImage && (
           <img
             className="edsc-image__image"
             alt={alt}
@@ -121,7 +121,7 @@ export const EDSCImage = (props) => {
 EDSCImage.defaultProps = {
   className: undefined,
   dataTestId: undefined,
-  isBase64Image: false,
+  resizeImage: false,
   srcSet: undefined,
   useSpinner: true
 }
@@ -131,7 +131,7 @@ EDSCImage.propTypes = {
   className: PropTypes.string,
   dataTestId: PropTypes.string,
   height: PropTypes.number.isRequired,
-  isBase64Image: PropTypes.bool,
+  resizeImage: PropTypes.bool,
   src: PropTypes.string.isRequired,
   srcSet: PropTypes.string,
   useSpinner: PropTypes.bool,

--- a/static/src/js/components/EDSCImage/__tests__/EDSCImage.test.js
+++ b/static/src/js/components/EDSCImage/__tests__/EDSCImage.test.js
@@ -113,7 +113,7 @@ describe('EDSCImage component', () => {
             src="http://test.com/test.jpg"
             srcSet="http://test.com/test-2x.jpg 2x, http://test.com/test.jpg 1x"
             width={500}
-            isBase64Image
+            resizeImage
           />
         )
 
@@ -142,7 +142,7 @@ describe('EDSCImage component', () => {
             src="http://test.com/test.jpg"
             srcSet="http://test.com/test-2x.jpg 2x, http://test.com/test.jpg 1x"
             width={500}
-            isBase64Image
+            resizeImage
           />
         )
 

--- a/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
@@ -349,7 +349,7 @@ const GranuleResultsFocusedMeta = ({
                             alt={description || `Browse image for ${title}`}
                             width={175}
                             height={175}
-                            isBase64Image
+                            resizeImage
                           />
                         )
                       )
@@ -397,7 +397,7 @@ const GranuleResultsFocusedMeta = ({
                           alt={description || `Browse image for ${title}`}
                           width={538}
                           height={538}
-                          isBase64Image
+                          resizeImage
                         />
                       )
                     )

--- a/static/src/js/components/GranuleResults/GranuleResultsItem.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.jsx
@@ -99,6 +99,8 @@ const GranuleResultsItem = forwardRef(({
   const buildThumbnail = () => {
     let element = null
     if (granuleThumbnail) {
+      // Only resize image if it is not an opensearch granule
+      const shouldResizeImage = !isOpenSearch
       element = (
         <EDSCImage
           className="granule-results-item__thumb-image"
@@ -107,7 +109,7 @@ const GranuleResultsItem = forwardRef(({
           width={thumbnailWidth}
           alt={`Browse Image for ${title}`}
           useSpinner={false}
-          isBase64Image
+          resizeImage={shouldResizeImage}
         />
       )
 

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsItem.test.js
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsItem.test.js
@@ -393,6 +393,7 @@ describe('GranuleResultsItem component', () => {
       const { enzymeWrapper } = setup('cmr')
 
       expect(enzymeWrapper.find('.granule-results-item__thumb-image').prop('src')).toEqual('/fake/path/image.jpg')
+      expect(enzymeWrapper.find('.granule-results-item__thumb-image').prop('resizeImage')).toEqual(true)
     })
 
     test('renders the start and end date', () => {
@@ -440,6 +441,7 @@ describe('GranuleResultsItem component', () => {
       const { enzymeWrapper } = setup('opensearch')
 
       expect(enzymeWrapper.find('.granule-results-item__thumb-image').prop('src')).toEqual('/fake/path/image.jpg')
+      expect(enzymeWrapper.find('.granule-results-item__thumb-image').prop('resizeImage')).toEqual(false)
     })
 
     test('renders the start and end date', () => {


### PR DESCRIPTION
# Overview

### What is the feature?

In cases where the granules are `opensearch` they are not hosted on the CMR so the scaleImage lambda which attempts to fetch data from a CMR call is going to fail. Additionally the `id` value on the granule is actually a separate endpoint which is why we were seeing some `CORS` errors our `node-fetch` call was trying to go to the endpoint in the `id` 

### What is the Solution?

Create clause to only fetch the image using the scaleImage lambda if the granule is not an opensearch granule

### What areas of the application does this impact?

Granule Search result thumbnails for `opensearch` granules

# Testing

### Reproduction steps

- **Environment for testing:*Prod*
- **Collection to test with:*C3108204134-INPE*

1. Go to the http://localhost:8080/search/granules?portal=idn&p=C3108204134-INPE&pg[0][v]=f&pg[0][gsk]=-start_date&fdc=ESA%252FESRIN&fpj=FedEO&ac=true&tl=1719422073!3!!&lat=-8.477034055239216&long=-77.8095703125&zoom=6 endpoint and ensure that we have no console warnings and that the granule thumbnails are returning as you scroll down


2. Ensure that for non opensearch granules we are getting back the same thumbnails for granules as we were prior to the change

### Attachments

![image](https://github.com/user-attachments/assets/7e6fc676-254f-492e-a931-55f22d7fd361)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
