### PR TITLE
EDSC-4292: Adds label to Harmony orders

### DIFF
--- a/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/constructOrderPayload.test.js
@@ -1,16 +1,35 @@
 import nock from 'nock'
 import { ReadStream } from 'fs'
 
-import * as getEarthdataConfig from '../../../../sharedUtils/config'
+import * as getConfig from '../../../../sharedUtils/config'
+import * as getClientId from '../../../../sharedUtils/getClientId'
 
 import { constructOrderPayload } from '../constructOrderPayload'
 import { mockCcwShapefile } from './mocks'
 
 describe('constructOrderPayload', () => {
+  const OLD_ENV = process.env
+
   beforeEach(() => {
-    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+    process.env = { ...OLD_ENV }
+    delete process.env.NODE_ENV
+    process.env.obfuscationSpin = 1234
+
+    jest.spyOn(getConfig, 'getEarthdataConfig').mockImplementation(() => ({
       cmrHost: 'https://cmr.earthdata.nasa.gov'
     }))
+
+    jest.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+      env: 'test'
+    }))
+
+    jest.spyOn(getClientId, 'getClientId').mockImplementation(() => ({
+      background: 'mock-background-clientId'
+    }))
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
   })
 
   describe('skipPreview', () => {
@@ -36,11 +55,44 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.get('skipPreview')).toEqual('true')
+    })
+  })
+
+  describe('label', () => {
+    test('returns labels', async () => {
+      nock(/cmr/)
+        .matchHeader('Authorization', 'Bearer access-token')
+        .get('/search/granules.json')
+        .reply(200, {
+          feed: {
+            entry: [{
+              id: 'G10000001-EDSC'
+            }, {
+              id: 'G10000005-EDSC'
+            }]
+          }
+        })
+
+      const accessMethod = {
+        selectedOutputFormat: 'image/png'
+      }
+      const granuleParams = {}
+      const accessToken = 'access-token'
+
+      const response = await constructOrderPayload({
+        accessMethod,
+        accessToken,
+        granuleParams,
+        retrievalId: 1234
+      })
+
+      expect(response.get('label')).toEqual('eed-edsc-test,edsc-id=7496392841')
     })
   })
 
