### PR TITLE
EDSC-4246: Show the EDD button when a Harmony order is complete_with_errors and has links

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatusItem.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.jsx
@@ -154,14 +154,15 @@ export class OrderStatusItem extends PureComponent {
       retrieval_collection_id: retrievalCollectionId
     } = collection
 
+    const orderStatus = aggregatedOrderStatus(orders)
+
     const [firstOrder = {}] = orders
     const {
-      state,
       type = ''
     } = firstOrder
 
     // If the order is Harmony and is still running or has no files, don't show the EDD link
-    const isDone = ['successful', 'complete_with_errors'].includes(state)
+    const isDone = !['creating', 'in progress'].includes(orderStatus)
     const notDoneOrEmpty = !isDone || downloadUrls.length === 0
     if (type.toLowerCase() === 'harmony' && notDoneOrEmpty) {
       return null

--- a/static/src/js/components/OrderStatus/OrderStatusItem.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.jsx
@@ -689,15 +689,16 @@ export class OrderStatusItem extends PureComponent {
                       >
                         <DownloadFilesPanel
                           accessMethodType={accessMethodType}
+                          collectionIsCSDA={collectionIsCSDA}
+                          disableEddInProgress={accessMethodType.toLowerCase() === 'harmony' && progressPercentage < 100}
                           downloadLinks={downloadUrls}
                           eddLink={this.buildEddLink('data', downloadUrls)}
                           granuleCount={granuleCount}
                           granuleLinksIsLoading={granuleLinksIsLoading}
                           percentDoneDownloadLinks={percentDoneDownloadLinks}
-                          retrievalId={retrievalId}
                           retrievalCollectionId={retrievalCollectionId}
+                          retrievalId={retrievalId}
                           showTextWindowActions={!isEsi}
-                          collectionIsCSDA={collectionIsCSDA}
                         />
                       </Tab>
                     )

--- a/static/src/js/components/OrderStatus/OrderStatusItem.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem.jsx
@@ -141,7 +141,7 @@ export class OrderStatusItem extends PureComponent {
     }
   }
 
