### PR TITLE
EDSC-4320: Updates browse image logic to include a check for http/https

### DIFF
--- a/serverless/src/scaleImage/utils/cmr/getBrowseImageUrlFromConcept.js
+++ b/serverless/src/scaleImage/utils/cmr/getBrowseImageUrlFromConcept.js
@@ -1,16 +1,18 @@
+import { isLinkBrowse } from '../../../../../sharedUtils/isLinkBrowse'
+
 /**
  * Search the provided CMR metadata for browse image urls
  * @param {JSON} concept The JSON metadata associated with a CMR concept
  * @returns {String} The image url if one is found, or null if none is found
  */
 export const getBrowseImageUrlFromConcept = (concept) => {
-  const imgRegex = /\b(browse#)$/
-
   // Default `links` to an empty array for concepts that do not have any
   const { id, links = [] } = concept
 
-  // Select the first browse image in the event there are more than one
-  const [imgUrl] = links.filter((link) => imgRegex.test(link.rel))
+  // Filter the links on the granule to find all browse links with an http/https protocol. This filters
+  // any S3 browse links which cause protocol issues.
+  const browseThumbnails = links.filter((link) => isLinkBrowse(link))
+  const [imgUrl] = browseThumbnails
 
   // If no image url was found return null
   if (imgUrl == null) {

--- a/sharedUtils/__tests__/isLinkBrowse.test.js
+++ b/sharedUtils/__tests__/isLinkBrowse.test.js
@@ -1,0 +1,42 @@
+import { isLinkBrowse } from '../isLinkBrowse'
+
+describe('isLinkBrowse', () => {
+  describe('when the link is not a browse link', () => {
+    test('returns false', () => {
+      const link = {
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/data#',
+        href: 'https://example.com/data'
+      }
+
+      const response = isLinkBrowse(link)
+
+      expect(response).toBeFalsy()
+    })
+  })
+
+  describe('when the link is an s3 browse link', () => {
+    test('returns false', () => {
+      const link = {
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/browse#',
+        href: 's3://bucket/key'
+      }
+
+      const response = isLinkBrowse(link)
+
+      expect(response).toBeFalsy()
+    })
+  })
+
+  describe('when the link is a https browse link', () => {
+    test('returns true', () => {
+      const link = {
+        rel: 'http://esipfed.org/ns/fedsearch/1.1/browse#',
+        href: 'https://example.com/browse.jpg'
+      }
+
+      const response = isLinkBrowse(link)
+
+      expect(response).toBeTruthy()
+    })
+  })
+})

--- a/sharedUtils/getBrowseUrls.js
+++ b/sharedUtils/getBrowseUrls.js
@@ -1,3 +1,5 @@
+import { isLinkBrowse } from './isLinkBrowse'
+
 /**
  * Pull out browse links from within the granule metadata
  * @param {Array} granules search result for granules that a user has asked to download
@@ -10,9 +12,9 @@ export const getBrowseUrls = (granules) => {
 
     // Find the correct link from the list within the metadata
     return linkMetadata.filter((link) => {
-      const { inherited, rel } = link
+      const { inherited } = link
 
-      return rel.includes('/browse#') && !inherited
+      return isLinkBrowse(link) && !inherited
     })
   }).filter(Boolean)
 

--- a/sharedUtils/isLinkBrowse.js
+++ b/sharedUtils/isLinkBrowse.js
@@ -1,0 +1,13 @@
+const protocolRegex = /^(http|https):\/\//
+const browseRegex = /\b(browse#)$/
+
+/**
+ * Returns true if the link is browse and http/https
+ * @param {Object} link A link object from CMR metadata, containing a rel and href
+ * @returns {Boolean} True if the link is browse and http/https
+ */
+export const isLinkBrowse = (link) => {
+  const { rel, href } = link
+
+  return browseRegex.test(rel) && protocolRegex.test(href)
+}

--- a/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsFocusedMeta.jsx
@@ -18,6 +18,7 @@ import {
 } from 'react-bootstrap'
 
 import { getEnvironmentConfig } from '../../../../../sharedUtils/config'
+import { isLinkBrowse } from '../../../../../sharedUtils/isLinkBrowse'
 
 import Button from '../Button/Button'
 import EDSCModalContainer from '../../containers/EDSCModalContainer/EDSCModalContainer'
@@ -48,8 +49,7 @@ const GranuleResultsFocusedMeta = ({
 
   // Filter the links on the granule to find all browse links with an http/https protocol. This filters
   // any S3 browse links which cause protocol issues.
-  const testProtocol = /^(http|https):\/\//
-  const browseThumbnails = links.filter(({ rel, href }) => rel.includes('/browse#') && testProtocol.test(href))
+  const browseThumbnails = links.filter((link) => isLinkBrowse(link))
 
   const onClickPreviousButton = () => {
     if (activeBrowseImageIndex > 0) {


### PR DESCRIPTION
# Overview

### What is the feature?

When displaying granule thumbnails, if the metadata lists s3 and https browse links but the s3 link comes first we are trying to fetch that image, which fails.

### What is the Solution?

When filtering granule links to check for the browse rel, also check the protocol of the href to ensure it is http or https

### What areas of the application does this impact?

Concept thumbnails, browse imagery

# Testing

This collection and granule in UAT have the right conditions (s3 and https browse links). Loading this page should show the granule thumbnail correctly and not show the "No Image Available" thumbnail

http://localhost:8080/search/granules?p=C1262899916-LARC_CLOUD&pg[0][v]=f&pg[0][id]=TEMPO_NO2_L2_V03_20240801T235308Z_S016G04.nc&pg[0][gsk]=-start_date&ee=uat&q=TEMPO_NO2_L2_V03&tl=1729082839!3!!&lat=38.3203125&long=-131.0625


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
