### PR TITLE
EDSC-4108: Adds 'granule' type layers to GIBS tagging job

### DIFF
--- a/serverless/src/generateGibsTags/__tests__/handler.test.js
+++ b/serverless/src/generateGibsTags/__tests__/handler.test.js
@@ -55,7 +55,7 @@ describe('generateGibsTags', () => {
 
     await generateGibsTags({}, {})
 
-    expect(mocksqsSendMessage.mock.calls.length).toEqual(4)
+    expect(mocksqsSendMessage.mock.calls.length).toEqual(5)
 
     expect(mocksqsSendMessage.mock.calls[0]).toEqual([{
       QueueUrl: 'http://example.com/tagQueue',
@@ -158,6 +158,36 @@ describe('generateGibsTags', () => {
       QueueUrl: 'http://example.com/tagQueue',
       MessageBody: JSON.stringify({
         tagName: 'edsc.extra.serverless.gibs',
+        action: 'ADD',
+        requireGranules: false,
+        tagData: {
+          'concept-id': 'C1000000004-EDSC',
+          data: [{
+            match: {
+              time_start: '>=2024-05-13T10:41:03Z',
+              day_night_flag: 'unspecified'
+            },
+            product: 'TEMPO_L2_Ozone_Cloud_Fraction_Granule',
+            group: 'overlays',
+            title: 'Ozone (L2, Cloud Fraction, Subdaily) (BETA)',
+            source: 'TEMPO',
+            format: 'png',
+            updated_at: '1988-09-03T10:00:00.000Z',
+            antarctic: false,
+            antarctic_resolution: null,
+            arctic: false,
+            arctic_resolution: null,
+            geographic: true,
+            geographic_resolution: '1km'
+          }]
+        }
+      })
+    }])
+
+    expect(mocksqsSendMessage.mock.calls[4]).toEqual([{
+      QueueUrl: 'http://example.com/tagQueue',
+      MessageBody: JSON.stringify({
+        tagName: 'edsc.extra.serverless.gibs',
         action: 'REMOVE',
         searchCriteria: {
           condition: {
@@ -173,6 +203,8 @@ describe('generateGibsTags', () => {
                   concept_id: 'C1000000002-EDSC'
                 }, {
                   concept_id: 'C1000000003-EDSC'
+                }, {
+                  concept_id: 'C1000000004-EDSC'
                 }]
               }
             }]

--- a/serverless/src/generateGibsTags/__tests__/mocks.js
+++ b/serverless/src/generateGibsTags/__tests__/mocks.js
@@ -132,6 +132,79 @@ export const gibsResponse = {
       daynight: [
         'day'
       ]
+    },
+    TEMPO_L2_Ozone_Cloud_Fraction_Granule: {
+      title: 'Ozone (L2, Cloud Fraction, Subdaily) (BETA)',
+      subtitle: 'TEMPO',
+      ongoing: true,
+      daynight: [
+        'unspecified'
+      ],
+      conceptIds: [
+        {
+          type: 'STD',
+          value: 'C1000000004-EDSC',
+          shortName: 'TEMPO_O3TOT_L2',
+          title: 'TEMPO ozone total column V03 (BETA)',
+          version: 'V03',
+          dataCenter: 'LARC_CLOUD'
+        }
+      ],
+      layerPeriod: 'Daily',
+      id: 'TEMPO_L2_Ozone_Cloud_Fraction_Granule',
+      description: 'tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule',
+      tags: '',
+      group: 'overlays',
+      layergroup: 'Ozone',
+      type: 'granule',
+      period: 'subdaily',
+      count: 1,
+      cmrAvailability: true,
+      startDate: '2024-05-13T10:41:03Z',
+      disableSnapshot: true,
+      format: 'image/png',
+      dateRanges: [
+        {
+          startDate: '2024-05-13T10:41:03Z',
+          endDate: '2024-05-13T10:41:03Z',
+          dateInterval: '6'
+        },
+        {
+          startDate: '2024-05-13T10:47:43Z',
+          endDate: '2024-05-13T10:47:43Z',
+          dateInterval: '6'
+        },
+        {
+          startDate: '2024-05-13T10:54:20Z',
+          endDate: '2024-05-13T10:54:20Z',
+          dateInterval: '6'
+        }
+      ],
+      projections: {
+        geographic: {
+          source: 'GIBS:geographic',
+          matrixSet: '1km'
+        }
+      },
+      palette: {
+        id: 'TEMPO_Ozone_Cloud_Fraction'
+      }
+    },
+    breakPointLayer: {
+      id: 'VIIRS_NOAA20_Thermal_Anomalies_375m_All',
+      type: 'wms',
+      format: 'image/png',
+      breakPointType: 'max',
+      projections: {
+        geographic: {
+          resolutionBreakPoint: 0.017578125,
+          source: 'GIBS:wms'
+        },
+        arctic: {
+          source: 'GIBS:wms:arctic',
+          resolutionBreakPoint: 2048
+        }
+      }
     }
   }
 }

--- a/serverless/src/generateGibsTags/getSupportedGibsLayers.js
+++ b/serverless/src/generateGibsTags/getSupportedGibsLayers.js
@@ -36,7 +36,9 @@ export const getSupportedGibsLayers = async () => {
     const { conceptIds, projections, type } = currentLayer
 
     // Ignore non Web Map Tile Service layers
-    if (type !== 'wmts') {
+    // `granule` type layers are WMTS layers with special properties for Worldview. We need to
+    // process them the same way we do WMTS layers
+    if (type !== 'wmts' && type !== 'granule') {
       return
     }
 

--- a/serverless/src/util/authorizer/validateToken.js
+++ b/serverless/src/util/authorizer/validateToken.js
@@ -48,8 +48,8 @@ export const validateToken = async (jwtToken, earthdataEnvironment) => {
       } = verifiedJwtToken
 
       // Retrieve the authenticated users' access tokens from the database
-      const existingUserTokens = await dbConnection('user_tokens')
-        .select([
+      const mostRecentToken = await dbConnection('user_tokens')
+        .first([
           'id',
           'access_token',
           'refresh_token',
@@ -61,12 +61,8 @@ export const validateToken = async (jwtToken, earthdataEnvironment) => {
         })
         .orderBy('created_at', 'DESC')
 
-      if (existingUserTokens.length === 0) {
-        return false
-      }
-
-      // In the off chance there are more than one, return the most recent token
-      const [mostRecentToken] = existingUserTokens
+      // If no token was found, return false
+      if (!mostRecentToken) return false
 
       const {
         access_token: accessToken,


### PR DESCRIPTION
# Overview

### What is the feature?

When we parse the wv.json file to build our GIBS tags, we need to be processing 'granule' type layers the same way we do 'wmts' type layers.

I also made a change to validateToken to only request a single row from the database, an improvement over requesting many rows and only using the first row. We want to see if this improves performance issues we've been seeing in production.

### What areas of the application does this impact?

GIBS tagging/imagery

# Testing

To fully test this process we need to run the code in production, because the collection concept-ids are only found in production

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