-  buildEddLink(linkType) {
+  buildEddLink(linkType, downloadUrls) {
     const {
       authToken,
       collection,
@@ -160,8 +160,12 @@ export class OrderStatusItem extends PureComponent {
       type = ''
     } = firstOrder
 
-    // If the order is Harmony and isn't successful, don't show the EDD link
-    if (type.toLowerCase() === 'harmony' && state !== 'successful') return null
+    // If the order is Harmony and is still running or has no files, don't show the EDD link
+    const isDone = ['successful', 'complete_with_errors'].includes(state)
+    const notDoneOrEmpty = !isDone || downloadUrls.length === 0
+    if (type.toLowerCase() === 'harmony' && notDoneOrEmpty) {
+      return null
+    }
 
     const {
       conceptId,
@@ -685,7 +689,7 @@ export class OrderStatusItem extends PureComponent {
                         <DownloadFilesPanel
                           accessMethodType={accessMethodType}
                           downloadLinks={downloadUrls}
-                          eddLink={this.buildEddLink('data')}
+                          eddLink={this.buildEddLink('data', downloadUrls)}
                           granuleCount={granuleCount}
                           granuleLinksIsLoading={granuleLinksIsLoading}
                           percentDoneDownloadLinks={percentDoneDownloadLinks}

--- a/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/DownloadFilesPanel.jsx
@@ -13,24 +13,27 @@ import './DownloadFilesPanel.scss'
  * Renders DownloadFilesPanel.
  * @param {Object} arg0 - The props passed into the component.
  * @param {String} arg0.accessMethodType - The retrieval collection access method.
+ * @param {Boolean} arg0.collectionIsCSDA - A flag set when the collection is CSDA.
+ * @param {Boolean} arg0.disableEddInProgress - Disables EDD button when a job is still in progress (e.g. a Harmony job still in progress).
  * @param {Array} arg0.downloadLinks - The download links.
- * @param {String} arg0.retrievalId - The retrieval id.
+ * @param {String} arg0.eddLink - The EDD link.
  * @param {Number} arg0.granuleCount - The retrieval collection granule count.
  * @param {Boolean} arg0.granuleLinksIsLoading - A flag set when the granule links are loading.
  * @param {Boolean} arg0.percentDoneDownloadLinks - Percentage of the download links that have been fetched.
+ * @param {String} arg0.retrievalId - The retrieval id.
  * @param {Boolean} arg0.showTextWindowActions - A flag set when the text window actions should be set.
- * @param {Boolean} arg0.collectionIsCSDA - A flag set when the collection is CSDA.
 */
 export const DownloadFilesPanel = ({
   accessMethodType,
+  collectionIsCSDA,
+  disableEddInProgress,
   downloadLinks,
+  eddLink,
   granuleCount,
   granuleLinksIsLoading,
   percentDoneDownloadLinks,
   retrievalId,
-  eddLink,
-  showTextWindowActions,
-  collectionIsCSDA
+  showTextWindowActions
 }) => {
   const downloadFileName = `${retrievalId}-${accessMethodType}.txt`
 
@@ -54,15 +57,16 @@ export const DownloadFilesPanel = ({
         }
       </div>
       <TextWindowActions
-        id={`links-${retrievalId}`}
+        clipboardContents={downloadLinks.join('\n')}
+        disableCopy={!showTextWindowActions}
+        disableEddInProgress={disableEddInProgress}
+        disableSave={!showTextWindowActions}
         eddLink={eddLink}
         fileContents={downloadLinks.join('\n')}
         fileName={downloadFileName}
-        clipboardContents={downloadLinks.join('\n')}
+        hideEdd={collectionIsCSDA}
+        id={`links-${retrievalId}`}
         modalTitle="Download Files"
-        disableCopy={!showTextWindowActions}
-        disableSave={!showTextWindowActions}
-        disableEdd={collectionIsCSDA}
       >
         <ul className="download-files-panel__list">
           {
@@ -88,24 +92,24 @@ export const DownloadFilesPanel = ({
 }
 
 DownloadFilesPanel.defaultProps = {
-  percentDoneDownloadLinks: null,
-  showTextWindowActions: true,
   collectionIsCSDA: false,
-  eddLink: null
+  disableEddInProgress: false,
+  eddLink: null,
+  percentDoneDownloadLinks: null,
+  showTextWindowActions: true
 }
 
 DownloadFilesPanel.propTypes = {
   accessMethodType: PropTypes.string.isRequired,
-  downloadLinks: PropTypes.arrayOf(
-    PropTypes.string
-  ).isRequired,
-  retrievalId: PropTypes.string.isRequired,
+  collectionIsCSDA: PropTypes.bool,
+  disableEddInProgress: PropTypes.bool,
+  downloadLinks: PropTypes.arrayOf(PropTypes.string).isRequired,
   eddLink: PropTypes.string,
   granuleCount: PropTypes.number.isRequired,
   granuleLinksIsLoading: PropTypes.bool.isRequired,
   percentDoneDownloadLinks: PropTypes.string,
-  showTextWindowActions: PropTypes.bool,
-  collectionIsCSDA: PropTypes.bool
+  retrievalId: PropTypes.string.isRequired,
+  showTextWindowActions: PropTypes.bool
 }
 
 export default DownloadFilesPanel

--- a/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
+++ b/static/src/js/components/OrderStatus/OrderStatusItem/__tests__/DownloadFilesPanel.test.js
@@ -95,7 +95,7 @@ describe('DownloadFilesPanel', () => {
       )
 
       const windowActions = enzymeWrapper.find(TextWindowActions)
-      expect(windowActions.props().disableEdd).toEqual(true)
+      expect(windowActions.props().hideEdd).toEqual(true)
     })
   })
 })

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -346,6 +346,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
       expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+      expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -436,6 +437,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().percentDoneDownloadLinks).toEqual('50')
       expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
       expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+      expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -596,6 +598,7 @@ describe('OrderStatusItem', () => {
       expect(linksTab.childAt(0).props().granuleCount).toEqual(100)
       expect(linksTab.childAt(0).props().downloadLinks).toEqual(['http://example.com'])
       expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=shortName_versionId&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+      expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
       const scriptTab = tabs.childAt(1)
       expect(scriptTab.props().title).toEqual('Download Script')
@@ -1806,6 +1809,7 @@ describe('OrderStatusItem', () => {
         ])
 
         expect(linksTab.childAt(0).props().eddLink).toEqual(null)
+        expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(true)
 
         const stacLinksTab = tabs.childAt(1)
         expect(stacLinksTab.childAt(0).props().granuleCount).toEqual(100)
@@ -1931,6 +1935,7 @@ describe('OrderStatusItem', () => {
         ])
 
         expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=testDataset_1&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+        expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
         const stacLinksTab = tabs.childAt(1)
         expect(stacLinksTab.childAt(0).props().granuleCount).toEqual(100)
@@ -2059,6 +2064,7 @@ describe('OrderStatusItem', () => {
         ])
 
         expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3D42%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=testDataset_1&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+        expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
         const stacLinksTab = tabs.childAt(1)
         expect(stacLinksTab.childAt(0).props().granuleCount).toEqual(100)
@@ -2481,9 +2487,8 @@ describe('OrderStatusItem', () => {
         expect(linksTab.childAt(0).props().granuleCount).toEqual(10)
         expect(linksTab.childAt(0).props().downloadLinks).toEqual([])
 
-        expect(linksTab.childAt(0).props().eddLink).toEqual(
-          'earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3Dundefined%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=undefined&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback'
-        )
+        expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3Dundefined%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=undefined&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+        expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
         const orderStatusTab = tabs.childAt(1)
         expect(orderStatusTab.props().title).toEqual('Order Status')
@@ -2574,6 +2579,7 @@ describe('OrderStatusItem', () => {
         ])
 
         expect(linksTab.childAt(0).props().eddLink).toEqual('earthdata-download://startDownload?getLinks=http%3A%2F%2Flocalhost%3A3000%2Fgranule_links%3Fid%3Dundefined%26flattenLinks%3Dtrue%26linkTypes%3Ddata%26ee%3Dprod&downloadId=undefined&clientId=eed-default-test-serverless-client&token=Bearer mock-token&authUrl=http%3A%2F%2Flocalhost%3A3000%2Flogin%3Fee%3Dprod%26eddRedirect%3Dearthdata-download%253A%252F%252FauthCallback&eulaRedirectUrl=http%3A%2F%2Flocalhost%3A8080%2Fauth_callback%3FeddRedirect%3Dearthdata-download%253A%252F%252FeulaCallback')
+        expect(linksTab.childAt(0).props().disableEddInProgress).toEqual(false)
 
         const orderStatusTab = tabs.childAt(1)
         expect(orderStatusTab.props().title).toEqual('Order Status')

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatusItem.test.js
@@ -1942,7 +1942,9 @@ describe('OrderStatusItem', () => {
         expect(orderStatusTab.props().title).toEqual('Order Status')
         expect(orderStatusTab.childAt(0).props().orders).toEqual(props.collection.orders)
       })
+    })
 
+    describe('when the order is completed_with_errors', () => {
       test('renders an updated progress state', () => {
         const { enzymeWrapper, props } = setup({
           type: 'harmony',
@@ -1963,7 +1965,7 @@ describe('OrderStatusItem', () => {
             granule_count: 100,
             orders: [{
               type: 'Harmony',
-              state: 'successful',
+              state: 'complete_with_errors',
               order_information: {
                 jobID: 'e116eeb5-f05e-4e5b-bc97-251dd6e1c66e',
                 links: [

--- a/static/src/js/components/TextWindowActions/TextWindowActions.jsx
+++ b/static/src/js/components/TextWindowActions/TextWindowActions.jsx
@@ -28,27 +28,30 @@ import './TextWindowActions.scss'
  * Renders TextWindowActions.
  * @param {Node} children - React children to display in the text window
  * @param {String} clipboardContents - An string that will be copied to the users clipboard.
+ * @param {Boolean} disableCopy - Disables the copy functionality.
+ * @param {Boolean} disableEddInProgress - Disables EDD button when a job is still in progress (e.g. a Harmony job still in progress).
+ * @param {Boolean} disableSave - Disables the save functionality.
+ * @param {String} eddLink - The EDD link.
  * @param {String} fileContents - An optional string to be saved to the users computer.
  * @param {String} fileName - An optional string to to set the name for the file saved to the users computer.
+ * @param {Boolean} hideEdd - A flag to hide the EDD button completely.
  * @param {String} id - The id to use for the bootstrap modal.
  * @param {String} modalTitle - The title for the modal.
- * @param {Boolean} disableCopy - Disables the copy functionality.
- * @param {Boolean} disableSave - Disables the save functionality.
- * @param {Boolean} disableEdd - Disables EDD button.
  */
 export const TextWindowActions = ({
   children,
   clipboardContents,
-  disableEdd,
   disableCopy,
+  disableEddInProgress,
   disableSave,
+  eddLink,
   fileContents,
   fileName,
+  hideEdd,
   id,
-  modalTitle,
-  eddLink
+  modalTitle
 }) => {
-  const { disableEddDownload } = getApplicationConfig()
+  const { disableEddInProgressDownload: hideEddFromSettings } = getApplicationConfig()
 
   const supportsClipboard = document.queryCommandSupported('copy')
   const textareaElRef = useRef(null)
@@ -83,12 +86,19 @@ export const TextWindowActions = ({
     }
   }
 
+  let eddTooltipMessage = 'Download files with Earthdata Download'
+  if (disableEddInProgress) {
+    // If the EDD button is disabled when a job is still in progress, add a note to the tooltip
+    eddTooltipMessage += ' when the job is complete'
+  }
+
   return (
     <div className="text-window-actions">
       <header className="text-window-actions__actions">
         {
-          (!disableEdd && disableEddDownload !== 'true' && eddLink) && (
+          (!hideEdd && hideEddFromSettings !== 'true' && (eddLink || disableEddInProgress)) && (
             <Button
+              disabled={disableEddInProgress}
               className="text-window-actions__action text-window-actions__action--edd"
               bootstrapSize="sm"
               icon={Download}
@@ -96,7 +106,7 @@ export const TextWindowActions = ({
               onClick={handleEddModalOpen}
               tooltipId={`text-window-actions__tooltip--${id}`}
               tooltip={(
-                <span>Download files with Earthdata Download</span>
+                <span>{eddTooltipMessage}</span>
               )}
             >
               Download Files
@@ -292,26 +302,28 @@ export const TextWindowActions = ({
 
 TextWindowActions.defaultProps = {
   children: null,
-  disableEdd: false,
-  disableCopy: false,
-  disableSave: false,
   clipboardContents: '',
+  disableCopy: false,
+  disableEddInProgress: false,
+  disableSave: false,
+  eddLink: null,
   fileContents: null,
   fileName: null,
+  hideEdd: false,
   id: null,
-  modalTitle: null,
-  eddLink: null
+  modalTitle: null
 }
 
 TextWindowActions.propTypes = {
   children: PropTypes.node,
   clipboardContents: PropTypes.string,
-  disableEdd: PropTypes.bool,
   disableCopy: PropTypes.bool,
+  disableEddInProgress: PropTypes.bool,
   disableSave: PropTypes.bool,
+  eddLink: PropTypes.string,
   fileContents: PropTypes.string,
   fileName: PropTypes.string,
-  eddLink: PropTypes.string,
+  hideEdd: PropTypes.bool,
   id: PropTypes.string,
   modalTitle: PropTypes.string
 }

--- a/static/src/js/components/TextWindowActions/__tests__/TextWindowActions.test.js
+++ b/static/src/js/components/TextWindowActions/__tests__/TextWindowActions.test.js
@@ -357,25 +357,30 @@ describe('TextWindowActions component', () => {
       })
     })
 
-    describe('when disabling the edd button', () => {
+    describe('when hiding the edd button', () => {
       const { enzymeWrapper } = setup({
-        disableEdd: true
+        hideEdd: true
       })
 
       test('hides the edd button', () => {
         expect(enzymeWrapper.find('.text-window-actions__action--edd').length).toEqual(0)
       })
+    })
 
-      describe('when the modal is open', () => {
-        const expandButton = enzymeWrapper.find('.text-window-actions__action--expand').filter(Button)
-        expandButton.simulate('click')
+    describe('when disabling the edd button while a job is in progress', () => {
+      const { enzymeWrapper } = setup({
+        eddLink: null,
+        disableEddInProgress: true
+      })
 
-        const linksModal = enzymeWrapper.find(EDSCModalContainer).at(0)
-        expect(linksModal.props().isOpen).toEqual(true)
+      test('disables the button and displays the correct tooltip message', () => {
+        const button = enzymeWrapper.find('.text-window-actions__action--edd')
+        expect(button.length).toEqual(1)
 
-        test('hides the edd button', () => {
-          expect(enzymeWrapper.find('.text-window-actions__modal-action--edd').length).toEqual(0)
-        })
+        expect(button.props().disabled).toEqual(true)
+        expect(button.props().tooltip).toEqual((
+          <span>Download files with Earthdata Download when the job is complete</span>
+        ))
       })
     })
   })


### PR DESCRIPTION
# Overview

### What is the feature?

Harmony orders can complete with errors but still have valid links. When this happens we are not showing the Earthdata Download download button.

### What is the Solution?

Change our logic to allow for complete_with_errors jobs that do have links to show the EDD button.

### What areas of the application does this impact?

Harmony orders

# Testing

### Reproduction steps

This job has a bounding box that doesn't work for the a granule within the applied temporal. Ensure that both temporal and spatial subsetting are selected.

http://localhost:8080/projects?p=C2670138092-NSIDC_CPRD!C2670138092-NSIDC_CPRD&pg[1][v]=t&pg[1][gsk]=-start_date&pg[1][m]=harmony0&pg[1][cd]=f&pg[1][ets]=t&pg[1][ess]=t&q=ATL06&sb[0]=-50.99141%2C68.31574%2C-47.56861%2C69.91401&qt=2019-02-22T19%3A47%3A47.080Z%2C2019-04-11T10%3A04%3A08.643Z&ff=Customizable&tl=1553331766!3!!

Locally you will have to submit the job manually, and fetch updates manually after the job is completed to get your order into the correct state.

Once in complete_with_errors with other valid links you should see the "Download Files" button

### Attachments

Completed successfully
<img width="753" alt="Screenshot 2024-11-08 at 2 40 38 PM" src="https://github.com/user-attachments/assets/6d959874-ef3b-4873-9835-3529be1afa83">

In Progress
<img width="800" alt="Screenshot 2024-11-12 at 5 01 13 PM" src="https://github.com/user-attachments/assets/30c7aacb-494a-480e-9051-a845bd50960e">

Completed with errors but with links
<img width="727" alt="Screenshot 2024-11-08 at 2 40 53 PM" src="https://github.com/user-attachments/assets/cf33225d-4f75-4cc4-a9ca-1cbe9bd0cd90">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
