### PR TITLE
Fix npm capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Earthdata Search runs on Node.js, in order to run the application you'll need to
 
     brew install node
 
-##### NPM
+##### npm
 
 npm is a separate project from Node.js, and tends to update more frequently. As a result, even if you’ve just downloaded Node.js (and therefore npm), you’ll probably need to update your npm. Luckily, npm knows how to update itself! To update your npm, type this into your terminal:
 

--- a/portals/buildAvailablePortals.js
+++ b/portals/buildAvailablePortals.js
@@ -1,6 +1,6 @@
 /**
  * This file reads from the list of portals and combines all the configs into a single JSON file (git ignored).
- * This file is set up to run as an NPM script on 'postinstall' and 'prestart'.
+ * This file is set up to run as an npm script on 'postinstall' and 'prestart'.
  * This should ensure that the availablePortals.json file is present in CI
  * environments, and updates to the file will be available in your local
  * environment after restarting the dev server.


### PR DESCRIPTION
Just a minor capitalization fix: `NPM` -> `npm`

npm should never be capitalized:
https://github.com/npm/cli#is-it-npm-or-npm-or-npm