### PR TITLE
EDSC-4108: Sends full date time in GIBS request for imagery. Increases lambda memory for generating GIBS tags

### DIFF
--- a/serverless-configs/aws-functions.yml
+++ b/serverless-configs/aws-functions.yml
@@ -175,6 +175,7 @@
   generateGibsTags:
     handler: serverless/src/generateGibsTags/handler.default
     description: Tag CMR collections with GIBS product information
+    memorySize: 512
     timeout: 300
     events:
       - schedule:

--- a/static/src/js/components/Map/GranuleGridLayerExtended.jsx
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.jsx
@@ -248,8 +248,6 @@ export class GranuleGridLayerExtended extends L.GridLayer {
 
     if (!this.gibsTag) return null
 
-    const date = granule.timeStart != null ? granule.timeStart.substring(0, 10) : undefined
-
     let matched = false
 
     // Select only the first layer until we are able to toggle between gibs layers.
@@ -319,11 +317,9 @@ export class GranuleGridLayerExtended extends L.GridLayer {
 
     if (!matched) { return null }
 
-    this.options.time = date
     if (this.options.granule) {
       this._originalUrl = this._originalUrl || this._url
       this._url = config.gibsGranuleUrl || this._originalUrl
-      this.options.time = granule.timeStart.replace(/\.\d{3}Z$/, 'Z')
     } else {
       this._url = this._originalUrl || this._url || config.gibsUrl
     }
@@ -333,7 +329,7 @@ export class GranuleGridLayerExtended extends L.GridLayer {
       x: tilePoint.x,
       y: tilePoint.y,
       z: tilePoint.z,
-      time: this.options.time
+      time: granule.timeStart
     }
 
     if (this._map && !this._map.options.crs.infinite) {

--- a/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
+++ b/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
@@ -143,7 +143,7 @@ describe('GranuleGridLayerExtended class', () => {
       }
 
       const result = layer.getTileUrl(tilePoint, updateProps.granules[0])
-      expect(result).toEqual('https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png')
+      expect(result).toEqual('https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png')
     })
   })
 

--- a/static/src/js/components/Map/__tests__/mocks.js
+++ b/static/src/js/components/Map/__tests__/mocks.js
@@ -1361,7 +1361,7 @@ export const pathsWithHolesResult = [[{
     y: 18
   }],
   index: 0,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h09v09.006.2020291073948.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',
@@ -1496,7 +1496,7 @@ export const pathsWithHolesResult = [[{
     y: 18
   }],
   index: 1,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h08v09.006.2020291074020.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',
@@ -1631,7 +1631,7 @@ export const pathsWithHolesResult = [[{
     y: 0
   }],
   index: 2,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h08v08.006.2020291074011.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',
@@ -1768,7 +1768,7 @@ export const pathsResult = [{
     y: 18
   }],
   index: 0,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h09v09.006.2020291073948.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',
@@ -1903,7 +1903,7 @@ export const pathsResult = [{
     y: 18
   }],
   index: 1,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h08v09.006.2020291074020.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',
@@ -2038,7 +2038,7 @@ export const pathsResult = [{
     y: 0
   }],
   index: 2,
-  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29/250m/0/0/0.png',
+  url: 'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_L3_EVI_16Day/default/2020-09-29T00:00:00.000Z/250m/0/0/0.png',
   granule: {
     producerGranuleId: 'MOD13Q1.A2020273.h08v08.006.2020291074011.hdf',
     timeStart: '2020-09-29T00:00:00.000Z',


### PR DESCRIPTION
# Overview

### What is the feature?

1. Some collections are reported to be showing the same GIBS image for every granule.
2. Some collections that should have imagery are not showing any.

### What is the Solution?

1. We are currently sending just the date to GIBS when requesting granule imagery. We need to be sending the full date time of the granule to retrieve the correct image for each granule
2. Our lambda has been running out of memory and not successfully creating the tags we use to trigger the request for granule imagery. Increasing that lambda memory will allow the function to finish execution.

### What areas of the application does this impact?

Granule imagery

# Testing

This collection was reported to show the same image for each granule. If you open your browser dev tools and look at the image request for the granule imagery, you should see the full date time, rather than just the date

http://localhost:8080/search/granules?p=C2930763263-LARC_CLOUD&q=C2930763263-LARC_CLOUD&ot=2024-07-01T00%3A00%3A00.000Z%2C2024-07-31T23%3A59%3A59.999Z&tl=1728336950!3!!&lat=-12.65625&long=-67.78125&zoom=1

Good: 
https://gitc.earthdata.nasa.gov/wmts/epsg4326/best/TEMPO_L3_NO2_Vertical_Column_Troposphere/default/2024-07-01T23:14:22.000Z/1km/1/0/0.png
Bad: 
https://gitc.earthdata.nasa.gov/wmts/epsg4326/best/TEMPO_L3_NO2_Vertical_Column_Troposphere/default/2024-07-01/1km/1/0/0.png

We cannot verify the lambda memory change fixes the issue until the code reaches production, as that is the only place we generate those tags. In SIT/UAT we can verify the lambda completes, but the tags will not be written correctly because we only have data on production collections

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
