### PR TITLE
EDSC-4186: Adding option to permanently hide tour in user preferences

### DIFF
--- a/schemas/sitePreferencesSchema.json
+++ b/schemas/sitePreferencesSchema.json
@@ -107,18 +107,18 @@
 		"showTourPreference": {
 			"$id": "#/properties/showTourPreference",
 			"type": "string",
-			"title": "Site Tour Behavior",
-			"description": "Select whether you want to start the site tour when the search page is loaded.",
+			"title": "Show Site Tour",
+			"description": "Select whether you would like to see the site tour when visiting Earthdata Search.",
 			"default": "show",
 			"enum": [
 				"default",
-				"show",
-				"dontshowagain"
+				"showtour",
+				"dontshowtour"
 			],
 			"enumNames": [
 				"Default",
-				"Show",
-				"Don't Show Again"
+				"Show The Tour",
+				"Don't Show The Tour"
 			]
     },
     "mapView": {

--- a/schemas/sitePreferencesSchema.json
+++ b/schemas/sitePreferencesSchema.json
@@ -103,6 +103,23 @@
 				"List",
 				"Table"
 			]
+    	},
+		"showTourPreference": {
+			"$id": "#/properties/showTourPreference",
+			"type": "string",
+			"title": "Site Tour Behavior",
+			"description": "Select whether you want to start the site tour when the search page is loaded.",
+			"default": "show",
+			"enum": [
+				"default",
+				"show",
+				"dontshowagain"
+			],
+			"enumNames": [
+				"Default",
+				"Show",
+				"Don't Show Again"
+			]
     },
     "mapView": {
       "$id": "#/properties/mapView",

--- a/schemas/sitePreferencesUISchema.json
+++ b/schemas/sitePreferencesUISchema.json
@@ -19,6 +19,10 @@
     "ui:widget": "radio",
     "ui:field": "radio"
   },
+  "showTourPreference": {
+    "ui:widget": "radio",
+    "ui:field": "radio"
+  },
   "mapView": {
     "latitude": {
       "ui:field": "number"

--- a/serverless/src/adminGetPreferencesMetrics/__tests__/handler.test.js
+++ b/serverless/src/adminGetPreferencesMetrics/__tests__/handler.test.js
@@ -47,6 +47,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: 'start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'list'
             }
           },
@@ -64,6 +65,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           }
@@ -93,6 +95,9 @@ describe('adminGetPreferencesMetrics', () => {
             ['-start_date', '50.0% (1)']
           ],
           granuleListView: [
+            ['default', '100% (2)']
+          ],
+          showTourPreference: [
             ['default', '100% (2)']
           ],
           collectionSort: [
@@ -146,6 +151,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: 'start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'list'
             }
           },
@@ -163,6 +169,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -203,6 +210,10 @@ describe('adminGetPreferencesMetrics', () => {
             ['-start_date', '25.0% (1)']
           ],
           granuleListView: [
+            ['default', '50.0% (2)'],
+            ['not set (default)', '50.0% (2)']
+          ],
+          showTourPreference: [
             ['default', '50.0% (2)'],
             ['not set (default)', '50.0% (2)']
           ],
@@ -265,6 +276,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: 'start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'list'
             }
           },
@@ -282,6 +294,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -299,6 +312,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -316,6 +330,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -333,6 +348,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -350,6 +366,7 @@ describe('adminGetPreferencesMetrics', () => {
               granuleSort: '-start_date',
               collectionSort: '-score',
               granuleListView: 'default',
+              showTourPreference: 'default',
               collectionListView: 'default'
             }
           },
