### PR TITLE
EDSC-3980: Fixes granule outlines for screens with decimal DPR values

### DIFF
--- a/static/src/js/components/Map/GranuleGridLayerExtended.jsx
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.jsx
@@ -346,7 +346,9 @@ export class GranuleGridLayerExtended extends L.GridLayer {
 
   // Draw the granule tile
   drawTile(canvases, back, tilePoint) {
-    const dpr = window.devicePixelRatio || 1
+    // Round the DPR up to the next whole number. This fixes an issue where
+    // outlines are drawn at the wrong location and scale when DPR is a decimal value.
+    const dpr = Math.ceil(window.devicePixelRatio || 1)
     const {
       imagery: imageryCanvas,
       outline: outlineCanvas


### PR DESCRIPTION
# Overview

### What is the feature?

Screens with decimal DPR values (like 0.833) are drawing granule outlines in the wrong location and scale. See faint green lines at top left and top center, they should be around the orange granule imagery
<img width="680" alt="Screenshot 2024-10-24 at 11 27 46 AM" src="https://github.com/user-attachments/assets/0bc05248-a514-48e6-8f88-327a70b11650">

### What is the Solution?

Rounding up the DPR to the next round number seems to fix this issue

### What areas of the application does this impact?

Granule outlines on the map

# Testing

You can emulate the dpr with Chrome dev tools (Settings > Devices > Add custom device... > Provide a name, resolution, and Device pixel ratio. Then in your EDSC tab's dev tools click the button "Toggle device toolbar" (second button in the top left), then you will see a toolbar show up in your browser where you can select your newly created device. 

A known DPR causing this issue is `0.8333333134651184`, but any non whole number will cause the issue (e.g. 1.2)

### Attachments

Correct outlines
<img width="632" alt="Screenshot 2024-10-24 at 11 28 46 AM" src="https://github.com/user-attachments/assets/16d8115a-3b26-45a9-bfbc-45426ae6e2c7">


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
