### PR TITLE
EDSC-4290: Adds database indexes to retrieval_orders and retrieval_collections

### DIFF
--- a/migrations/1730216056247_add-index-to-retrieval-orders.js
+++ b/migrations/1730216056247_add-index-to-retrieval-orders.js
@@ -1,0 +1,11 @@
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.createIndex('retrieval_orders', ['retrieval_collection_id'], {
+    method: 'btree'
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropIndex('retrieval_orders', ['retrieval_collection_id'])
+}

--- a/migrations/1730216091956_add-index-to-retrieval-collections.js
+++ b/migrations/1730216091956_add-index-to-retrieval-collections.js
@@ -1,0 +1,11 @@
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.createIndex('retrieval_collections', ['retrieval_id'], {
+    method: 'btree'
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropIndex('retrieval_collections', ['retrieval_id'])
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Adds two database indexes to improve database efficiency for queries to `retrieval_orders` and `retrieval_collections` tables.

### What areas of the application does this impact?

Calls to the following lambdas will be impacted:
- retrieveGranuleLinks
- getRetrievals
- fetchRetrievalHistory
- getRetrieval
- getRetrievalCollection

# Testing

Ensure submitting a retrieval and fetching download links works. 
Ensure viewing the download history page works

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
