### PR TITLE
EDSC-4162: Add bamboo var for tour feature toggle

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -20,6 +20,7 @@ config="`jq '.application.openSearchGranuleLinksPageSize = $newValue' --arg newV
 config="`jq '.application.disableDatabaseComponents = $newValue' --arg newValue $bamboo_DISABLE_DATABASE_COMPONENTS <<< $config`"
 config="`jq '.application.disableEddDownload = $newValue' --arg newValue $bamboo_DISABLE_EDD_DOWNLOAD <<< $config`"
 config="`jq '.application.disableOrdering = $newValue' --arg newValue $bamboo_DISABLE_ORDERING <<< $config`"
+config="`jq '.application.disableSiteTour = $newValue' --arg newValue $bamboo_DISABLE_SITE_TOUR <<< $config`"
 config="`jq '.application.disableSwodlr = $newValue' --arg newValue $bamboo_DISABLE_SWODLR <<< $config`"
 config="`jq '.application.macOSEddDownloadSize = $newValue' --arg newValue $bamboo_MACOS_EDD_DOWNLOAD_SIZE <<< $config`"
 config="`jq '.application.windowsEddDownloadSize = $newValue' --arg newValue $bamboo_WINDOWS_EDD_DOWNLOAD_SIZE <<< $config`"


### PR DESCRIPTION
# Overview

### What is the feature?

Adding env var for tour so that it can be turned off. This just pulls from bamboo env vars to do so

### What is the Solution?

Adding new env var to the bamboo script

### What areas of the application does this impact?

EDSC sit tour, edsc environment variables

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Set env var in bamboo
2. Confirm that tour features can be toggled via redeployments

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
