### PR TITLE
EDSC-4302: Update the secondary toolbar to include updated designs as well as leaflet controls

### DIFF
--- a/static/src/js/components/Button/Button.jsx
+++ b/static/src/js/components/Button/Button.jsx
@@ -39,8 +39,7 @@ export const Button = React.forwardRef(({
   tooltipPlacement,
   tooltipId,
   type,
-  variant,
-  ...rest
+  variant
 }, ref) => {
   const buttonClasses = classNames(
     'button',
@@ -104,7 +103,6 @@ export const Button = React.forwardRef(({
       style={style}
       data-testid={dataTestId}
       download={download}
-      {...rest}
     >
       {
         (!spinner && icon && iconPosition === 'left') && (

--- a/static/src/js/components/Button/Button.jsx
+++ b/static/src/js/components/Button/Button.jsx
@@ -39,7 +39,8 @@ export const Button = React.forwardRef(({
   tooltipPlacement,
   tooltipId,
   type,
-  variant
+  variant,
+  ...rest
 }, ref) => {
   const buttonClasses = classNames(
     'button',
@@ -103,6 +104,7 @@ export const Button = React.forwardRef(({
       style={style}
       data-testid={dataTestId}
       download={download}
+      {...rest}
     >
       {
         (!spinner && icon && iconPosition === 'left') && (

--- a/static/src/js/components/Legend/Legend.scss
+++ b/static/src/js/components/Legend/Legend.scss
@@ -1,5 +1,6 @@
 .legend {
   position: relative;
+  margin-top: 0.5rem;
   border-radius: 0.125rem;
   border: 1px solid rgba($color__carbon--30, 0.9);
   overflow: hidden;

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
@@ -13,10 +13,10 @@ import classNames from 'classnames'
 import {
   FaArrowCircleLeft,
   FaFolder,
-  FaLightbulb,
-  FaLock,
+  FaQuestion,
   FaSave,
-  FaUser
+  FaUser,
+  FaSignInAlt
 } from 'react-icons/fa'
 import TourContext from '../../contexts/TourContext'
 import { getApplicationConfig, getEnvironmentConfig } from '../../../../../sharedUtils/config'
@@ -214,7 +214,9 @@ class SecondaryToolbar extends Component {
             className={classNames(['secondary-toolbar__project', { 'focus-light': isMapOverlay }])}
             bootstrapVariant="light"
             href={`${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(projectPath)}`}
-            label="View Project"
+            tooltip="View your project"
+            tooltipId="view-project-tooltip"
+            tooltipPlacement="left"
             icon={FaFolder}
           >
             My Project
@@ -233,9 +235,11 @@ class SecondaryToolbar extends Component {
           }
           className={classNames(['secondary-toolbar__project', { 'focus-light': isMapOverlay }])}
           bootstrapVariant="light"
-          label="View Project"
           icon={FaFolder}
           iconPosition="left"
+          tooltip="View your project"
+          tooltipId="view-project-tooltip"
+          tooltipPlacement="left"
           updatePath
         >
           My Project
@@ -250,16 +254,17 @@ class SecondaryToolbar extends Component {
         className={classNames({ 'focus-light': isMapOverlay })}
         bootstrapVariant="light"
         href={`${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(returnPath)}`}
-        label="Login"
-        icon={FaLock}
+        tooltip="Log In with Earthdata Login"
+        tooltipId="login-tooltip"
+        tooltipPlacement="left"
+        icon={FaSignInAlt}
       >
-        Login
+        Log In
       </Button>
     )
     const loggedInDropdown = (
       <Dropdown>
         <Dropdown.Toggle
-          label="User menu"
           className={classNames([`secondary-toolbar__user-dropdown-toggle ${mapButtonClass}`, { 'focus-light': isMapOverlay }])}
           bootstrapVariant="light"
           as={Button}
@@ -352,9 +357,16 @@ class SecondaryToolbar extends Component {
           onClick={this.onToggleProjectDropdown}
           icon={FaSave}
           iconSize="0.825rem"
+          iconOnly
           bootstrapVariant="light"
-          label="Create a project with your current search"
-        />
+          tooltip="Create a project with your current search"
+          tooltipId="create-project-tooltip"
+          tooltipPlacement="left"
+        >
+          <span className="secondary-toolbar__dropdown-text sr-only">
+            Save Project
+          </span>
+        </Dropdown.Toggle>
         <Dropdown.Menu>
           <Form inline className="flex-nowrap secondary-toolbar__project-name-form">
             <Form.Row>
@@ -399,14 +411,15 @@ class SecondaryToolbar extends Component {
               <Dropdown.Toggle
                 className={classNames(['secondary-toolbar__start-tour-button', { 'focus-light': isMapOverlay }])}
                 as={Button}
-                icon={FaLightbulb}
+                icon={FaQuestion}
                 iconSize="0.825rem"
                 onClick={setRunTour}
                 bootstrapVariant="light"
-                label="Want to learn more? Click here to take a tour of our site."
-              >
-                Start Tour
-              </Dropdown.Toggle>
+                tooltip="Take a tour to learn how to use Earthdata Search"
+                tooltipId="start-tour-tooltip"
+                tooltipPlacement="left"
+                aria-label="Start tour"
+              />
             )
           }
         </TourContext.Consumer>
@@ -425,9 +438,9 @@ class SecondaryToolbar extends Component {
           {isDownloadPathWithId(location.pathname) && backToProjectLink}
           <PortalFeatureContainer authentication>
             <>
-              {showStartTourButton && startTourButton}
               {showViewProjectLink && projectLink}
               {showSaveProjectDropdown && saveProjectDropdown}
+              {showStartTourButton && startTourButton}
               {!loggedIn ? loginLink : loggedInDropdown}
             </>
           </PortalFeatureContainer>

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
@@ -357,7 +357,6 @@ class SecondaryToolbar extends Component {
           onClick={this.onToggleProjectDropdown}
           icon={FaSave}
           iconSize="0.825rem"
-          iconOnly
           bootstrapVariant="light"
           tooltip="Create a project with your current search"
           tooltipId="create-project-tooltip"

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
@@ -417,7 +417,7 @@ class SecondaryToolbar extends Component {
                 tooltip="Take a tour to learn how to use Earthdata Search"
                 tooltipId="start-tour-tooltip"
                 tooltipPlacement="left"
-                aria-label="Start tour"
+                label="Start tour"
               />
             )
           }

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.scss
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.scss
@@ -23,9 +23,9 @@
     white-space: nowrap;
   }
 
-  &--map-overlay {
+  &--map-overlay > {
     .button,
-    .dropdown-toggle {
+    .dropdown > .dropdown-toggle {
       box-shadow: none;
       border-radius: 0.25rem;
       border: 2px solid rgba($color__carbon--80, 0.3);

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -377,19 +377,9 @@ describe('SecondaryToolbar component', () => {
       test('clicking the tour works as expected', () => {
         setup()
         const tourButton = screen.getByRole('button', { name: 'Start tour' })
+        // Tour functionality is being tested in tour.spec.js
         expect(tourButton).toBeInTheDocument()
       })
-    })
-
-    test.skip('clicking the tour button calls onStartTour', async () => {
-      const { user, onStartTour } = setup()
-      const tourButton = screen.getByRole('button', { name: 'Start tour' })
-
-      await act(async () => {
-        await user.click(tourButton)
-      })
-
-      expect(onStartTour).toBeCalledTimes(1)
     })
 
     test('hovering over the tour renders a tool-tip', async () => {

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -358,8 +358,9 @@ describe('SecondaryToolbar component', () => {
   })
 
   describe('when navigating the Search Tour from the secondary toolbar', () => {
+    // Tour functionality is being tested in tour.spec.js
     describe('while the user is logged out', () => {
-      test('clicking the tour works as expected', () => {
+      test('tour button renders', () => {
         setup('loggedOut')
         const tourButton = screen.getByRole('button', { name: 'Start tour' })
         expect(tourButton).toBeInTheDocument()
@@ -367,10 +368,9 @@ describe('SecondaryToolbar component', () => {
     })
 
     describe('while the user is logged in', () => {
-      test('clicking the tour works as expected', () => {
+      test('tour button renders', () => {
         setup()
         const tourButton = screen.getByRole('button', { name: 'Start tour' })
-        // Tour functionality is being tested in tour.spec.js
         expect(tourButton).toBeInTheDocument()
       })
     })

--- a/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
+++ b/static/src/js/components/SecondaryToolbar/__tests__/SecondaryToolbar.test.js
@@ -91,6 +91,7 @@ describe('SecondaryToolbar component', () => {
     test('hovering over the login button should show a tool-tip', async () => {
       const { user } = setup()
       const loginButton = screen.getByRole('button', { name: 'Log In' })
+
       await act(async () => {
         await user.hover(loginButton)
       })
@@ -100,15 +101,13 @@ describe('SecondaryToolbar component', () => {
 
     test('should not render the user dropdown', () => {
       setup()
-      // TODO add the value for the userMenu not found
       expect(screen.queryByRole('button', { name: 'First Name' })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Save Project' })).not.toBeInTheDocument()
     })
 
     test('should not render the project dropdown', () => {
       setup()
-      // TODO double check this isn't invalidated now
-      expect(screen.queryByRole('button', { name: 'Create a project with your current search' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Save Project' })).not.toBeInTheDocument()
     })
   })
 
@@ -138,11 +137,8 @@ describe('SecondaryToolbar component', () => {
 
     test('should render the user and project name dropdowns', () => {
       setup('loggedIn')
-      // Const saveButton = screen.getByText('Save Project').parentElement.parentElement
-      // expect(within(saveButton).getByRole('button', { hidden: true })).toBeInTheDocument()
-      // screen.debug()
-
       const saveButton = screen.getByRole('button', { name: 'Save Project' })
+
       expect(saveButton).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'First Name' })).toBeInTheDocument()
     })
@@ -154,7 +150,6 @@ describe('SecondaryToolbar component', () => {
 
     test('clicking the logout button should call handleLogout', async () => {
       const { onLogout, user } = setup('loggedIn')
-
       const usermenuButton = screen.getByRole('button', { name: 'First Name' })
 
       await act(async () => {
@@ -162,15 +157,14 @@ describe('SecondaryToolbar component', () => {
       })
 
       const logoutButton = screen.getByRole('button', { name: 'Logout' })
-      await user.click(logoutButton)
 
+      await user.click(logoutButton)
       expect(onLogout).toBeCalledTimes(1)
     })
 
     describe('Download Status and History link', () => {
       test('adds the ee param if the earthdataEnvironment is different than the deployed environment', async () => {
         const { user } = setup('loggedIn', { earthdataEnvironment: 'uat' })
-
         const usermenuButton = screen.queryByRole('button', { name: 'First Name' })
 
         await act(async () => {
@@ -219,6 +213,7 @@ describe('SecondaryToolbar component', () => {
 
       expect(preventDefaultSpy).toHaveBeenCalledTimes(1)
       expect(stopPropagationSpy).toHaveBeenCalledTimes(1)
+
       preventDefaultSpy.mockRestore()
       stopPropagationSpy.mockRestore()
     })
@@ -263,7 +258,6 @@ describe('SecondaryToolbar component', () => {
       })
     })
 
-    // TODO this should show up if I am also logged in
     test('hovering over My Project renders a tool-tip', async () => {
       const { user } = setup(undefined, { projectCollectionIds: ['123'] })
       await act(async () => {
@@ -286,24 +280,23 @@ describe('SecondaryToolbar component', () => {
       expect(myProjectButton).not.toBeInTheDocument()
     })
 
-    test('clicking the dropdown sets the state', async () => {
+    test('clicking the save project dropdown sets the state', async () => {
       const { user } = setup('loggedIn')
-      // The Save project button
-      const myProjectButton = screen.getByRole('button', { name: 'Save Project' })
+      const saveProjectButton = screen.getByRole('button', { name: 'Save Project' })
+
       await act(async () => {
-        await user.click(myProjectButton)
+        await user.click(saveProjectButton)
       })
 
-      expect(within(myProjectButton.parentElement).getByRole('textbox').placeholder).toBe('Untitled Project')
-      expect(within(myProjectButton.parentElement).getByRole('button', { name: 'Save Project' })).toBeInTheDocument()
+      expect(within(saveProjectButton.parentElement).getByRole('textbox').placeholder).toBe('Untitled Project')
     })
 
     test('hovering over saved project renders the tool-tip', async () => {
       const { user } = setup('loggedIn')
-      // The Save project button
-      const myProjectButton = screen.getByRole('button', { name: 'Save Project' })
+      const saveProjectButton = screen.getByRole('button', { name: 'Save Project' })
+
       await act(async () => {
-        await user.hover(myProjectButton)
+        await user.hover(saveProjectButton)
       })
 
       expect(screen.getByText('Create a project with your current search')).toBeVisible()
@@ -311,22 +304,22 @@ describe('SecondaryToolbar component', () => {
 
     test('clicking the save button sets the state and calls onUpdateProjectName', async () => {
       const { user, onUpdateProjectName } = setup('loggedIn')
-      const myProjectButton = screen.getByRole('button', { name: 'Save Project' })
-
-      await act(async () => {
-        await user.click(myProjectButton)
-      })
-
-      expect(within(myProjectButton.parentElement).getByRole('textbox').placeholder).toBe('Untitled Project')
-
-      const projectNameField = within(myProjectButton.parentElement).getByRole('textbox')
-
-      await user.type(projectNameField, 'test project name')
-
-      const saveProjectButton = screen.getByRole('button', { name: 'Save project name' })
+      const saveProjectButton = screen.getByRole('button', { name: 'Save Project' })
 
       await act(async () => {
         await user.click(saveProjectButton)
+      })
+
+      expect(within(saveProjectButton.parentElement).getByRole('textbox').placeholder).toBe('Untitled Project')
+
+      const projectNameField = within(saveProjectButton.parentElement).getByRole('textbox')
+
+      await user.type(projectNameField, 'test project name')
+
+      const saveProjectNameButton = screen.getByRole('button', { name: 'Save project name' })
+
+      await act(async () => {
+        await user.click(saveProjectNameButton)
       })
 
       expect(onUpdateProjectName).toBeCalledTimes(1)

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -12,7 +12,6 @@
     margin-bottom: 0.5rem;
     text-transform: uppercase;
     letter-spacing: 0.125rem;
-    // letter-spacing: 0.25rem;
     font-family: $font-family-monospace;
   }
 
@@ -94,9 +93,6 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
-    // gap: 0.9375rem;
-    // position: absolute;
-    // right: 0;
 
     &.intro {
       width: 100%;

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -11,7 +11,8 @@
     font-size: 0.75rem;
     margin-bottom: 0.5rem;
     text-transform: uppercase;
-    letter-spacing: 0.25rem;
+    letter-spacing: 0.125rem;
+    font-family: $font-family-monospace;
   }
 
   &__subheading {
@@ -21,9 +22,9 @@
     letter-spacing: -1%;
   }
 
-  &__content, 
+  &__content,
   &__webinar-description {
-    font-size: 1rem;
+    font-size: 0.875rem;
     margin-bottom: 1.25rem;
     text-align: left;
   }
@@ -40,7 +41,7 @@
   }
 
   &__note {
-    font-size: 0.875rem;
+    font-size: 0.775rem;
     margin-bottom: 1.25rem;
     text-align: left;
   }
@@ -89,22 +90,18 @@
   }
 
   &__buttons {
-    margin-top: 5rem;
     display: flex;
     justify-content: flex-end;
-    gap: 0.9375rem;
-    position: absolute;
-    right: 0;
+    gap: 0.75rem;
+    // gap: 0.9375rem;
+    // position: absolute;
+    // right: 0;
 
     &.intro {
       width: 100%;
       justify-content: center;
       position: static;
       margin-top: 1.25rem;
-    }
-
-    &:not(.intro) {
-      width: 9rem;
     }
   }
 
@@ -113,7 +110,7 @@
     padding: 1rem 1rem 0.0625rem;
     margin-bottom: 0.9375rem;
     border-radius: 0.25rem;
-    font-size: 0.875rem;
+    font-size: 0.75rem;
     text-align: left;
 
     &__link {
@@ -123,40 +120,101 @@
     }
   }
 
-  &__webinar {
-    &__box {
-      background-color: $color__carbon--5;
-      padding: 0.625rem;
-      margin-bottom: 1.25rem;
-      border-radius: 0.375rem;
+  &__webinar-link {
+    background-color: $color__carbon--5;
+    margin-bottom: 1.25rem;
+    border-radius: 0.25rem;
+    text-decoration: none;
+    color: $color__carbon-black;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    margin-top: 0.625rem;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+      background-color: $color__carbon--10;
       text-decoration: none;
-      color: $color__carbon-black;
-      display: flex;
-      align-items: center;
-    }
-
-    &__text {
-      flex: 0 0 13.75rem;
-      margin-right: 0.9375rem;
-    }
-
-    &__thumbnail {
-      width: 100%;
-      height: auto;
-    }
-
-    &__link {
-      font-size: 1rem;
-      font-weight: bold;
-      margin-top: 0.625rem;
-      margin-left: 0.625rem;
     }
   }
 
-  &__discover-more {
-    padding: 0.625rem;
+  &__webinar-text {
+    flex: 0 0 13.75rem;
+  }
+
+  &__webinar-thumbnail-wrapper {
+    width: 100%;
+    height: auto;
+    position: relative;
+  }
+
+  &__webinar-thumbnail-overlay {
+    position: absolute;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inset: 0;
+    background-color: rgba($color__carbon-black, 0.25);
+  }
+
+  &__webinar-thumbnail-icon-bg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 3rem;
+    width: 3rem;
+    border-radius: 50%;
+    background-color: rgba($color__nasa-red--shade, 0.875);
+    transition: all 0.2s ease-in-out;
+    transform: scale(1);
+
+    .search-tour__webinar-link:hover &,
+    .search-tour__webinar-link:focus-visible & {
+      background-color: rgba($color__nasa-red--shade, 1);
+      transform: scale(1.05);
+    }
+  }
+
+  &__webinar-thumbnail-icon {
+    position: relative;
+    z-index: 0;
+    display: block;
+    color: $color__spacesuit-white;
+    font-size: 1rem;
+  }
+
+  &__webinar-thumbnail {
+    width: 100%;
+    height: auto;
+  }
+
+  &__webinar-content {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  &__webinar-inner-link {
+    display: inline-block;
+    font-size: 1rem;
+    font-weight: bold;
+    margin-top: 0.625rem;
+    margin-bottom: 0;
+    text-decoration: none;
+  }
+
+  &__webinar-discover-more {
+    display: inline-block;
     font-size: 1rem;
     font-weight: 500;
+    text-decoration: none;
+
+    .search-tour__webinar-link:hover &,
+    .search-tour__webinar-link:focus-visible & {
+      text-decoration: none;
+    }
   }
 
   &__more-info {
@@ -187,13 +245,11 @@
     position: relative;
     min-height: 12.5rem;
   }
-  &__content-wrapper {
-    padding-bottom: 1.25rem;
-  }
 }
 
 .step-counter-text {
   font-family: $font-family-monospace;
+  letter-spacing: 0.125rem;
   font-size: 0.75rem;
   margin-bottom: 0.9375rem;
   color: $color__carbon--40;
@@ -210,7 +266,7 @@
 
 kbd {
   display: inline-block;
-  vertical-align: center;
+  vertical-align: middle;
   font-size: 0.75em;
   padding: 0.125rem 0.1875rem;
 }

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -44,6 +44,8 @@
     font-size: 0.775rem;
     margin-bottom: 1.25rem;
     text-align: left;
+    display: flex;
+    align-items: center;
   }
 
   &__tour-toggle {

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -12,6 +12,7 @@
     margin-bottom: 0.5rem;
     text-transform: uppercase;
     letter-spacing: 0.125rem;
+    // letter-spacing: 0.25rem;
     font-family: $font-family-monospace;
   }
 
@@ -244,6 +245,10 @@
     text-align: center;
     position: relative;
     min-height: 12.5rem;
+  }
+
+  &__content-wrapper {
+    padding-bottom: 1.25rem;
   }
 }
 

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import {
   FaInfoCircle,
   FaPlay,
-  FaPlus
+  FaPlus,
+  FaQuestion
 } from 'react-icons/fa'
 import PropTypes from 'prop-types'
 import ExternalLink from '../ExternalLink/ExternalLink'
@@ -109,7 +110,7 @@ const TourSteps = ({
         <p className="search-tour__note">
           If you want to skip the tour for now, it is always available by clicking the
           {' '}
-          <strong>?</strong>
+          <FaQuestion />
           {' '}
           at the top of the page.
         </p>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -109,7 +109,7 @@ const TourSteps = ({
         <p className="search-tour__note">
           If you want to skip the tour for now, it is always available by clicking
           {' '}
-          <strong>Start Tour</strong>
+          <strong>the ?</strong>
           {' '}
           at the top of the page.
         </p>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { FaInfoCircle, FaPlus } from 'react-icons/fa'
+import {
+  FaInfoCircle,
+  FaPlay,
+  FaPlus
+} from 'react-icons/fa'
 import PropTypes from 'prop-types'
 import ExternalLink from '../ExternalLink/ExternalLink'
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
@@ -525,25 +529,32 @@ const TourSteps = ({
           Check out our latest webinar where you will see a hands-on example of
           how to search for data in Earthdata Search.
         </p>
-        <div className="search-tour__webinar__box">
-          <div className="search-tour__webinar__text">
-            <img
-              src={TourThumbnail}
-              alt="Webinar Thumbnail"
-              className="search-tour__webinar__thumbnail"
-            />
+        <a className="search-tour__webinar-link" href="https://www.youtube.com/watch?v=QtfMlkd7kII">
+          <div className="search-tour__webinar-text">
+            <div className="search-tour__webinar-thumbnail-wrapper">
+              <div className="search-tour__webinar-thumbnail-overlay">
+                <div className="search-tour__webinar-thumbnail-icon-bg">
+                  <EDSCIcon className="search-tour__webinar-thumbnail-icon" size="18px" icon={FaPlay} />
+                </div>
+              </div>
+              <img
+                className="search-tour__webinar-thumbnail"
+                src={TourThumbnail}
+                alt="Webinar Thumbnail"
+              />
+            </div>
           </div>
-          <div>
-            <div className="search-tour__discover-more">
+          <div className="search-tour__webinar-content">
+            <div className="search-tour__webinar-discover-more">
               Discover and Access Earth Science Data Using Earthdata Search
             </div>
-            <p className="search-tour__webinar__link">
-              <ExternalLink href="https://www.youtube.com/watch?v=QtfMlkd7kII">
-                Watch the webinar
+            <p className="search-tour__webinar-inner-link">
+              <ExternalLink>
+                Watch the webinar on YouTube
               </ExternalLink>
             </p>
           </div>
-        </div>
+        </a>
         <p className="search-tour__more-info">
           Find more information here:
         </p>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -111,8 +111,7 @@ const TourSteps = ({
           If you want to skip the tour for now, it is always available by clicking the
           {' '}
           <FaQuestion />
-          {' '}
-          at the top of the page.
+          &nbsp;at the top of the page.
         </p>
         <div className="search-tour__tour-toggle">
           <input

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -107,9 +107,9 @@ const TourSteps = ({
           preferences.
         </p>
         <p className="search-tour__note">
-          If you want to skip the tour for now, it is always available by clicking
+          If you want to skip the tour for now, it is always available by clicking the
           {' '}
-          <strong>the ?</strong>
+          <strong>?</strong>
           {' '}
           at the top of the page.
         </p>

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -124,7 +124,6 @@ test.describe('Joyride Tour Navigation', () => {
   test('should navigate through the Joyride tour', async ({ page }) => {
     // Start the tour by clicking the "Start Tour" button
     page.getByRole('button', { name: 'Start tour' }).click()
-    // Await page.click('button:has-text("Start Tour")')
 
     // Start Tour View: Welcome to Earthdata Search
     await expect(page.locator('.search-tour__welcome')).toContainText('Welcome to Earthdata Search!')

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -123,7 +123,8 @@ test.describe('Joyride Tour Navigation', () => {
 
   test('should navigate through the Joyride tour', async ({ page }) => {
     // Start the tour by clicking the "Start Tour" button
-    await page.click('button:has-text("Start Tour")')
+    page.getByRole('button', { name: 'Start tour' }).click()
+    // Await page.click('button:has-text("Start Tour")')
 
     // Start Tour View: Welcome to Earthdata Search
     await expect(page.locator('.search-tour__welcome')).toContainText('Welcome to Earthdata Search!')
@@ -374,9 +375,9 @@ test.describe('Joyride Tour Navigation', () => {
     }
 
     expectWithinMargin(spotlightRect, {
-      left: 1172,
+      left: 1240,
       top: 34,
-      width: 133,
+      width: 63,
       height: 56
     }, 10)
 


### PR DESCRIPTION
# Overview

### What is the feature?


Updates the secondary toolbar with the improvements post the design. This includes adding tool-tips on the buttons in the secondary tool-bar header and some styling improvements to the tour. It also fixes the spacing discrepancy between the colormap and the scale in leaflet when a colormap is rendered

### What is the Solution?

Updating the styling for the Tour steps, secondary toolbar, and the colormap

### What areas of the application does this impact?

Secondary toolbar, Leaflet colormap, the tour steps visuals

# Testing

### Reproduction steps

- **Environment for testing:*Any*
- **Collection to test with:*C1601063219-NSIDC_ECS* (For the colormap)

1. Ensure that hovering over the following buttons displays a tool-tip (My Project, Save Project, Login, Tour button
2. Ensure that the tour steps continue to work as expected with the following differences: the final page for the webinar has been updated with an updated image for the video link; ensure that when hovering the button reacts by enlarging the play button. Also ensure that clicking on the image takes you to the webinar on Youtube


### Attachments
Logged out
![image](https://github.com/user-attachments/assets/e11d66df-773b-4c57-85aa-726191fa6bf6)

Logged in with a project created
![image](https://github.com/user-attachments/assets/9ab67a1e-74cb-4b27-b90f-7838a7af8a64)

Webinar last tour step
![image](https://github.com/user-attachments/assets/87c53130-f909-4eb3-9e65-b8a3b8b44621)

Even out spacing between colormap and the leaflet scale
![image](https://github.com/user-attachments/assets/a81a3481-f191-4166-b8b2-5239a5d1718c)

Tour First page:
![image](https://github.com/user-attachments/assets/fb1f3bad-d63b-4a25-8d1e-4e4f0865660b)


Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
