### PR TITLE
EDSC-4294: Reverse granule imagery list to align with granule outlines

### DIFF
--- a/static/src/js/components/Map/GranuleGridLayerExtended.jsx
+++ b/static/src/js/components/Map/GranuleGridLayerExtended.jsx
@@ -475,7 +475,13 @@ export class GranuleGridLayerExtended extends L.GridLayer {
     // Draw the granule imagery.
     setTimeout(
       (
-        () => this.drawClippedImagery(imageryCanvas, boundary, paths, nwPoint, tilePoint)
+        () => this.drawClippedImagery(
+          imageryCanvas,
+          boundary,
+          [...paths].reverse(),
+          nwPoint,
+          tilePoint
+        )
       ), 0
     )
 

--- a/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
+++ b/static/src/js/components/Map/__tests__/GranuleGridLayerExtended.test.js
@@ -246,7 +246,7 @@ describe('GranuleGridLayerExtended class', () => {
       expect(drawClippedImageryMock).toBeCalledWith(
         canvases.imagery,
         boundary,
-        pathsResult,
+        [...pathsResult].reverse(),
         nwPoint,
         tilePoint
       )


### PR DESCRIPTION
# Overview

### What is the feature?

Our granule outlines will draw the latest granules above other granules. When you select a granule (from the results list or map) it will pull that granule to the 'top' by reordering the list of granules the map is processing. GIBS imagery does not behave in the same way, it is showing the oldest granules.

### What is the Solution?

Reverse the list of granules passed into the function that renders the imagery.

### What areas of the application does this impact?

Granules with GIBS imagery

# Testing

I've found [this collection](http://localhost:8080/search/granules?p=C2930763263-LARC_CLOUD&pg[0][v]=f&pg[0][gsk]=-start_date&q=C2930763263-LARC_CLOUD&ot=2024-07-01T00%3A00%3A00.000Z%2C2024-07-31T23%3A59%3A59.999Z&tl=1728336950!3!!&lat=26.58553990490026&long=-220.78125&zoom=1) useful for testing this. 

Take care note of what the image displayed looks like (look for gaps in the image, or specific coloration to follow). Scroll down the list of granules until a new page of granules loads. You will see the image disappear and reappear, but once it completes you should see the same image as you originally did.

Click on one of the newly loaded granules in the results list to focus that granule. Again you will see the image disappear and reappear, and you might see the original image for a second, but it will switch to the imagery for the granule you selected. When clicking on that granule again (or an empty part of the map) the imagery will switch back to the original image you saw.

### Attachments

Your imagery might be different depending on if new granules have been added

Original image
<img width="1130" alt="Screenshot 2024-10-24 at 12 04 47 PM" src="https://github.com/user-attachments/assets/db2dd9d0-12f2-4bf2-bb4d-90d623c1d844">

More pages loaded, same original image shown
<img width="1126" alt="Screenshot 2024-10-24 at 12 05 25 PM" src="https://github.com/user-attachments/assets/96c68ecf-40fc-4a91-b406-4d0cd90c9d46">

Focused granule from new page
<img width="1125" alt="Screenshot 2024-10-24 at 12 05 42 PM" src="https://github.com/user-attachments/assets/7c642259-7796-4060-845b-5b2017d60fdb">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