@@ -68,8 +120,9 @@ describe('constructOrderPayload', () => {
 
         const response = await constructOrderPayload({
           accessMethod,
+          accessToken,
           granuleParams,
-          accessToken
+          retrievalId: 1234
         })
 
         expect(response.get('format')).toEqual('image/png')
@@ -97,8 +150,9 @@ describe('constructOrderPayload', () => {
 
         const response = await constructOrderPayload({
           accessMethod,
+          accessToken,
           granuleParams,
-          accessToken
+          retrievalId: 1234
         })
 
         expect(response.get('format')).toEqual(null)
@@ -130,8 +184,9 @@ describe('constructOrderPayload', () => {
 
         const response = await constructOrderPayload({
           accessMethod,
+          accessToken,
           granuleParams,
-          accessToken
+          retrievalId: 1234
         })
 
         expect(response.get('outputCrs')).toEqual('EPSG:4326')
@@ -160,8 +215,9 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.get('granuleId')).toEqual('G10000001-EDSC,G10000005-EDSC')
@@ -195,8 +251,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual(['time("2020-01-01T01:36:52.273Z":"2020-01-01T06:18:19.482Z")'])
@@ -229,8 +286,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual(['time("2020-01-01T01:36:52.273Z":"*")'])
@@ -262,8 +320,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual(['time("*":"2020-01-01T06:18:19.482Z")'])
@@ -297,8 +356,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual([])
@@ -334,8 +394,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
-            granuleParams,
             accessToken,
+            granuleParams,
+            retrievalId: 1234,
             shapefile
           })
 
@@ -369,8 +430,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -403,8 +465,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -437,8 +500,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -471,8 +535,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.get('shapefile')).toBeInstanceOf(ReadStream)
@@ -513,8 +578,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -550,8 +616,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -593,8 +660,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -636,8 +704,9 @@ describe('constructOrderPayload', () => {
 
           const response = await constructOrderPayload({
             accessMethod,
+            accessToken,
             granuleParams,
-            accessToken
+            retrievalId: 1234
           })
 
           expect(response.getAll('subset')).toEqual([
@@ -682,8 +751,9 @@ describe('constructOrderPayload', () => {
 
         const response = await constructOrderPayload({
           accessMethod,
+          accessToken,
           granuleParams,
-          accessToken
+          retrievalId: 1234
         })
 
         expect(response.getAll('subset')).not.toEqual([
@@ -722,8 +792,9 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.getAll('concatenate')).toEqual([
@@ -760,8 +831,9 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.getAll('concatenate')).toEqual([
@@ -797,8 +869,9 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.getAll('concatenate')).toEqual([])
@@ -830,8 +903,9 @@ describe('constructOrderPayload', () => {
 
       const response = await constructOrderPayload({
         accessMethod,
+        accessToken,
         granuleParams,
-        accessToken
+        retrievalId: 1234
       })
 
       expect(response.getAll('variable')).toEqual(['test_var,test_var_2'])

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -278,7 +278,7 @@ describe('submitHarmonyOrder', () => {
     expect(queries[2].method).toEqual('update')
     expect(queries[2].bindings).toEqual(['create_failed', 'Error: You are not authorized to access the requested resource', 12])
 
-    expect(consoleMock).toBeCalledTimes(8)
+    expect(consoleMock).toBeCalledTimes(9)
     expect(consoleMock.mock.calls[0]).toEqual(['Processing 1 order(s)'])
     expect(consoleMock.mock.calls[1]).toEqual(['Harmony order payload'])
     expect(consoleMock.mock.calls[2]).toEqual(['forceAsync: true'])
@@ -286,6 +286,7 @@ describe('submitHarmonyOrder', () => {
     expect(consoleMock.mock.calls[4]).toEqual(['format: NetCDF-4'])
     expect(consoleMock.mock.calls[5]).toEqual(['variable: test_var,test_var_2'])
     expect(consoleMock.mock.calls[6]).toEqual(['skipPreview: true'])
-    expect(consoleMock.mock.calls[7]).toEqual(['AxiosError (403): Error: You are not authorized to access the requested resource'])
+    expect(consoleMock.mock.calls[7]).toEqual(['label: eed-edsc-test-serverless-background,downloadId=1'])
+    expect(consoleMock.mock.calls[8]).toEqual(['AxiosError (403): Error: You are not authorized to access the requested resource'])
   })
 })

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -3,6 +3,7 @@ import mockKnex from 'mock-knex'
 import nock from 'nock'
 
 import * as createLimitedShapefile from '../../util/createLimitedShapefile'
+import * as getClientId from '../../../../sharedUtils/getClientId'
 import * as getDbConnection from '../../util/database/getDbConnection'
 import * as getEarthdataConfig from '../../../../sharedUtils/config'
 import * as getEdlConfig from '../../util/getEdlConfig'
@@ -16,6 +17,8 @@ let dbTracker
 
 beforeEach(() => {
   jest.clearAllMocks()
+
+  jest.spyOn(getClientId, 'getClientId').mockImplementation(() => ({ background: 'eed-edsc-test-serverless-background' }))
 
   jest.spyOn(getEarthdataConfig, 'getSecretEarthdataConfig').mockImplementation(() => ({
     clientId: 'clientId',

--- a/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
+++ b/serverless/src/submitHarmonyOrder/__tests__/handler.test.js
@@ -3,10 +3,10 @@ import mockKnex from 'mock-knex'
 import nock from 'nock'
 
 import * as createLimitedShapefile from '../../util/createLimitedShapefile'
-import * as getClientId from '../../../../sharedUtils/getClientId'
 import * as getDbConnection from '../../util/database/getDbConnection'
-import * as getEarthdataConfig from '../../../../sharedUtils/config'
+import * as getConfig from '../../../../sharedUtils/config'
 import * as getEdlConfig from '../../util/getEdlConfig'
+import * as getClientId from '../../../../sharedUtils/getClientId'
 import * as startOrderStatusUpdateWorkflow from '../../util/startOrderStatusUpdateWorkflow'
 
 import { mockHarmonyOrder } from './mocks'
@@ -18,11 +18,17 @@ let dbTracker
 beforeEach(() => {
   jest.clearAllMocks()
 
-  jest.spyOn(getClientId, 'getClientId').mockImplementation(() => ({ background: 'eed-edsc-test-serverless-background' }))
-
-  jest.spyOn(getEarthdataConfig, 'getSecretEarthdataConfig').mockImplementation(() => ({
+  jest.spyOn(getConfig, 'getSecretEarthdataConfig').mockImplementation(() => ({
     clientId: 'clientId',
     secret: 'jwt-secret'
+  }))
+
+  jest.spyOn(getConfig, 'getApplicationConfig').mockImplementation(() => ({
+    env: 'test'
+  }))
+
+  jest.spyOn(getClientId, 'getClientId').mockImplementation(() => ({
+    background: 'mock-background-clientId'
   }))
 
   jest.spyOn(getEdlConfig, 'getEdlConfig').mockImplementation(() => ({
@@ -53,7 +59,7 @@ afterEach(() => {
 
 describe('submitHarmonyOrder', () => {
   test('correctly discovers the correct fields from the provided json', async () => {
-    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+    jest.spyOn(getConfig, 'getEarthdataConfig').mockImplementation(() => ({
       cmrHost: 'https://cmr.earthdata.nasa.gov',
       edscHost: 'http://localhost:8080'
     }))
@@ -126,7 +132,7 @@ describe('submitHarmonyOrder', () => {
   })
 
   test('creates a limited shapefile if the shapefile was limited by the user', async () => {
-    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+    jest.spyOn(getConfig, 'getEarthdataConfig').mockImplementation(() => ({
       cmrHost: 'https://cmr.earthdata.nasa.gov',
       edscHost: 'http://localhost:8080'
     }))
@@ -220,7 +226,7 @@ describe('submitHarmonyOrder', () => {
   test('stores returned error message when order creation fails', async () => {
     const consoleMock = jest.spyOn(console, 'log')
 
-    jest.spyOn(getEarthdataConfig, 'getEarthdataConfig').mockImplementation(() => ({
+    jest.spyOn(getConfig, 'getEarthdataConfig').mockImplementation(() => ({
       cmrHost: 'https://cmr.earthdata.nasa.gov',
       edscHost: 'http://localhost:8080'
     }))
@@ -289,7 +295,7 @@ describe('submitHarmonyOrder', () => {
     expect(consoleMock.mock.calls[4]).toEqual(['format: NetCDF-4'])
     expect(consoleMock.mock.calls[5]).toEqual(['variable: test_var,test_var_2'])
     expect(consoleMock.mock.calls[6]).toEqual(['skipPreview: true'])
-    expect(consoleMock.mock.calls[7]).toEqual(['label: eed-edsc-test-serverless-background,downloadId=1'])
+    expect(consoleMock.mock.calls[7]).toEqual(['label: eed-edsc-test,edsc-id=4517239960'])
     expect(consoleMock.mock.calls[8]).toEqual(['AxiosError (403): Error: You are not authorized to access the requested resource'])
   })
 })

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -7,8 +7,9 @@ import { stringify } from 'qs'
 
 import { bboxToPolygon } from './bboxToPolygon'
 import { ccwShapefile } from './ccwShapefile'
+import { getApplicationConfig, getEarthdataConfig } from '../../../sharedUtils/config'
 import { getClientId } from '../../../sharedUtils/getClientId'
-import { getEarthdataConfig } from '../../../sharedUtils/config'
+import { obfuscateId } from '../util/obfuscation/obfuscateId'
 import { parseError } from '../../../sharedUtils/parseError'
 import { pointStringToLatLng } from './pointStringToLatLng'
 import { readCmrResults } from '../util/cmr/readCmrResults'
@@ -234,7 +235,7 @@ export const constructOrderPayload = async ({
   orderPayload.append('skipPreview', true)
 
   // Add label to identify EDSC orders in Harmony
-  orderPayload.append('label', `${getClientId().background},downloadId=${retrievalId}`)
+  orderPayload.append('label', `eed-edsc-${getApplicationConfig().env},edsc-id=${obfuscateId(retrievalId)}`)
 
   return orderPayload
 }

--- a/serverless/src/submitHarmonyOrder/constructOrderPayload.js
+++ b/serverless/src/submitHarmonyOrder/constructOrderPayload.js
@@ -18,10 +18,11 @@ import { readCmrResults } from '../util/cmr/readCmrResults'
  */
 export const constructOrderPayload = async ({
   accessMethod,
-  granuleParams,
   accessToken,
-  shapefile,
-  environment
+  environment,
+  granuleParams,
+  retrievalId,
+  shapefile
 }) => {
   // Request granules from CMR
   const granuleResponse = await axios({
@@ -231,6 +232,9 @@ export const constructOrderPayload = async ({
 
   // EDSC-3440: Add skipPreview=true to all Harmony orders
   orderPayload.append('skipPreview', true)
+
+  // Add label to identify EDSC orders in Harmony
+  orderPayload.append('label', `${getClientId().background},downloadId=${retrievalId}`)
 
   return orderPayload
 }

--- a/serverless/src/submitHarmonyOrder/handler.js
+++ b/serverless/src/submitHarmonyOrder/handler.js
@@ -58,6 +58,7 @@ const submitHarmonyOrder = async (event, context) => {
       collection_id: collectionId,
       environment,
       granule_params: granuleParams,
+      id: retrievalId,
       jsondata,
       user_id: userId
     } = retrievalRecord
@@ -89,10 +90,11 @@ const submitHarmonyOrder = async (event, context) => {
 
       const orderPayload = await constructOrderPayload({
         accessMethod,
-        granuleParams,
         accessToken,
-        shapefile,
-        environment
+        environment,
+        granuleParams,
+        retrievalId,
+        shapefile
       })
 
       console.log('Harmony order payload')

--- a/serverless/src/util/database/getDbConnection.js
+++ b/serverless/src/util/database/getDbConnection.js
@@ -13,9 +13,17 @@ export const getDbConnection = async () => {
   if (dbConnection == null) {
     const dbConnectionConfig = await getDbConnectionConfig()
 
+    const pool = {}
+
+    if (process.env.IS_OFFLINE) {
+      // When running locally set the pool min to 0 to avoid idle connections
+      pool.min = 0
+    }
+
     dbConnection = knex({
       client: 'pg',
-      connection: dbConnectionConfig
+      connection: dbConnectionConfig,
+      pool
     })
   }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Adding two labels to Harmony orders in order for the Harmony team to track EDSC orders and group large orders that we split into multiple Harmony orders.

Also fixed the annoying database problem in dev where we say "sorry, too many clients already" by forcing idle connections to be disconnected.

### What areas of the application does this impact?

Harmony orders

# Testing

### Reproduction steps

Submit a harmony order, check the labels added

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
