### PR TITLE
EDSC-4257: Enable CloudFront caching in EDSC

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -169,7 +169,7 @@ custom:
     objectHeaders:
       index.html:
         - name: Cache-Control
-          value: no-store
+          value: no-cache
       '*.css':
         - name: Cache-Control
           value: 'max-age=31536000'

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -81,6 +81,9 @@ class App extends Component {
     const { env } = getApplicationConfig()
     this.edscHost = edscHost
     this.env = env
+
+    console.log("🚀 ~ Edge caching test 1")
+
   }
 
   // Portal paths have been removed, but this needs to stay in order to redirect users using

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -82,7 +82,7 @@ class App extends Component {
     this.edscHost = edscHost
     this.env = env
 
-    console.log("🚀 ~ Edge caching test 1")
+    console.log("🚀 ~ Edge caching test 2 asdfasdfasfasdf")
 
   }
 

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -81,9 +81,6 @@ class App extends Component {
     const { env } = getApplicationConfig()
     this.edscHost = edscHost
     this.env = env
-
-    console.log("🚀 ~ Edge caching test 2 asdfasdfasfasdf")
-
   }
 
   // Portal paths have been removed, but this needs to stay in order to redirect users using


### PR DESCRIPTION
# Overview

### What is the feature?

Changing the configuration index file that is being stored in S3 from no-store to no-cache. "no-cache" allows caching but requires revalidation with the origin server before using the cached copy. Verified that caching behavior works as expected in SIT environment. Confirmed that updates to the configuration file are properly reflected after cache revalidation