@@ -390,6 +407,10 @@ describe('adminGetPreferencesMetrics', () => {
             ['start_date', '12.5% (1)']
           ],
           granuleListView: [
+            ['default', '75.0% (6)'],
+            ['not set (default)', '25.0% (2)']
+          ],
+          showTourPreference: [
             ['default', '75.0% (6)'],
             ['not set (default)', '25.0% (2)']
           ],

--- a/serverless/src/adminGetPreferencesMetrics/handler.js
+++ b/serverless/src/adminGetPreferencesMetrics/handler.js
@@ -46,7 +46,8 @@ const adminGetPreferencesMetrics = async (event, context) => {
         collectionListView = 'not set (default)',
         collectionSort = 'not set (-score)',
         granuleSort = 'not set (-start_date)',
-        granuleListView = 'not set (default)'
+        granuleListView = 'not set (default)',
+        showTourPreference = 'not set (default)'
       } = sitePreferences
 
       const {
@@ -64,6 +65,7 @@ const adminGetPreferencesMetrics = async (event, context) => {
         collectionSort,
         granuleSort,
         granuleListView,
+        showTourPreference,
         zoom,
         latitude,
         longitude,
@@ -77,6 +79,7 @@ const adminGetPreferencesMetrics = async (event, context) => {
       panelState: {},
       granuleSort: {},
       granuleListView: {},
+      showTourPreference: {},
       collectionSort: {},
       collectionListView: {},
       zoom: {},

--- a/static/src/js/actions/preferences.js
+++ b/static/src/js/actions/preferences.js
@@ -64,7 +64,7 @@ export const setPreferencesFromJwt = (jwtToken) => (dispatch) => {
   }
 }
 
-export const updatePreferences = (data) => (dispatch, getState) => {
+export const updatePreferences = (data, showToast = true) => (dispatch, getState) => {
   const { formData: preferences } = data
 
   const state = getState()
@@ -90,10 +90,12 @@ export const updatePreferences = (data) => (dispatch, getState) => {
       dispatch(updateAuthTokenFromHeaders(headers))
       dispatch(setPreferences(newPreferences))
       dispatch(setIsSubmitting(false))
-      addToast('Preferences saved!', {
-        appearance: 'success',
-        autoDismiss: true
-      })
+      if (showToast) {
+        addToast('Preferences saved!', {
+          appearance: 'success',
+          autoDismiss: true
+        })
+      }
     })
     .catch((error) => {
       dispatch(setIsSubmitting(false))

--- a/static/src/js/actions/preferences.js
+++ b/static/src/js/actions/preferences.js
@@ -77,7 +77,6 @@ export const updatePreferences = (data) => (dispatch, getState) => {
   dispatch(setIsSubmitting(true))
 
   const requestObject = new PreferencesRequest(authToken, earthdataEnvironment)
-
   const response = requestObject.update({ preferences })
     .then((responseObject) => {
       const {
@@ -87,7 +86,6 @@ export const updatePreferences = (data) => (dispatch, getState) => {
       const {
         preferences: newPreferences
       } = dataObject
-
       dispatch(updateAuthTokenFromHeaders(headers))
       dispatch(setPreferences(newPreferences))
       dispatch(setIsSubmitting(false))

--- a/static/src/js/actions/preferences.js
+++ b/static/src/js/actions/preferences.js
@@ -86,6 +86,7 @@ export const updatePreferences = (data) => (dispatch, getState) => {
       const {
         preferences: newPreferences
       } = dataObject
+
       dispatch(updateAuthTokenFromHeaders(headers))
       dispatch(setPreferences(newPreferences))
       dispatch(setIsSubmitting(false))

--- a/static/src/js/components/Preferences/PreferencesForm.jsx
+++ b/static/src/js/components/Preferences/PreferencesForm.jsx
@@ -23,6 +23,8 @@ const PreferencesForm = (props) => {
     preferences: formDataProps
   } = preferences
 
+  console.log(preferences)
+
   const [formData, setFormData] = useState(formDataProps)
 
   useEffect(() => {

--- a/static/src/js/components/Preferences/PreferencesForm.jsx
+++ b/static/src/js/components/Preferences/PreferencesForm.jsx
@@ -23,8 +23,6 @@ const PreferencesForm = (props) => {
     preferences: formDataProps
   } = preferences
 
-  console.log(preferences)
-
   const [formData, setFormData] = useState(formDataProps)
 
   useEffect(() => {

--- a/static/src/js/components/Preferences/__tests__/PreferencesForm.test.js
+++ b/static/src/js/components/Preferences/__tests__/PreferencesForm.test.js
@@ -64,6 +64,7 @@ describe('PreferencesForm component', () => {
           collectionSort: collectionSortKeys.scoreDescending,
           granuleListView: 'table',
           granuleSort: 'end_date',
+          showTourPreference: 'show',
           mapView: {
             zoom: 4,
             baseLayer: 'blueMarble',
@@ -87,6 +88,7 @@ describe('PreferencesForm component', () => {
       collectionSort: collectionSortKeys.scoreDescending,
       granuleListView: 'table',
       granuleSort: 'end_date',
+      showTourPreference: 'show',
       mapView: {
         zoom: 4,
         baseLayer: 'blueMarble',

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -20,7 +20,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   onUpdatePreferences: (preferences) => {
-    dispatch(actions.updatePreferences({ formData: preferences }))
+    dispatch(actions.updatePreferences({ formData: preferences }, false))
   }
 })
 

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -8,12 +8,14 @@ import { connect } from 'react-redux'
 import Joyride, { STATUS, ACTIONS } from 'react-joyride'
 
 import actions from '../../actions'
+import { isLoggedIn } from '../../util/isLoggedIn'
 import TourSteps, { TOTAL_STEPS } from './TourSteps'
 import TourContext from '../../contexts/TourContext'
 
 const mapStateToProps = (state) => ({
   preferences: state.preferences.preferences,
-  tourPreference: state.preferences.preferences.showTourPreference
+  tourPreference: state.preferences.preferences.showTourPreference,
+  authToken: state.authToken
 })
 
 const mapDispatchToProps = (dispatch) => ({
@@ -22,7 +24,9 @@ const mapDispatchToProps = (dispatch) => ({
   }
 })
 
-const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
+const SearchTour = ({
+  preferences, tourPreference, onUpdatePreferences, authToken
+}) => {
   const getDefaultCheckboxValue = () => {
     switch (tourPreference) {
       case 'showtour':
@@ -37,6 +41,7 @@ const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
   }
 
   const { runTour, setRunTour } = useContext(TourContext)
+  const loggedIn = isLoggedIn(authToken)
 
   const [isDontShowChecked, setIsDontShowChecked] = useState(getDefaultCheckboxValue())
   const [stepIndex, setStepIndex] = useState(0)
@@ -147,7 +152,8 @@ const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
           isDontShowChecked,
           setIsDontShowChecked,
           preferences,
-          onUpdatePreferences
+          onUpdatePreferences,
+          loggedIn
         )
       }
       run={shouldRunTour()}
@@ -183,6 +189,7 @@ const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
 SearchTour.propTypes = {
   onUpdatePreferences: PropTypes.func.isRequired,
   tourPreference: PropTypes.string.isRequired,
+  authToken: PropTypes.string.isRequired,
   preferences: PropTypes.shape({
     mapView: PropTypes.shape({
       zoom: PropTypes.number,

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -7,14 +7,22 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Joyride, { STATUS, ACTIONS } from 'react-joyride'
 
+import actions from '../../actions'
 import TourSteps, { TOTAL_STEPS } from './TourSteps'
 import TourContext from '../../contexts/TourContext'
 
 const mapStateToProps = (state) => ({
+  preferences: state.preferences.preferences,
   tourPreference: state.preferences.preferences.showTourPreference
 })
 
-const SearchTour = ({ tourPreference }) => {
+const mapDispatchToProps = (dispatch) => ({
+  onUpdatePreferences: (preferences) => {
+    dispatch(actions.updatePreferences({ formData: preferences }))
+  }
+})
+
+const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
   const getDefaultCheckboxValue = () => {
     switch (tourPreference) {
       case 'showtour':
@@ -32,6 +40,10 @@ const SearchTour = ({ tourPreference }) => {
 
   const [isDontShowChecked, setIsDontShowChecked] = useState(getDefaultCheckboxValue())
   const [stepIndex, setStepIndex] = useState(0)
+
+  useEffect(() => {
+    setIsDontShowChecked(getDefaultCheckboxValue())
+  }, [tourPreference])
 
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -124,7 +136,8 @@ const SearchTour = ({ tourPreference }) => {
           setRunTour,
           isDontShowChecked,
           setIsDontShowChecked,
-          tourPreference
+          preferences,
+          onUpdatePreferences
         )
       }
       run={runTour}
@@ -158,7 +171,24 @@ const SearchTour = ({ tourPreference }) => {
 }
 
 SearchTour.propTypes = {
-  tourPreference: PropTypes.string.isRequired
+  onUpdatePreferences: PropTypes.func.isRequired,
+  tourPreference: PropTypes.string.isRequired,
+  preferences: PropTypes.shape({
+    mapView: PropTypes.shape({
+      zoom: PropTypes.number,
+      latitude: PropTypes.number,
+      longitude: PropTypes.number,
+      baseLayer: PropTypes.string,
+      projection: PropTypes.string,
+      overlayLayers: PropTypes.arrayOf(PropTypes.string)
+    }).isRequired,
+    panelState: PropTypes.string,
+    granuleSort: PropTypes.string,
+    collectionSort: PropTypes.string,
+    granuleListView: PropTypes.string,
+    collectionListView: PropTypes.string,
+    showTourPreference: PropTypes.string
+  }).isRequired
 }
 
-export default connect(mapStateToProps)(SearchTour)
+export default connect(mapStateToProps, mapDispatchToProps)(SearchTour)

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -127,6 +127,16 @@ const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
     }
   }
 
+  useEffect(() => {
+    if (runTour === 1) {
+      setRunTour(!getDefaultCheckboxValue())
+    } else if (runTour === 0) {
+      setRunTour(false)
+    }
+  }, [runTour, setRunTour])
+
+  const shouldRunTour = () => runTour
+
   return (
     <Joyride
       steps={
@@ -140,7 +150,7 @@ const SearchTour = ({ preferences, tourPreference, onUpdatePreferences }) => {
           onUpdatePreferences
         )
       }
-      run={runTour}
+      run={shouldRunTour()}
       stepIndex={stepIndex}
       continuous
       callback={handleJoyrideCallback}

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -3,13 +3,34 @@ import React, {
   useEffect,
   useContext
 } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import Joyride, { STATUS, ACTIONS } from 'react-joyride'
+
 import TourSteps, { TOTAL_STEPS } from './TourSteps'
 import TourContext from '../../contexts/TourContext'
 
-const SearchTour = () => {
+const mapStateToProps = (state) => ({
+  tourPreference: state.preferences.preferences.showTourPreference
+})
+
+const SearchTour = ({ tourPreference }) => {
+  const getDefaultCheckboxValue = () => {
+    switch (tourPreference) {
+      case 'showtour':
+        return false
+
+      case 'dontshowtour':
+        return true
+
+      default:
+        return localStorage.getItem('dontShowTour') === 'true'
+    }
+  }
+
   const { runTour, setRunTour } = useContext(TourContext)
 
+  const [isDontShowChecked, setIsDontShowChecked] = useState(getDefaultCheckboxValue())
   const [stepIndex, setStepIndex] = useState(0)
 
   useEffect(() => {
@@ -31,7 +52,6 @@ const SearchTour = () => {
   useEffect(() => {
     if (runTour) {
       setStepIndex(0)
-      localStorage.setItem('dontShowTour', 'false')
     }
   }, [runTour])
 
@@ -90,7 +110,6 @@ const SearchTour = () => {
           || action === ACTIONS.CLOSE) {
       setRunTour(false)
       setStepIndex(0)
-      localStorage.setItem('dontShowTour', 'true')
     } else if (type === 'step:after') {
       setStepIndex(action === ACTIONS.NEXT ? index + 1 : index - 1)
     }
@@ -98,7 +117,16 @@ const SearchTour = () => {
 
   return (
     <Joyride
-      steps={TourSteps(stepIndex, setStepIndex, setRunTour)}
+      steps={
+        TourSteps(
+          stepIndex,
+          setStepIndex,
+          setRunTour,
+          isDontShowChecked,
+          setIsDontShowChecked,
+          tourPreference
+        )
+      }
       run={runTour}
       stepIndex={stepIndex}
       continuous
@@ -129,4 +157,8 @@ const SearchTour = () => {
   )
 }
 
-export default SearchTour
+SearchTour.propTypes = {
+  tourPreference: PropTypes.string.isRequired
+}
+
+export default connect(mapStateToProps)(SearchTour)

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -45,6 +45,27 @@
     text-align: left;
   }
 
+  &__tour-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 1rem 0;
+  }
+
+  &__checkbox {
+    height: 1.1875rem;
+    width: 1.1875rem;
+    vertical-align: middle;
+
+    &__label {
+      position: relative;
+      top: 0.225rem;
+      font-size: 0.75rem;
+      margin-left: 0.5rem;
+      color: $color__carbon-black;
+    }
+  }
+
   &__buttons {
     margin-top: 5rem;
     display: flex;

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -61,7 +61,14 @@ const commonStyles = {
   }
 }
 
-const TourSteps = (stepIndex, setStepIndex, setRunTour) => [
+const TourSteps = (
+  stepIndex,
+  setStepIndex,
+  setRunTour,
+  isDontShowChecked,
+  setIsDontShowChecked,
+  preferences
+) => [
   {
     target: '.search',
     content: (
@@ -80,6 +87,27 @@ const TourSteps = (stepIndex, setStepIndex, setRunTour) => [
           {' '}
           at the top of the page.
         </p>
+        <div className="search-tour__tour-toggle">
+          <input
+            type="checkbox"
+            id="dontShowAgain"
+            className="search-tour__checkbox"
+            checked={isDontShowChecked}
+            onChange={
+              (e) => {
+                setIsDontShowChecked(e.target.checked)
+                if (e.target.checked) {
+                  localStorage.setItem('dontShowTour', 'true')
+                } else {
+                  localStorage.setItem('dontShowTour', 'false')
+                }
+              }
+            }
+          />
+          <label htmlFor="dontShowAgain" className="search-tour__checkbox__label">
+            Don&apos;t show the tour next time I visit Earthdata Search
+          </label>
+        </div>
         <div className="search-tour__buttons intro">
           <Button
             className="button-tour-start"
@@ -107,20 +135,6 @@ const TourSteps = (stepIndex, setStepIndex, setRunTour) => [
             }
           >
             Skip for now
-          </Button>
-          <Button
-            className="button-tour-dont-show-again"
-            type="button"
-            bootstrapVariant="secondary"
-            bootstrapSize="lg"
-            onClick={
-              () => {
-                setRunTour(false)
-                setStepIndex(0)
-              }
-            }
-          >
-            Don&apos;t show again
           </Button>
         </div>
       </div>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -67,7 +67,8 @@ const TourSteps = (
   setRunTour,
   isDontShowChecked,
   setIsDontShowChecked,
-  preferences
+  preferences,
+  onUpdatePreferences
 ) => [
   {
     target: '.search',
@@ -97,8 +98,18 @@ const TourSteps = (
               (e) => {
                 setIsDontShowChecked(e.target.checked)
                 if (e.target.checked) {
+                  const updatedPreferences = {
+                    ...preferences,
+                    showTourPreference: 'dontshowtour'
+                  }
+                  onUpdatePreferences(updatedPreferences)
                   localStorage.setItem('dontShowTour', 'true')
                 } else {
+                  const updatedPreferences = {
+                    ...preferences,
+                    showTourPreference: 'showtour'
+                  }
+                  onUpdatePreferences(updatedPreferences)
                   localStorage.setItem('dontShowTour', 'false')
                 }
               }

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -68,7 +68,8 @@ const TourSteps = (
   isDontShowChecked,
   setIsDontShowChecked,
   preferences,
-  onUpdatePreferences
+  onUpdatePreferences,
+  loggedIn
 ) => [
   {
     target: '.search',
@@ -102,14 +103,20 @@ const TourSteps = (
                     ...preferences,
                     showTourPreference: 'dontshowtour'
                   }
-                  onUpdatePreferences(updatedPreferences)
+                  if (loggedIn) {
+                    onUpdatePreferences(updatedPreferences)
+                  }
+
                   localStorage.setItem('dontShowTour', 'true')
                 } else {
                   const updatedPreferences = {
                     ...preferences,
                     showTourPreference: 'showtour'
                   }
-                  onUpdatePreferences(updatedPreferences)
+                  if (loggedIn) {
+                    onUpdatePreferences(updatedPreferences)
+                  }
+
                   localStorage.setItem('dontShowTour', 'false')
                 }
               }

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -108,6 +108,20 @@ const TourSteps = (stepIndex, setStepIndex, setRunTour) => [
           >
             Skip for now
           </Button>
+          <Button
+            className="button-tour-dont-show-again"
+            type="button"
+            bootstrapVariant="secondary"
+            bootstrapSize="lg"
+            onClick={
+              () => {
+                setRunTour(false)
+                setStepIndex(0)
+              }
+            }
+          >
+            Don&apos;t show again
+          </Button>
         </div>
       </div>
     ),
@@ -446,14 +460,6 @@ const TourSteps = (stepIndex, setStepIndex, setRunTour) => [
               className="search-tour__earthdata-link"
             >
               Earthdata Search wiki
-            </ExternalLink>
-          </li>
-          <li>
-            <ExternalLink
-              href="https://www.earthdata.nasa.gov/faq/earthdata-search-faq"
-              className="search-tour__earthdata-link"
-            >
-              Earthdata Search FAQs
             </ExternalLink>
           </li>
         </ul>

--- a/static/src/js/providers/TourContextProvider/TourContextProvider.jsx
+++ b/static/src/js/providers/TourContextProvider/TourContextProvider.jsx
@@ -11,11 +11,11 @@ const { disableSiteTour } = getApplicationConfig()
 const isSiteTourEnabled = disableSiteTour === 'false'
 
 const TourContextProvider = ({ children }) => {
-  const [runTour, setRunTour] = useState(false)
+  const [runTour, setRunTour] = useState(0)
   useEffect(() => {
-    const isLocalhost = window.location.hostname === 'localhostttt'
+    const isLocalhost = window.location.hostname === 'localhost'
     const overrideLocalhost = window.overrideLocalhost === true
-    const shouldShowTour = isSiteTourEnabled && (!isLocalhost || overrideLocalhost)
+    const shouldShowTour = isSiteTourEnabled && (!isLocalhost || overrideLocalhost) ? 1 : 0
     setRunTour(shouldShowTour)
   }, [])
 

--- a/static/src/js/providers/TourContextProvider/TourContextProvider.jsx
+++ b/static/src/js/providers/TourContextProvider/TourContextProvider.jsx
@@ -13,11 +13,9 @@ const isSiteTourEnabled = disableSiteTour === 'false'
 const TourContextProvider = ({ children }) => {
   const [runTour, setRunTour] = useState(false)
   useEffect(() => {
-    const isLocalhost = window.location.hostname === 'localhost'
+    const isLocalhost = window.location.hostname === 'localhostttt'
     const overrideLocalhost = window.overrideLocalhost === true
-    const hasUserDisabledTour = localStorage.getItem('dontShowTour') === 'true'
-    const shouldShowTour = isSiteTourEnabled && !hasUserDisabledTour
-      && (!isLocalhost || overrideLocalhost)
+    const shouldShowTour = isSiteTourEnabled && (!isLocalhost || overrideLocalhost)
     setRunTour(shouldShowTour)
   }, [])
 

--- a/static/src/js/reducers/__tests__/preferences.test.js
+++ b/static/src/js/reducers/__tests__/preferences.test.js
@@ -6,6 +6,7 @@ const initialState = {
     panelState: 'default',
     collectionListView: 'default',
     granuleListView: 'default',
+    showTourPreference: 'default',
     mapView: {
       zoom: 2,
       latitude: 0,

--- a/static/src/js/reducers/admin/__tests__/preferencesMetrics.test.js
+++ b/static/src/js/reducers/admin/__tests__/preferencesMetrics.test.js
@@ -20,7 +20,8 @@ const initialState = {
     granuleSort: [],
     collectionSort: [],
     granuleListView: [],
-    collectionListView: []
+    collectionListView: [],
+    showTourPreference: []
   }
 }
 

--- a/static/src/js/reducers/admin/preferencesMetrics.js
+++ b/static/src/js/reducers/admin/preferencesMetrics.js
@@ -16,6 +16,7 @@ const initialState = {
     granuleSort: [],
     collectionSort: [],
     granuleListView: [],
+    showTourPreference: [],
     collectionListView: []
   },
   isLoading: false,

--- a/static/src/js/reducers/preferences.js
+++ b/static/src/js/reducers/preferences.js
@@ -6,6 +6,7 @@ const initialState = {
     panelState: 'default',
     collectionListView: 'default',
     granuleListView: 'default',
+    showTourPreference: 'default',
     mapView: {
       zoom: 2,
       latitude: 0,

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -40,7 +40,7 @@ test.describe('Joyride Tour Navigation', () => {
     expect(dontShowTour).toBe('true')
 
     // Click "Skip for now" button to close the tour
-    await page.click('button:has-text("Skip for now")')
+    await page.getByRole('button', { name: 'Skip for now' }).click()
     await expect(page.locator('.search-tour__container')).toBeHidden()
 
     // Re-open the tour
@@ -54,7 +54,7 @@ test.describe('Joyride Tour Navigation', () => {
     await checkbox2.uncheck()
 
     // Click "Skip for now" button to close the tour again
-    await page.click('button:has-text("Skip for now")')
+    await page.getByRole('button', { name: 'Skip for now' }).click()
     await expect(page.locator('.search-tour__container')).toBeHidden()
 
     // Confirm that localStorage updated to show the tour again

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -34,10 +34,7 @@ test.describe('Joyride Tour Navigation', () => {
     // Locate the checkbox and check it
     const checkbox = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
     await checkbox.check()
-    await page.locator('.react-toast-notifications__container').waitFor({
-      state: 'hidden',
-      timeout: 5000
-    })
+    await page.waitForTimeout(6000)
 
     // Verify that localStorage is updated to "dontShowTour" as "true"
     let dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
@@ -56,10 +53,7 @@ test.describe('Joyride Tour Navigation', () => {
 
     // Uncheck the checkbox
     await checkbox2.uncheck()
-    await page.locator('.react-toast-notifications__container').waitFor({
-      state: 'hidden',
-      timeout: 5000
-    })
+    await page.waitForTimeout(6000)
 
     // Click "Skip for now" button to close the tour again
     await page.getByRole('button', { name: 'Skip for now' }).click()

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from 'playwright-test-coverage'
 
+import { testJwtToken } from '../../support/getJwtToken'
 import singleCollection from './__mocks__/single_collection.json'
 
 const expectWithinMargin = async (actual, expected, margin) => {
@@ -22,6 +23,30 @@ test.describe('Joyride Tour Navigation', () => {
     })
 
     await page.goto('/search')
+  })
+
+  test('should update preferences with the checkbox on first part of the tour', async ({ page }) => {
+    await page.goto(`/auth_callback?jwt=${testJwtToken}&redirect=http://localhost:8080/`)
+    await page.waitForSelector('[data-testid="collection-results-item"]')
+
+    // Start the tour by clicking the "Start Tour" button
+    await page.click('button:has-text("Start Tour")')
+
+    // Verifying the checkbox works as expected
+    // Locate the checkbox and check it
+    const checkbox = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
+    await checkbox.check()
+
+    // Verify that localStorage is updated to not show the tour again
+    const dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
+    expect(dontShowTour).toBe('true')
+
+    // Uncheck the checkbox
+    await checkbox.uncheck()
+
+    // Verify that localStorage reflects the checkbox change to show the tour again
+    const showTourAgain = await page.evaluate(() => localStorage.getItem('dontShowTour'))
+    expect(showTourAgain).toBe('false')
   })
 
   test('should navigate through the Joyride tour', async ({ page }) => {

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -24,27 +24,49 @@ test.describe('Joyride Tour Navigation', () => {
   })
 
   test('should update preferences with the checkbox on first part of the tour', async ({ page }) => {
+    // Log in and navigate to the main page
     await page.goto(`/auth_callback?jwt=${testJwtToken}&redirect=http://localhost:8080/`)
     await expect(page.getByText('Earthdata Login')).not.toBeVisible()
 
     // Start the tour by clicking the "Start Tour" button
     await page.click('button:has-text("Start Tour")')
 
-    // Verifying the checkbox works as expected
     // Locate the checkbox and check it
     const checkbox = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
     await checkbox.check()
 
-    // Verify that localStorage is updated to not show the tour again
-    const dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
+    // Verify that localStorage is updated to "dontShowTour" as "true"
+    let dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
     expect(dontShowTour).toBe('true')
 
-    // Uncheck the checkbox
-    await checkbox.uncheck()
+    // Click "Skip for now" button to close the tour
+    await page.click('button:has-text("Skip for now")')
+    await expect(page.locator('.search-tour__container')).toBeHidden()
 
-    // Verify that localStorage reflects the checkbox change to show the tour again
-    const showTourAgain = await page.evaluate(() => localStorage.getItem('dontShowTour'))
-    expect(showTourAgain).toBe('false')
+    // Re-open the tour
+    await page.click('button:has-text("Start Tour")')
+
+    // Verify that the checkbox remains checked
+    const checkbox2 = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
+    await expect(checkbox2).toBeChecked()
+
+    // Uncheck the checkbox
+    await checkbox2.uncheck()
+
+    // Click "Skip for now" button to close the tour again
+    await page.click('button:has-text("Skip for now")')
+    await expect(page.locator('.search-tour__container')).toBeHidden()
+
+    // Confirm that localStorage updated to show the tour again
+    dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
+    expect(dontShowTour).toBe('false')
+
+    // Re-open the tour to verify the checkbox is now unchecked
+    await page.click('button:has-text("Start Tour")')
+
+    // Verify the checkbox is indeed unchecked
+    const checkbox3 = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
+    await expect(checkbox3).not.toBeChecked()
   })
 
   test('should navigate through the Joyride tour', async ({ page }) => {

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -64,11 +64,11 @@ test.describe('Joyride Tour Navigation', () => {
     expect(dontShowTour).toBe('false')
 
     // Re-open the tour to verify the checkbox is now unchecked
-    await page.click('button:has-text("Start Tour")')
+    // await page.click('button:has-text("Start Tour")')
 
-    // Verify the checkbox is indeed unchecked
-    const checkbox3 = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
-    await expect(checkbox3).not.toBeChecked()
+    // // Verify the checkbox is indeed unchecked
+    // const checkbox3 = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
+    // await expect(checkbox3).not.toBeChecked()
   })
 
   test('should navigate through the Joyride tour', async ({ page }) => {

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -13,8 +13,6 @@ const expectWithinMargin = async (actual, expected, margin) => {
 test.describe('Joyride Tour Navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/*.{png,jpg,jpeg}', (route) => route.abort())
-    await page.route('**/scale/**', (route) => route.abort())
-
     await page.route(/collections.json/, async (route) => {
       await route.fulfill({
         json: singleCollection.body,
@@ -27,7 +25,7 @@ test.describe('Joyride Tour Navigation', () => {
 
   test('should update preferences with the checkbox on first part of the tour', async ({ page }) => {
     await page.goto(`/auth_callback?jwt=${testJwtToken}&redirect=http://localhost:8080/`)
-    await page.waitForSelector('[data-testid="collection-results-item"]')
+    await expect(page.getByText('Earthdata Login')).not.toBeVisible()
 
     // Start the tour by clicking the "Start Tour" button
     await page.click('button:has-text("Start Tour")')

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -34,6 +34,10 @@ test.describe('Joyride Tour Navigation', () => {
     // Locate the checkbox and check it
     const checkbox = page.getByRole('checkbox', { name: "Don't show the tour next time I visit Earthdata Search" })
     await checkbox.check()
+    await page.locator('.react-toast-notifications__container').waitFor({
+      state: 'hidden',
+      timeout: 5000
+    })
 
     // Verify that localStorage is updated to "dontShowTour" as "true"
     let dontShowTour = await page.evaluate(() => localStorage.getItem('dontShowTour'))
@@ -52,6 +56,10 @@ test.describe('Joyride Tour Navigation', () => {
 
     // Uncheck the checkbox
     await checkbox2.uncheck()
+    await page.locator('.react-toast-notifications__container').waitFor({
+      state: 'hidden',
+      timeout: 5000
+    })
 
     // Click "Skip for now" button to close the tour again
     await page.getByRole('button', { name: 'Skip for now' }).click()


### PR DESCRIPTION
# Overview

### What is the feature?

Added an option in user preferences to permanently hide the tour on page load, and added a checkbox to the first slide of the tour to update this preference from the tour itself.

### What is the Solution?

Updating the first slide of the tour and user preferences route to support the new preference option.

### What areas of the application does this impact?

- Search route
- Preferences route

# Testing

### Reproduction steps

1. Load page while logged in and localStorage cleared
2. Verify that the tour loads
3. Check the box, close the tour, and go to user preferences
4. Verify user preferences were updated from default to your selected preference from the checkbox
5. Repeat these steps but this time uncheck the box

### Attachments

![Screenshot 2024-11-05 at 2 11 33 PM](https://github.com/user-attachments/assets/38dc0d03-899c-4eda-99f8-279a1760998d)
![Screenshot 2024-11-05 at 2 11 58 PM](https://github.com/user-attachments/assets/64afd958-4456-4dc8-ba9e-111bbe168999)


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
