### PR TITLE
EDSC-4296: Fixes inserting `selected_features` into shapefiles database table

### DIFF
--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -446,7 +446,7 @@ describe('submitCatalogRestOrder', () => {
       '959220857ddbb3b2398ac31a58765df6', // File_hash
       'Limited-MockFile.geojson', // Filename
       1084815579, // Parent_shapefile_id
-      JSON.stringify(['1']), // SelectedFeatures
+      '["1"]', // SelectedFeatures
       1 // User_id
     ])
 

--- a/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
+++ b/serverless/src/submitCatalogRestOrder/__tests__/handler.test.js
@@ -446,7 +446,7 @@ describe('submitCatalogRestOrder', () => {
       '959220857ddbb3b2398ac31a58765df6', // File_hash
       'Limited-MockFile.geojson', // Filename
       1084815579, // Parent_shapefile_id
-      ['1'], // SelectedFeatures
+      JSON.stringify(['1']), // SelectedFeatures
       1 // User_id
     ])
 

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -204,7 +204,7 @@ describe('submitHarmonyOrder', () => {
       '959220857ddbb3b2398ac31a58765df6', // File_hash
       'Limited-MockFile.geojson', // Filename
       1084815579, // Parent_shapefile_id
-      ['1'], // SelectedFeatures
+      JSON.stringify(['1']), // SelectedFeatures
       1 // User_id
     ])
 

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -204,7 +204,7 @@ describe('submitHarmonyOrder', () => {
       '959220857ddbb3b2398ac31a58765df6', // File_hash
       'Limited-MockFile.geojson', // Filename
       1084815579, // Parent_shapefile_id
-      JSON.stringify(['1']), // SelectedFeatures
+      '["1"]', // SelectedFeatures
       1 // User_id
     ])
 

--- a/serverless/src/util/__tests__/processPartialShapefile.test.js
+++ b/serverless/src/util/__tests__/processPartialShapefile.test.js
@@ -141,7 +141,7 @@ describe('processPartialShapefile', () => {
           '959220857ddbb3b2398ac31a58765df6', // File_hash
           'Limited-MockFile.geojson', // Filename
           1084815579, // Parent_shapefile_id
-          ['1'], // SelectedFeatures
+          JSON.stringify(['1']), // SelectedFeatures
           1 // User_id
         ])
 

--- a/serverless/src/util/__tests__/processPartialShapefile.test.js
+++ b/serverless/src/util/__tests__/processPartialShapefile.test.js
@@ -141,7 +141,7 @@ describe('processPartialShapefile', () => {
           '959220857ddbb3b2398ac31a58765df6', // File_hash
           'Limited-MockFile.geojson', // Filename
           1084815579, // Parent_shapefile_id
-          JSON.stringify(['1']), // SelectedFeatures
+          '["1"]', // SelectedFeatures
           1 // User_id
         ])
 

--- a/serverless/src/util/processPartialShapefile.js
+++ b/serverless/src/util/processPartialShapefile.js
@@ -60,7 +60,7 @@ export const processPartialShapefile = async (
           file,
           filename: `Limited-${filename}`,
           parent_shapefile_id: deobfuscatedShapefileId,
-          selected_features: selectedFeatures,
+          selected_features: JSON.stringify(selectedFeatures),
           user_id: userId
         })
     }


### PR DESCRIPTION
# Overview

### What is the feature?

Shapefile subsetting when the shapefile has a `selected_features` field is broken because the SQL statement to insert the data is invalid.

### What is the Solution?

We need to stringify the `selected_features` array before inserting it into the database.

### What areas of the application does this impact?

Shapefile subsetting (Harmony, ESI)

# Testing

### Reproduction steps

Upload a shapefile and submit a Harmony order for a collection that supports shapefile subsetting. In UAT `C1254854453-LARC_CLOUD` works.
Ensure that the order submits successfully to Harmony

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
