### PR TITLE
EDSC-4218: Don't submit granule queries on each keystroke of temporal entry

### DIFF
--- a/static/src/js/components/Datepicker/Datepicker.jsx
+++ b/static/src/js/components/Datepicker/Datepicker.jsx
@@ -101,13 +101,19 @@ class Datepicker extends PureComponent {
       conditionalInputProps.value = ''
     }
 
+    const onKeyDown = (event) => {
+      // If the user presses `Enter`, the field should behave the same as bluring the input
+      if (event.key === 'Enter') onInputBlur(event)
+    }
+
     return (
       <Datetime
         className="datetime"
+        closeOnClickOutside
         closeOnSelect
         closeOnTab
-        closeOnClickOutside
         dateFormat={format}
+        initialViewMode={viewMode}
         inputProps={
           {
             id,
@@ -115,25 +121,25 @@ class Datepicker extends PureComponent {
             autoComplete: 'off',
             className: `form-control ${size === 'sm' ? 'form-control-sm' : ''}`,
             'aria-label': label,
-            onChange: (e) => {
-              this.onInputChange(e)
+            onChange: (event) => {
+              this.onInputChange(event)
 
               // eslint-disable-next-line no-underscore-dangle
               picker.current._closeCalendar()
             },
             onBlur: onInputBlur,
+            onKeyDown,
             ...conditionalInputProps
           }
         }
         isValidDate={isValidDate}
         onChange={onChange}
         ref={picker}
+        strictParsing
         timeFormat={false}
         utc
         value={value}
-        strictParsing
         viewMode={viewMode}
-        initialViewMode={viewMode}
       />
     )
   }

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -502,10 +502,9 @@ export const GranuleFiltersForm = (props) => {
                 }
                 onSubmitStart={
                   (startDate, shouldSubmit) => {
-                    const {
-                      input
-                    } = startDate.creationData()
+                    const { input } = startDate.creationData()
                     const value = startDate.isValid() ? startDate.toISOString() : input
+
                     setFieldValue('temporal.startDate', value)
                     setFieldTouched('temporal.startDate')
 
@@ -515,7 +514,7 @@ export const GranuleFiltersForm = (props) => {
                     }
 
                     // Only call handleSubmit if `onSubmitStart` was called
-                    if (shouldSubmit && startDate.isValid()) {
+                    if (shouldSubmit && (startDate.isValid() || !input)) {
                       handleSubmit()
 
                       // Submit usage metric for setting Start Date granule filter
@@ -528,10 +527,9 @@ export const GranuleFiltersForm = (props) => {
                 }
                 onSubmitEnd={
                   (endDate, shouldSubmit) => {
-                    const {
-                      input
-                    } = endDate.creationData()
+                    const { input } = endDate.creationData()
                     const value = endDate.isValid() ? endDate.toISOString() : input
+
                     setFieldValue('temporal.endDate', value)
                     setFieldTouched('temporal.endDate')
 
@@ -540,7 +538,7 @@ export const GranuleFiltersForm = (props) => {
                       setFieldValue('temporal.recurringDayEnd', endDate.dayOfYear())
                     }
 
-                    if (shouldSubmit && endDate.isValid()) {
+                    if (shouldSubmit && (endDate.isValid() || !input)) {
                       handleSubmit()
 
                       // Submit usage metric for setting End Date granule filter
@@ -856,15 +854,13 @@ export const GranuleFiltersForm = (props) => {
                             validate={false}
                             onSubmitStart={
                               (startDate, shouldSubmit) => {
-                                const {
-                                  input
-                                } = startDate.creationData()
+                                const { input } = startDate.creationData()
                                 const value = startDate.isValid() ? startDate.toISOString() : input
 
                                 setFieldValue('equatorCrossingDate.startDate', value)
                                 setFieldTouched('equatorCrossingDate.startDate')
 
-                                if (shouldSubmit && startDate.isValid()) {
+                                if (shouldSubmit && (startDate.isValid() || !input)) {
                                   handleSubmit()
                                   onMetricsGranuleFilter({
                                     type: 'Equatorial Crossing Set Start Date',
@@ -875,15 +871,13 @@ export const GranuleFiltersForm = (props) => {
                             }
                             onSubmitEnd={
                               (endDate, shouldSubmit) => {
-                                const {
-                                  input
-                                } = endDate.creationData()
+                                const { input } = endDate.creationData()
                                 const value = endDate.isValid() ? endDate.toISOString() : input
 
                                 setFieldValue('equatorCrossingDate.endDate', value)
                                 setFieldTouched('equatorCrossingDate.endDate')
 
-                                if (shouldSubmit && endDate.isValid()) {
+                                if (shouldSubmit && (endDate.isValid() || !input)) {
                                   handleSubmit()
                                   onMetricsGranuleFilter({
                                     type: 'Equatorial Crossing Set End Date',

--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -501,9 +501,11 @@ export const GranuleFiltersForm = (props) => {
                   }
                 }
                 onSubmitStart={
-                  (startDate) => {
-                  // eslint-disable-next-line no-underscore-dangle
-                    const value = startDate.isValid() ? startDate.toISOString() : startDate._i
+                  (startDate, shouldSubmit) => {
+                    const {
+                      input
+                    } = startDate.creationData()
+                    const value = startDate.isValid() ? startDate.toISOString() : input
                     setFieldValue('temporal.startDate', value)
                     setFieldTouched('temporal.startDate')
 
@@ -512,19 +514,24 @@ export const GranuleFiltersForm = (props) => {
                       setFieldValue('temporal.recurringDayStart', startDate.dayOfYear())
                     }
 
-                    handleSubmit()
+                    // Only call handleSubmit if `onSubmitStart` was called
+                    if (shouldSubmit && startDate.isValid()) {
+                      handleSubmit()
 
-                    // Submit usage metric for setting Start Date granule filter
-                    onMetricsGranuleFilter({
-                      type: 'Set Start Date',
-                      value
-                    })
+                      // Submit usage metric for setting Start Date granule filter
+                      onMetricsGranuleFilter({
+                        type: 'Set Start Date',
+                        value
+                      })
+                    }
                   }
                 }
                 onSubmitEnd={
-                  (endDate) => {
-                  // eslint-disable-next-line no-underscore-dangle
-                    const value = endDate.isValid() ? endDate.toISOString() : endDate._i
+                  (endDate, shouldSubmit) => {
+                    const {
+                      input
+                    } = endDate.creationData()
+                    const value = endDate.isValid() ? endDate.toISOString() : input
                     setFieldValue('temporal.endDate', value)
                     setFieldTouched('temporal.endDate')
 
@@ -533,13 +540,15 @@ export const GranuleFiltersForm = (props) => {
                       setFieldValue('temporal.recurringDayEnd', endDate.dayOfYear())
                     }
 
-                    handleSubmit()
+                    if (shouldSubmit && endDate.isValid()) {
+                      handleSubmit()
 
-                    // Submit usage metric for setting End Date granule filter
-                    onMetricsGranuleFilter({
-                      type: 'Set End Date',
-                      value
-                    })
+                      // Submit usage metric for setting End Date granule filter
+                      onMetricsGranuleFilter({
+                        type: 'Set End Date',
+                        value
+                      })
+                    }
                   }
                 }
               />
@@ -846,33 +855,41 @@ export const GranuleFiltersForm = (props) => {
                             temporal={equatorCrossingDate}
                             validate={false}
                             onSubmitStart={
-                              (startDate) => {
-                                const value = startDate.isValid()
-                                // eslint-disable-next-line no-underscore-dangle
-                                  ? startDate.toISOString() : startDate._i
+                              (startDate, shouldSubmit) => {
+                                const {
+                                  input
+                                } = startDate.creationData()
+                                const value = startDate.isValid() ? startDate.toISOString() : input
+
                                 setFieldValue('equatorCrossingDate.startDate', value)
                                 setFieldTouched('equatorCrossingDate.startDate')
 
-                                handleSubmit()
-                                onMetricsGranuleFilter({
-                                  type: 'Equatorial Crossing Set Start Date',
-                                  value
-                                })
+                                if (shouldSubmit && startDate.isValid()) {
+                                  handleSubmit()
+                                  onMetricsGranuleFilter({
+                                    type: 'Equatorial Crossing Set Start Date',
+                                    value
+                                  })
+                                }
                               }
                             }
                             onSubmitEnd={
-                              (endDate) => {
-                                const value = endDate.isValid()
-                                // eslint-disable-next-line no-underscore-dangle
-                                  ? endDate.toISOString() : endDate._i
+                              (endDate, shouldSubmit) => {
+                                const {
+                                  input
+                                } = endDate.creationData()
+                                const value = endDate.isValid() ? endDate.toISOString() : input
+
                                 setFieldValue('equatorCrossingDate.endDate', value)
                                 setFieldTouched('equatorCrossingDate.endDate')
 
-                                handleSubmit()
-                                onMetricsGranuleFilter({
-                                  type: 'Equatorial Crossing Set End Date',
-                                  value
-                                })
+                                if (shouldSubmit && endDate.isValid()) {
+                                  handleSubmit()
+                                  onMetricsGranuleFilter({
+                                    type: 'Equatorial Crossing Set End Date',
+                                    value
+                                  })
+                                }
                               }
                             }
                           />

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
+import MockDate from 'mockdate'
 
 import GranuleFiltersForm from '../GranuleFiltersForm'
 
@@ -20,6 +21,8 @@ jest.mock('formik', () => ({
 // TODO: Figure out how to test validation @low
 
 const setup = (overrideProps) => {
+  const user = userEvent.setup()
+
   const handleBlur = jest.fn()
   const handleChange = jest.fn()
   const handleSubmit = jest.fn()
@@ -49,8 +52,6 @@ const setup = (overrideProps) => {
   render(
     <GranuleFiltersForm {...props} />
   )
-
-  const user = userEvent.setup()
 
   return {
     handleBlur,
@@ -242,8 +243,51 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls the correct callbacks on startDate submit', async () => {
+          MockDate.set('2019-08-13')
+
           const {
-            onMetricsGranuleFilter, setFieldTouched, setFieldValue, user
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
+          } = setup({
+            values: {
+              temporal: {
+                startDate: '',
+                endDate: '2019-08-14T23:59:59:999Z'
+              }
+            }
+          })
+
+          const button = screen.getAllByRole('button', { name: 'Today' })[0]
+          await user.click(button)
+
+          expect(setFieldTouched).toHaveBeenCalledTimes(1)
+          expect(setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
+
+          expect(setFieldValue).toHaveBeenCalledTimes(1)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2019-08-13T00:00:00.000Z')
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+          expect(handleSubmit).toHaveBeenCalledWith()
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set Start Date',
+            value: '2019-08-13T00:00:00.000Z'
+          })
+
+          MockDate.reset()
+        })
+
+        test('does not call handleSubmit if shouldSubmit is false on startDate submit', async () => {
+          const {
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
           } = setup({
             values: {
               temporal: {
@@ -254,29 +298,30 @@ describe('GranuleFiltersForm component', () => {
           })
 
           const startDateTextField = screen.getByRole('textbox', { name: 'Start Date' })
+          await user.type(startDateTextField, '2019')
 
-          await user.click(startDateTextField)
-          await user.type(startDateTextField, '2019-08-13')
-
-          await user.tab(startDateTextField)
-          expect(setFieldTouched).toHaveBeenCalledTimes(10)
+          expect(setFieldTouched).toHaveBeenCalledTimes(4)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
 
-          expect(setFieldValue).toHaveBeenCalledTimes(10)
+          expect(setFieldValue).toHaveBeenCalledTimes(4)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '2')
           expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '0')
           expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '1')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '9')
 
-          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(10)
-          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
-            type: 'Set Start Date',
-            value: '2'
-          })
+          expect(handleSubmit).toHaveBeenCalledTimes(0)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
         })
 
         test('calls the correct callbacks on endDate submit', async () => {
+          MockDate.set('2019-08-14')
+
           const {
-            onMetricsGranuleFilter, setFieldTouched, setFieldValue, user
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
           } = setup({
             values: {
               temporal: {
@@ -285,30 +330,66 @@ describe('GranuleFiltersForm component', () => {
               }
             }
           })
-          const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
 
-          await user.click(endDateTextField)
-          await user.type(endDateTextField, '2019-08-14')
-          await user.tab(endDateTextField)
+          const button = screen.getAllByRole('button', { name: 'Today' })[1]
+          await user.click(button)
 
-          expect(setFieldTouched).toHaveBeenCalledTimes(10)
+          expect(setFieldTouched).toHaveBeenCalledTimes(1)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.endDate')
 
-          expect(setFieldValue).toHaveBeenCalledTimes(10)
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2')
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '0')
-          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '1')
+          expect(setFieldValue).toHaveBeenCalledTimes(1)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2019-08-14T23:59:59.000Z')
 
-          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(10)
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+          expect(handleSubmit).toHaveBeenCalledWith()
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
           expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
             type: 'Set End Date',
-            value: '2'
+            value: '2019-08-14T23:59:59.000Z'
           })
+
+          MockDate.reset()
+        })
+
+        test('does not call handleSubmit if shouldSubmit is false on endDate submit', async () => {
+          const {
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
+          } = setup({
+            values: {
+              temporal: {
+                startDate: '2019-08-13T00:00:00:000Z',
+                endDate: ''
+              }
+            }
+          })
+
+          const endDateTextField = screen.getByRole('textbox', { name: 'End Date' })
+          await user.type(endDateTextField, '2020')
+
+          expect(setFieldTouched).toHaveBeenCalledTimes(4)
+          expect(setFieldTouched).toHaveBeenCalledWith('temporal.endDate')
+
+          expect(setFieldValue).toHaveBeenCalledTimes(4)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '0')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '2')
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '0')
+
+          expect(handleSubmit).toHaveBeenCalledTimes(0)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
         })
 
         test('calls the correct callbacks on onRecurringToggle', async () => {
           const {
-            onMetricsGranuleFilter, user, setFieldTouched, setFieldValue
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
           } = setup({
             values: {
               temporal: {
@@ -341,7 +422,11 @@ describe('GranuleFiltersForm component', () => {
         })
 
         test('calls the correct callbacks on onRecurringToggle when a leap day is involved', async () => {
-          const { user, setFieldTouched, setFieldValue } = setup({
+          const {
+            setFieldTouched,
+            setFieldValue,
+            user
+          } = setup({
             values: {
               temporal: {
                 startDate: '2019-06-01T00:00:00.000Z',
@@ -1041,7 +1126,13 @@ describe('GranuleFiltersForm component', () => {
       })
 
       test('calls the correct callbacks on startDate submit', async () => {
-        const { setFieldTouched, setFieldValue, user } = setup({
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
           collectionMetadata: {
             isOpenSearch: false,
             tags: {
@@ -1057,22 +1148,73 @@ describe('GranuleFiltersForm component', () => {
             }
           }
         })
+
         const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
+        await user.type(equatorCrossingStartDateTextField, '2019')
 
-        await user.click(equatorCrossingStartDateTextField)
-        await user.type(equatorCrossingStartDateTextField, '2019-08-13')
-        await user.tab(equatorCrossingStartDateTextField)
-
-        expect(setFieldTouched).toHaveBeenCalledTimes(10)
+        expect(setFieldTouched).toHaveBeenCalledTimes(4)
         expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.startDate')
-        expect(setFieldValue).toHaveBeenCalledTimes(10)
+
+        expect(setFieldValue).toHaveBeenCalledTimes(4)
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '0')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '0')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(0)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
+      })
+
+      test('does not call handleSubmit if shouldSubmit is false on startDate submit', async () => {
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
+          collectionMetadata: {
+            isOpenSearch: false,
+            tags: {
+              'edsc.extra.serverless.collection_capabilities': {
+                data: { orbit_calculated_spatial_domains: true }
+              }
+            }
+          },
+          values: {
+            equatorCrossingDate: {
+              startDate: '',
+              endDate: '2019-08-14T23:59:59:999Z'
+            }
+          }
+        })
+
+        const endDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
+        await user.type(endDateTextField, '2019')
+
+        expect(setFieldTouched).toHaveBeenCalledTimes(4)
+        expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.startDate')
+
+        expect(setFieldValue).toHaveBeenCalledTimes(4)
         expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2')
         expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '0')
         expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '1')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '9')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(0)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
       })
 
       test('calls the correct callbacks on endDate submit', async () => {
-        const { setFieldTouched, setFieldValue, user } = setup({
+        MockDate.set('2019-08-14')
+
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
           collectionMetadata: {
             isOpenSearch: false,
             tags: {
@@ -1089,18 +1231,65 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingEndDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
+        const button = screen.getAllByRole('button', { name: 'Today' })[3]
+        await user.click(button)
 
-        await user.click(equatorCrossingEndDateTextField)
-        await user.type(equatorCrossingEndDateTextField, '2019-08-14')
-        await user.tab(equatorCrossingEndDateTextField)
-
-        expect(setFieldTouched).toHaveBeenCalledTimes(10)
+        expect(setFieldTouched).toHaveBeenCalledTimes(1)
         expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.endDate')
-        expect(setFieldValue).toHaveBeenCalledTimes(10)
+
+        expect(setFieldValue).toHaveBeenCalledTimes(1)
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '2019-08-14T23:59:59.000Z')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(1)
+        expect(handleSubmit).toHaveBeenCalledWith()
+
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+          type: 'Equatorial Crossing Set End Date',
+          value: '2019-08-14T23:59:59.000Z'
+        })
+
+        MockDate.reset()
+      })
+
+      test('does not call handleSubmit if shouldSubmit is false on endDate submit', async () => {
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
+          collectionMetadata: {
+            isOpenSearch: false,
+            tags: {
+              'edsc.extra.serverless.collection_capabilities': {
+                data: { orbit_calculated_spatial_domains: true }
+              }
+            }
+          },
+          values: {
+            equatorCrossingDate: {
+              startDate: '2019-08-13T00:00:00:000Z',
+              endDate: ''
+            }
+          }
+        })
+
+        const endDateTextField = screen.getAllByRole('textbox', { name: 'End Date' })[1]
+        await user.type(endDateTextField, '2020')
+
+        expect(setFieldTouched).toHaveBeenCalledTimes(4)
+        expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.endDate')
+
+        expect(setFieldValue).toHaveBeenCalledTimes(4)
         expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '2')
         expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '0')
-        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '1')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '2')
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '0')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(0)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.js
@@ -281,6 +281,46 @@ describe('GranuleFiltersForm component', () => {
           MockDate.reset()
         })
 
+        test('calls the correct callbacks on startDate submit with an empty value', async () => {
+          MockDate.set('2019-08-13')
+
+          const {
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
+          } = setup({
+            values: {
+              temporal: {
+                startDate: '',
+                endDate: '2019-08-14T23:59:59:999Z'
+              }
+            }
+          })
+
+          const button = screen.getAllByRole('button', { name: 'Clear' })[0]
+          await user.click(button)
+
+          // `onClearClick` calls `onChange` twice
+          expect(setFieldTouched).toHaveBeenCalledTimes(2)
+          expect(setFieldTouched).toHaveBeenCalledWith('temporal.startDate')
+
+          expect(setFieldValue).toHaveBeenCalledTimes(2)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.startDate', '')
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+          expect(handleSubmit).toHaveBeenCalledWith()
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set Start Date',
+            value: ''
+          })
+
+          MockDate.reset()
+        })
+
         test('does not call handleSubmit if shouldSubmit is false on startDate submit', async () => {
           const {
             handleSubmit,
@@ -347,6 +387,46 @@ describe('GranuleFiltersForm component', () => {
           expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
             type: 'Set End Date',
             value: '2019-08-14T23:59:59.000Z'
+          })
+
+          MockDate.reset()
+        })
+
+        test('calls the correct callbacks on endDate submit with an empty value', async () => {
+          MockDate.set('2019-08-14')
+
+          const {
+            handleSubmit,
+            onMetricsGranuleFilter,
+            setFieldTouched,
+            setFieldValue,
+            user
+          } = setup({
+            values: {
+              temporal: {
+                startDate: '2019-08-13T00:00:00:000Z',
+                endDate: ''
+              }
+            }
+          })
+
+          const button = screen.getAllByRole('button', { name: 'Clear' })[1]
+          await user.click(button)
+
+          // `onClearClick` calls `onChange` twice
+          expect(setFieldTouched).toHaveBeenCalledTimes(2)
+          expect(setFieldTouched).toHaveBeenCalledWith('temporal.endDate')
+
+          expect(setFieldValue).toHaveBeenCalledTimes(2)
+          expect(setFieldValue).toHaveBeenCalledWith('temporal.endDate', '')
+
+          expect(handleSubmit).toHaveBeenCalledTimes(1)
+          expect(handleSubmit).toHaveBeenCalledWith()
+
+          expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+          expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+            type: 'Set End Date',
+            value: ''
           })
 
           MockDate.reset()
@@ -1126,6 +1206,8 @@ describe('GranuleFiltersForm component', () => {
       })
 
       test('calls the correct callbacks on startDate submit', async () => {
+        MockDate.set('2019-08-13')
+
         const {
           handleSubmit,
           onMetricsGranuleFilter,
@@ -1149,20 +1231,69 @@ describe('GranuleFiltersForm component', () => {
           }
         })
 
-        const equatorCrossingStartDateTextField = screen.getAllByRole('textbox', { name: 'Start Date' })[1]
-        await user.type(equatorCrossingStartDateTextField, '2019')
+        const button = screen.getAllByRole('button', { name: 'Today' })[2]
+        await user.click(button)
 
-        expect(setFieldTouched).toHaveBeenCalledTimes(4)
+        expect(setFieldTouched).toHaveBeenCalledTimes(1)
         expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.startDate')
 
-        expect(setFieldValue).toHaveBeenCalledTimes(4)
-        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2')
-        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '0')
-        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2')
-        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '0')
+        expect(setFieldValue).toHaveBeenCalledTimes(1)
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '2019-08-13T00:00:00.000Z')
 
-        expect(handleSubmit).toHaveBeenCalledTimes(0)
-        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(0)
+        expect(handleSubmit).toHaveBeenCalledTimes(1)
+        expect(handleSubmit).toHaveBeenCalledWith()
+
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+          type: 'Equatorial Crossing Set Start Date',
+          value: '2019-08-13T00:00:00.000Z'
+        })
+
+        MockDate.reset()
+      })
+
+      test('calls the correct callbacks on startDate submit with an empty value', async () => {
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
+          collectionMetadata: {
+            isOpenSearch: false,
+            tags: {
+              'edsc.extra.serverless.collection_capabilities': {
+                data: { orbit_calculated_spatial_domains: true }
+              }
+            }
+          },
+          values: {
+            equatorCrossingDate: {
+              startDate: '',
+              endDate: '2019-08-14T23:59:59:999Z'
+            }
+          }
+        })
+
+        const button = screen.getAllByRole('button', { name: 'Clear' })[2]
+        await user.click(button)
+
+        // `onClearClick` calls `onChange` twice
+        expect(setFieldTouched).toHaveBeenCalledTimes(2)
+        expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.startDate')
+
+        expect(setFieldValue).toHaveBeenCalledTimes(2)
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.startDate', '')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(1)
+        expect(handleSubmit).toHaveBeenCalledWith()
+
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+          type: 'Equatorial Crossing Set Start Date',
+          value: ''
+        })
       })
 
       test('does not call handleSubmit if shouldSubmit is false on startDate submit', async () => {
@@ -1247,6 +1378,54 @@ describe('GranuleFiltersForm component', () => {
         expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
           type: 'Equatorial Crossing Set End Date',
           value: '2019-08-14T23:59:59.000Z'
+        })
+
+        MockDate.reset()
+      })
+
+      test('calls the correct callbacks on endDate submit with an empty value', async () => {
+        MockDate.set('2019-08-14')
+
+        const {
+          handleSubmit,
+          onMetricsGranuleFilter,
+          setFieldTouched,
+          setFieldValue,
+          user
+        } = setup({
+          collectionMetadata: {
+            isOpenSearch: false,
+            tags: {
+              'edsc.extra.serverless.collection_capabilities': {
+                data: { orbit_calculated_spatial_domains: true }
+              }
+            }
+          },
+          values: {
+            equatorCrossingDate: {
+              startDate: '2019-08-13T00:00:00:000Z',
+              endDate: ''
+            }
+          }
+        })
+
+        const button = screen.getAllByRole('button', { name: 'Clear' })[3]
+        await user.click(button)
+
+        // `onClearClick` calls `onChange` twice
+        expect(setFieldTouched).toHaveBeenCalledTimes(2)
+        expect(setFieldTouched).toHaveBeenCalledWith('equatorCrossingDate.endDate')
+
+        expect(setFieldValue).toHaveBeenCalledTimes(2)
+        expect(setFieldValue).toHaveBeenCalledWith('equatorCrossingDate.endDate', '')
+
+        expect(handleSubmit).toHaveBeenCalledTimes(1)
+        expect(handleSubmit).toHaveBeenCalledWith()
+
+        expect(onMetricsGranuleFilter).toHaveBeenCalledTimes(1)
+        expect(onMetricsGranuleFilter).toHaveBeenCalledWith({
+          type: 'Equatorial Crossing Set End Date',
+          value: ''
         })
 
         MockDate.reset()

--- a/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
+++ b/static/src/js/containers/DatepickerContainer/DatepickerContainer.jsx
@@ -99,6 +99,9 @@ const DatepickerContainer = ({
     // Reset the time to a default value to override any previous custom time entry
     onChange(moment().utc().startOf('day').format(format), false)
     onChange('', true)
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (pickerRef.current?._closeCalendar) pickerRef.current._closeCalendar()
   }
 
   /**
@@ -115,6 +118,9 @@ const DatepickerContainer = ({
     }
 
     onChange(valueToSet ? valueToSet.format(format) : valueToSet, true)
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (pickerRef.current?._closeCalendar) pickerRef.current._closeCalendar()
   }
 
   /**


### PR DESCRIPTION
# Overview

### What is the feature?

Currently when you type into the granule filters temporal fields, every new keystroke results in a query to CMR. We want to limit sending those queries to only when the user has finished typing.

### What is the Solution?

I passed a `shouldSubmit` flag into the `onSubmitStart` and `onSubmitEnd` callbacks in `GranuleFiltersForm`. This flag is false for regular change events, but true when the user clicked a date, or blurs the field.

I also don't submit the metrics call unless a query is submitted.

### What areas of the application does this impact?

Granule Filters

# Testing

### Reproduction steps

Select a collection to view the granules, and the granule filters.
Selecting a date by clicking in the datepicker should always result in a new granules query sent to CMR.
Typing in the temporal fields should not send a granules query to CMR until you leave/blur the textbox.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
