### PR TITLE
EDSC-4071: Improve the display of the Harmony tooltip

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -296,7 +296,6 @@ const AccessMethod = ({
   const getAccessMethodTypes = (hasHarmony, radioList, collectionId) => {
     if (hasHarmony) {
       const id = `${collectionId}_access-method__harmony_type`
-      console.log('🚀 ~ getAccessMethodTypes ~ hasHarmony:', hasHarmony)
 
       return (
         <>

--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -296,10 +296,17 @@ const AccessMethod = ({
   const getAccessMethodTypes = (hasHarmony, radioList, collectionId) => {
     if (hasHarmony) {
       const id = `${collectionId}_access-method__harmony_type`
+      console.log('🚀 ~ getAccessMethodTypes ~ hasHarmony:', hasHarmony)
 
       return (
         <>
           <AccessMethodRadio
+            externalLink={
+              {
+                link: 'https://harmony.earthdata.nasa.gov/',
+                message: 'What is Harmony?'
+              }
+            }
             key={id}
             id={id}
             value="HarmonyMethodType"

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -17,9 +17,9 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-jest.mock('../../FormFields/AccessMethodRadio/AccessMethodRadio', () => jest.fn(() => (
-  <mock-AccessMethodRadio />
-)))
+jest.mock('../../FormFields/AccessMethodRadio/AccessMethodRadio', () => jest.fn().mockImplementation(
+  jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio
+))
 
 afterEach(() => {
   // Don't share global state between the tests
@@ -158,8 +158,6 @@ describe('AccessMethod component', () => {
   })
 
   describe('radio button display', () => {
-    AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
-
     test('renders a radio button for download', () => {
       setup({
         accessMethods: {
@@ -175,7 +173,6 @@ describe('AccessMethod component', () => {
     })
 
     test('renders a radio button for echo orders', () => {
-      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
 
       setup({
         accessMethods: {
@@ -191,8 +188,6 @@ describe('AccessMethod component', () => {
     })
 
     test('renders a radio button for esi', () => {
-      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
-
       setup({
         accessMethods: {
           esi: {
@@ -356,7 +351,6 @@ describe('AccessMethod component', () => {
     })
 
     test('renders an echoform', async () => {
-      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
       const collectionId = 'collectionId'
       const form = 'echo form here'
 
@@ -460,7 +454,6 @@ describe('AccessMethod component', () => {
 
   describe('when the selected access method type is harmony', () => {
     test('sets the checkbox checked in Step 1 for "Customize with Harmony"', () => {
-      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
       const collectionId = 'collectionId'
       setup({
         accessMethods: {

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -10,11 +10,16 @@ import userEvent from '@testing-library/user-event'
 
 import ResizeObserver from 'resize-observer-polyfill'
 import AccessMethod from '../AccessMethod'
+import AccessMethodRadio from '../../FormFields/AccessMethodRadio/AccessMethodRadio'
 
 beforeEach(() => {
   global.ResizeObserver = ResizeObserver
   jest.clearAllMocks()
 })
+
+jest.mock('../../FormFields/AccessMethodRadio/AccessMethodRadio', () => jest.fn(() => (
+  <mock-AccessMethodRadio />
+)))
 
 afterEach(() => {
   // Don't share global state between the tests
@@ -153,6 +158,8 @@ describe('AccessMethod component', () => {
   })
 
   describe('radio button display', () => {
+    AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
+
     test('renders a radio button for download', () => {
       setup({
         accessMethods: {
@@ -168,6 +175,8 @@ describe('AccessMethod component', () => {
     })
 
     test('renders a radio button for echo orders', () => {
+      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
+
       setup({
         accessMethods: {
           echoOrder0: {
@@ -182,6 +191,8 @@ describe('AccessMethod component', () => {
     })
 
     test('renders a radio button for esi', () => {
+      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
+
       setup({
         accessMethods: {
           esi: {
@@ -218,6 +229,21 @@ describe('AccessMethod component', () => {
           }
         }
       })
+
+      // Called twice due to rerender from useEffect()
+      expect(AccessMethodRadio).toHaveBeenCalledTimes(2)
+      expect(AccessMethodRadio).toHaveBeenCalledWith(
+        expect.objectContaining({
+          externalLink: {
+            link: 'https://harmony.earthdata.nasa.gov/',
+            message: 'What is Harmony?'
+          },
+          title: 'Customize with Harmony',
+          details: 'Select options like variables, transformations, and output formats by applying a Harmony service. Data will be staged in the cloud for download and analysis.',
+          value: 'HarmonyMethodType'
+        }),
+        expect.anything()
+      )
 
       const directDownloadAccessMethodRadioButton = screen.getByRole('radio')
       // Multiple `Harmony` services are possible for a collection
@@ -330,6 +356,7 @@ describe('AccessMethod component', () => {
     })
 
     test('renders an echoform', async () => {
+      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
       const collectionId = 'collectionId'
       const form = 'echo form here'
 
@@ -433,6 +460,7 @@ describe('AccessMethod component', () => {
 
   describe('when the selected access method type is harmony', () => {
     test('sets the checkbox checked in Step 1 for "Customize with Harmony"', () => {
+      AccessMethodRadio.mockImplementation(jest.requireActual('../../FormFields/AccessMethodRadio/AccessMethodRadio').AccessMethodRadio)
       const collectionId = 'collectionId'
       setup({
         accessMethods: {

--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.js
@@ -173,7 +173,6 @@ describe('AccessMethod component', () => {
     })
 
     test('renders a radio button for echo orders', () => {
-
       setup({
         accessMethods: {
           echoOrder0: {

--- a/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.jsx
+++ b/static/src/js/components/FormFields/AccessMethodRadio/AccessMethodRadio.jsx
@@ -40,7 +40,6 @@ export const AccessMethodRadio = ({
       'access-method-radio--disable-button': disabled
     }
   ]
-
   const [showTooltip, setShowTooltip] = useState(false)
 
   const labelClassName = classNames(labelClasses)
@@ -125,7 +124,7 @@ export const AccessMethodRadio = ({
               overlay={
                 (
                   <Tooltip
-                    className="tooltip--ta-left tooltip--wide"
+                    className="tooltip--ta-left"
                     onMouseEnter={() => externalLink && setShowTooltip(true)}
                     onMouseLeave={() => externalLink && setShowTooltip(false)}
                   >
@@ -135,7 +134,7 @@ export const AccessMethodRadio = ({
                       </p>
                       {
                         externalLink && (
-                          <ExternalLink href={externalLink.link} className="d-inline-block mt-3" variant="light">
+                          <ExternalLink href={externalLink.link} className="d-inline-block mt-3 mb-1" variant="light">
                             {externalLink.message}
                           </ExternalLink>
                         )


### PR DESCRIPTION
# Overview

### What is the feature?

Taking a second look at and improving the tool tip for the harmony access method.

### What is the Solution?

We added a link to the harmony landing page mainly, there are some mild adjustments to margin and link color as well.

### What areas of the application does this impact?

AccessMethod and AccessMethodRadio

# Testing

### Reproduction steps

- **Environment for testing:** prod
- **Collection to test with:** C1996881146-POCLOUD

1. Select granules and progress to project page
2. Open up the access method component and mouse over/hover the ? icon to display the tooltip

### Attachments

Before:
<img width="386" alt="Screenshot 2024-10-09 at 8 21 55 AM" src="https://github.com/user-attachments/assets/3097358d-e25d-4797-9a0a-8933b4e13bf6">

After:
<img width="304" alt="Screenshot 2024-10-09 at 8 22 01 AM" src="https://github.com/user-attachments/assets/8877c999-ae65-4f24-8a0c-e4d7c6428497">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
