### PR TITLE
EDSC-4330: Tour adjustments

### DIFF
--- a/static/src/js/components/CollectionResults/CollectionResultsItem.scss
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.scss
@@ -163,18 +163,6 @@
     display: flex;
     flex-shrink: 0;
     flex-grow: 0;
-
-    @media (hover: hover) {
-      visibility: hidden;
-      width: 0;
-
-      .collection-results-item__link:hover &,
-      .collection-results-item__link:focus &,
-      .collection-results-item__link--active & {
-        visibility: visible;
-        width: auto;
-      }
-    }
   }
 
   &__action {

--- a/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
+++ b/static/src/js/components/SecondaryToolbar/SecondaryToolbar.jsx
@@ -251,7 +251,12 @@ class SecondaryToolbar extends Component {
 
     const loginLink = (
       <Button
-        className={classNames({ 'focus-light': isMapOverlay })}
+        className={
+          classNames(
+            'secondary-toolbar__login-button',
+            { 'focus-light': isMapOverlay }
+          )
+        }
         bootstrapVariant="light"
         href={`${apiHost}/login?ee=${earthdataEnvironment}&state=${encodeURIComponent(returnPath)}`}
         tooltip="Log In with Earthdata Login"
@@ -410,6 +415,7 @@ class SecondaryToolbar extends Component {
               <Dropdown.Toggle
                 className={classNames(['secondary-toolbar__start-tour-button', { 'focus-light': isMapOverlay }])}
                 as={Button}
+                aria-label="Start Search Tour"
                 icon={FaQuestion}
                 iconSize="0.825rem"
                 onClick={setRunTour}

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -70,7 +70,7 @@ const SearchTour = () => {
 
       overlayDiv = document.createElement('div')
       overlayDiv.style.width = `${widthDelta}px`
-      overlayDiv.classList.add('target-overlay')
+      overlayDiv.classList.add('search-tour__target-overlay')
 
       if (panelEl) {
         panelEl.appendChild(overlayDiv)

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -53,20 +53,6 @@ const SearchTour = () => {
       }
     }
 
-    // Step 8 refers to the '+' and 'info' buttons which are only visible when
-    // a collection is hovered. This adds and cleans up the class to make them
-    // visible for this step.
-    if (stepIndex === 8) {
-      const firstItem = document.querySelector('.collection-results-item__link')
-      if (firstItem) {
-        firstItem.classList.add('collection-results-item__link--active')
-
-        return () => {
-          firstItem.classList.remove('collection-results-item__link--active')
-        }
-      }
-    }
-
     // On the step where we highlight the map, we are creating an element
     // to overlay the visible portion of the map and highlighting that
     // element with the tour spotlight

--- a/static/src/js/components/Tour/SearchTour.jsx
+++ b/static/src/js/components/Tour/SearchTour.jsx
@@ -53,6 +53,20 @@ const SearchTour = () => {
       }
     }
 
+    // Step 8 refers to the '+' and 'info' buttons which are only visible when
+    // a collection is hovered. This adds and cleans up the class to make them
+    // visible for this step.
+    if (stepIndex === 8) {
+      const firstItem = document.querySelector('.collection-results-item__link')
+      if (firstItem) {
+        firstItem.classList.add('collection-results-item__link--active')
+
+        return () => {
+          firstItem.classList.remove('collection-results-item__link--active')
+        }
+      }
+    }
+
     // On the step where we highlight the map, we are creating an element
     // to overlay the visible portion of the map and highlighting that
     // element with the tour spotlight

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -312,9 +312,3 @@
     pointer-events: none;
   }
 }
-
-// Move these to top level search tour
-// Don't show the tour again
-// Add aria labels to icons
-// Use bem for li
-// remove intro class, do a separate class for regular buttons and intro buttons

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -287,11 +287,11 @@
     width: 0.85rem;
   }
   
-  kbd {
+  &__kbd {
     display: inline-block;
     vertical-align: middle;
-    font-size: 0.75em;
-    padding: 0.125rem 0.1875rem;
+    font-size: 0.75rem;
+    padding: 0.125rem 0.3875rem;
   }
   
   &__button-tour-finish {

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -34,10 +34,10 @@
     color: $color__carbon-black;
     padding: 0;
     margin: 0;
+  }
 
-    li {
-      margin-bottom: 0.5rem;
-    }
+  &__list {
+    margin-bottom: 0.5rem;
   }
 
   &__note {
@@ -69,16 +69,17 @@
   &__footer {
     position: relative;
     padding: 0 0 0.5rem 0;
+  }
 
-    &-content {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-end;
-      width: 100%;
-      position: absolute;
-      left: 0;
-      right: 0;
-    }
+  &__footer-content {
+    padding: 0 0 0.5rem 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    width: 100%;
+    position: absolute;
+    left: 0;
+    right: 0;
   }
 
   &__tour-toggle-footer {
@@ -92,27 +93,38 @@
     height: 1.1875rem;
     width: 1.1875rem;
     vertical-align: middle;
+  }
 
-    &__label {
-      position: relative;
-      top: 0.225rem;
-      font-size: 0.75rem;
-      margin-left: 0.5rem;
-      color: $color__carbon-black;
-    }
+  &__checkbox-label {
+    position: relative;
+    top: 0.225rem;
+    font-size: 0.75rem;
+    margin-left: 0.5rem;
+    color: $color__carbon-black;
+  }
+
+  &__hotkey-info {
+    background-color: $color__carbon--5;
+    padding: 1rem 1rem 0.5rem;
+    margin-bottom: 0.9375rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    text-align: left;
   }
 
   &__buttons {
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
+  }
 
-    &.intro {
-      width: 100%;
-      justify-content: center;
-      position: static;
-      margin-top: 1.25rem;
-    }
+  &__intro-buttons {
+    display: flex;
+    gap: 0.75rem;
+    width: 100%;
+    justify-content: center;
+    position: static;
+    margin-top: 1.25rem;
   }
 
   &__info-box {
@@ -259,44 +271,50 @@
   &__content-wrapper {
     padding-bottom: 1.25rem;
   }
+
+  &__step-counter-text {
+    font-family: $font-family-monospace;
+    letter-spacing: 0.125rem;
+    font-size: 0.75rem;
+    margin-bottom: 0.9375rem;
+    color: $color__carbon--40;
+    text-align: left;
+  }
+  
+  &__text-icon {
+    display: inline-block;
+    vertical-align: center;
+    margin-top: -0.125rem;
+    height: 0.85rem;
+    width: 0.85rem;
+  }
+  
+  kbd {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 0.75em;
+    padding: 0.125rem 0.1875rem;
+  }
+  
+  &__button-tour-finish {
+    min-width: 5.625rem;
+  }
+  
+  &__target-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0);
+    z-index: 9999;
+    left: calc(100%);
+    pointer-events: none;
+  }
 }
 
-.step-counter-text {
-  font-family: $font-family-monospace;
-  letter-spacing: 0.125rem;
-  font-size: 0.75rem;
-  margin-bottom: 0.9375rem;
-  color: $color__carbon--40;
-  text-align: left;
-}
-
-.text-icon {
-  display: inline-block;
-  vertical-align: center;
-  margin-top: -0.125rem;
-  height: 0.85rem;
-  width: 0.85rem;
-}
-
-kbd {
-  display: inline-block;
-  vertical-align: middle;
-  font-size: 0.75em;
-  padding: 0.125rem 0.1875rem;
-}
-
-.button-tour-finish {
-  min-width: 5.625rem;
-}
-
-.target-overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-color: rgba(0, 0, 0, 0);
-  z-index: 9999;
-  left: calc(100%);
-  pointer-events: none;
-}
+// Move these to top level search tour
+// Don't show the tour again
+// Add aria labels to icons
+// Use bem for li
+// remove intro class, do a separate class for regular buttons and intro buttons

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -48,6 +48,17 @@
     align-items: center;
   }
 
+  &__footnote {
+    font-size: 0.775rem;
+    font-style: italic;
+    margin-top: 0.25rem;
+    margin-bottom: 0;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   &__tour-toggle {
     display: flex;
     align-items: center;

--- a/static/src/js/components/Tour/SearchTour.scss
+++ b/static/src/js/components/Tour/SearchTour.scss
@@ -44,8 +44,6 @@
     font-size: 0.775rem;
     margin-bottom: 1.25rem;
     text-align: left;
-    display: flex;
-    align-items: center;
   }
 
   &__footnote {
@@ -283,7 +281,7 @@
   
   &__text-icon {
     display: inline-block;
-    vertical-align: center;
+    vertical-align: middle;
     margin-top: -0.125rem;
     height: 0.85rem;
     width: 0.85rem;

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -7,6 +7,11 @@ import {
   FaQuestion
 } from 'react-icons/fa'
 import PropTypes from 'prop-types'
+import {
+  ArrowFilledLeft,
+  ArrowFilledRight
+} from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
+
 import ExternalLink from '../ExternalLink/ExternalLink'
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
 import Button from '../Button/Button'
@@ -159,7 +164,9 @@ const TourSteps = ({
             </Button>
           </div>
           <p className="search-tour__footnote">
-            The tour steps can be navigated using the arrow keys.
+            The tour steps can be navigated using the arrow keys
+            <EDSCIcon icon={ArrowFilledLeft} />
+            <EDSCIcon icon={ArrowFilledRight} />
           </p>
         </div>
       ),

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -438,6 +438,8 @@ const TourSteps = ({
           </p>
           <div className="search-tour__info-box">
             <p>
+              <strong>Tip:</strong>
+              {' '}
               All keyboard shortcuts can be displayed by pressing the
               {' '}
               <kbd>?</kbd>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -195,7 +195,6 @@ const TourSteps = ({
               <EDSCIcon
                 className="align-middle"
                 icon={ArrowFilledLeft}
-                size={8}
                 aria-label="Left arrow key"
               />
             </kbd>
@@ -205,7 +204,6 @@ const TourSteps = ({
                 className="align-middle"
                 icon={ArrowFilledRight}
                 aria-label="Right arrow key"
-                size={8}
               />
             </kbd>
             on your keyboard to navigate the tour.

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -191,19 +191,19 @@ const TourSteps = ({
             <strong>Tip:</strong>
             {' '}
             Use
-            <kbd className="mx-1 align-bottom">
+            <kbd className="mx-1 align-baseline">
               <EDSCIcon
-                className="align-middle"
                 icon={ArrowFilledLeft}
                 aria-label="Left arrow key"
+                size="10"
               />
             </kbd>
             and
-            <kbd className="mx-1 align-bottom">
+            <kbd className="mx-1 align-baseline">
               <EDSCIcon
-                className="align-middle"
                 icon={ArrowFilledRight}
                 aria-label="Right arrow key"
+                size="10"
               />
             </kbd>
             on your keyboard to navigate the tour.

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -158,6 +158,9 @@ const TourSteps = ({
               Skip for now
             </Button>
           </div>
+          <p className="search-tour__footnote">
+            The tour steps can be navigated using the arrow keys.
+          </p>
         </div>
       ),
       disableBeacon: true,

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -432,7 +432,7 @@ const TourSteps = ({
             or dragging the bar above. The panel can be hidden or shown by clicking the
             handle or using the
             {' '}
-            <kbd className="mx-1 align-baseline">]</kbd>
+            <kbd className="search-tour__kbd mx-1 align-baseline">]</kbd>
             {' '}
             key.
           </p>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -597,6 +597,7 @@ const TourSteps = ({
               className="search-tour__text-icon"
               icon={FaQuestion}
               aria-label="Start Search Tour"
+              size="10"
             />
           </p>
           <div className="search-tour__footer">

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -35,7 +35,7 @@ const TourButtons = ({
           checked={isChecked}
           onChange={handleCheckboxChange}
         />
-        <label htmlFor="dontShowAgain" className="search-tour__checkbox__label">
+        <label htmlFor="dontShowAgain" className="search-tour__checkbox-label">
           Don&apos;t show again
         </label>
       </div>
@@ -69,7 +69,7 @@ TourButtons.propTypes = {
 }
 
 const StepCounter = ({ currentStep, totalSteps }) => (
-  <p className="step-counter-text">
+  <p className="search-tour__step-counter-text">
     {currentStep}
     {' '}
     OF
@@ -118,7 +118,11 @@ const TourSteps = ({
           <p className="search-tour__note">
             If you want to skip the tour for now, it is always available by clicking
             {' '}
-            <EDSCIcon className="text-icon" icon={FaQuestion} />
+            <EDSCIcon
+              className="search-tour__text-icon"
+              icon={FaQuestion}
+              aria-label="Start Search Tour"
+            />
             {' '}
             at the top of the page.
           </p>
@@ -130,13 +134,13 @@ const TourSteps = ({
               checked={isChecked}
               onChange={handleCheckboxChange}
             />
-            <label htmlFor="dontShowAgain" className="search-tour__checkbox__label">
+            <label htmlFor="dontShowAgain" className="search-tour__checkbox-label">
               Don&apos;t show the tour next time I visit Earthdata Search
             </label>
           </div>
-          <div className="search-tour__buttons intro">
+          <div className="search-tour__intro-buttons">
             <Button
-              className="button-tour-start"
+              className="search-tour__button-tour-start"
               type="button"
               bootstrapVariant="primary"
               bootstrapSize="lg"
@@ -163,11 +167,6 @@ const TourSteps = ({
               Skip for now
             </Button>
           </div>
-          <p className="search-tour__footnote">
-            The tour steps can be navigated using the arrow keys
-            <EDSCIcon icon={ArrowFilledLeft} />
-            <EDSCIcon icon={ArrowFilledRight} />
-          </p>
         </div>
       ),
       disableBeacon: true,
@@ -187,6 +186,29 @@ const TourSteps = ({
           <p className="search-tour__content">
             Available filters include keyword search, spatial and temporal bounds,
             and advanced search options.
+          </p>
+          <p className="search-tour__hotkey-info align-middle">
+            <strong>Tip:</strong>
+            {' '}
+            Use
+            <kbd className="mx-1 align-bottom">
+              <EDSCIcon
+                className="align-middle"
+                icon={ArrowFilledLeft}
+                size={8}
+                aria-label="Left arrow key"
+              />
+            </kbd>
+            and
+            <kbd className="mx-1 align-bottom">
+              <EDSCIcon
+                className="align-middle"
+                icon={ArrowFilledRight}
+                aria-label="Right arrow key"
+                size={8}
+              />
+            </kbd>
+            on your keyboard to navigate the tour.
           </p>
           <TourButtons
             stepIndex={stepIndex}
@@ -364,7 +386,11 @@ const TourSteps = ({
             the right data, including a summary, temporal range, and information about
             capabilities. To view more information about a collection, click the
             {' '}
-            <EDSCIcon className="text-icon" icon={FaInfoCircle} />
+            <EDSCIcon
+              className="search-tour__text-icon"
+              icon={FaInfoCircle}
+              aria-label="View collection details"
+            />
             {' '}
             icon.
           </p>
@@ -372,7 +398,11 @@ const TourSteps = ({
             Add granules to a project and customize options before accessing the data.
             To add a collection to your project, click the
             {' '}
-            <EDSCIcon className="text-icon" icon={FaPlus} />
+            <EDSCIcon
+              className="search-tour__text-icon"
+              icon={FaPlus}
+              aria-label="Add collection to the current project"
+            />
             {' '}
             icon.
             To add individual granules to a project, click on a search result to view and
@@ -430,7 +460,7 @@ const TourSteps = ({
       styles: commonStyles
     },
     {
-      target: '.target-overlay',
+      target: '.search-tour__target-overlay',
       content: (
         <div className="search-tour__content-wrapper">
           <StepCounter currentStep={stepIndex} totalSteps={TOTAL_STEPS} />
@@ -487,7 +517,11 @@ const TourSteps = ({
           <p className="search-tour__content">
             Click
             {' '}
-            <EDSCIcon className="text-icon" icon={FaSave} />
+            <EDSCIcon
+              className="search-tour__text-icon"
+              icon={FaSave}
+              aria-label="Save Project"
+            />
             {' '}
             to save a project using your current search criteria.
           </p>
@@ -528,7 +562,7 @@ const TourSteps = ({
 
   const loggedOutStep = [
     {
-      target: '.search',
+      target: '.secondary-toolbar__login-button',
       content: (
         <div className="search-tour__content-wrapper">
           <StepCounter currentStep={stepIndex} totalSteps={TOTAL_STEPS} />
@@ -544,10 +578,9 @@ const TourSteps = ({
           />
         </div>
       ),
-      placement: 'center',
+      placement: 'right',
       hideFooter: true,
-      styles: commonStyles,
-      disableBeacon: true
+      styles: commonStyles
     }
   ]
 
@@ -560,7 +593,11 @@ const TourSteps = ({
           <p className="search-tour__content">
             You can replay this tour anytime by clicking
             {' '}
-            <EDSCIcon className="text-icon" icon={FaQuestion} />
+            <EDSCIcon
+              className="search-tour__text-icon"
+              icon={FaQuestion}
+              aria-label="Start Search Tour"
+            />
           </p>
           <div className="search-tour__footer">
             <div className="search-tour__footer-content">
@@ -572,8 +609,8 @@ const TourSteps = ({
                   checked={isChecked}
                   onChange={handleCheckboxChange}
                 />
-                <label htmlFor="dontShowAgain" className="search-tour__checkbox__label">
-                  Don&apos;t show again
+                <label htmlFor="dontShowAgain" className="search-tour__checkbox-label">
+                  Don&apos;t show tour again
                 </label>
               </div>
               <div className="search-tour__buttons">
@@ -586,7 +623,7 @@ const TourSteps = ({
                   Previous
                 </Button>
                 <Button
-                  className="button-tour-finish"
+                  className="search-tour__button-tour-finish"
                   type="button"
                   bootstrapVariant="primary"
                   bootstrapSize="sm"
@@ -623,7 +660,12 @@ const TourSteps = ({
               <div className="search-tour__webinar-thumbnail-wrapper">
                 <div className="search-tour__webinar-thumbnail-overlay">
                   <div className="search-tour__webinar-thumbnail-icon-bg">
-                    <EDSCIcon className="search-tour__webinar-thumbnail-icon" size="18px" icon={FaPlay} />
+                    <EDSCIcon
+                      className="search-tour__webinar-thumbnail-icon"
+                      size="18px"
+                      icon={FaPlay}
+                      aria-label="Play Webinar Video"
+                    />
                   </div>
                 </div>
                 <img
@@ -648,7 +690,7 @@ const TourSteps = ({
             Find more information here:
           </p>
           <ul className="search-tour__earthdata-list">
-            <li>
+            <li className="search-tour__list">
               <ExternalLink
                 href="https://www.earthdata.nasa.gov/learn/earthdata-search"
               >
@@ -664,7 +706,7 @@ const TourSteps = ({
               checked={isChecked}
               onChange={handleCheckboxChange}
             />
-            <label htmlFor="dontShowAgain" className="search-tour__checkbox__label">
+            <label htmlFor="dontShowAgain" className="search-tour__checkbox-label">
               Don&apos;t show the tour next time I visit Earthdata Search
             </label>
           </div>

--- a/static/src/js/components/Tour/TourSteps.jsx
+++ b/static/src/js/components/Tour/TourSteps.jsx
@@ -432,7 +432,7 @@ const TourSteps = ({
             or dragging the bar above. The panel can be hidden or shown by clicking the
             handle or using the
             {' '}
-            <kbd>]</kbd>
+            <kbd className="mx-1 align-baseline">]</kbd>
             {' '}
             key.
           </p>

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -376,11 +376,6 @@ test.describe('When not logged in', () => {
     // Step 8: High-level description for each search result
     await page.waitForTimeout(500)
     await expect(page.getByRole('alertdialog', { name: 'A high-level description is displayed for each search result' })).toBeVisible()
-
-    // Check that the add to project (+) and info buttons are visible for this step
-    await expect(page.locator('.collection-results-item__action.collection-results-item__action--add')).toBeVisible()
-    await expect(page.locator('.collection-results-item__action--collection-details')).toBeVisible()
-
     await page.getByRole('button', { name: 'Next' }).click()
 
     // Get and verify the position and size of the highlighted section

--- a/tests/e2e/tour/tour.spec.js
+++ b/tests/e2e/tour/tour.spec.js
@@ -376,6 +376,11 @@ test.describe('When not logged in', () => {
     // Step 8: High-level description for each search result
     await page.waitForTimeout(500)
     await expect(page.getByRole('alertdialog', { name: 'A high-level description is displayed for each search result' })).toBeVisible()
+
+    // Check that the add to project (+) and info buttons are visible for this step
+    await expect(page.locator('.collection-results-item__action.collection-results-item__action--add')).toBeVisible()
+    await expect(page.locator('.collection-results-item__action--collection-details')).toBeVisible()
+
     await page.getByRole('button', { name: 'Next' }).click()
 
     // Get and verify the position and size of the highlighted section


### PR DESCRIPTION
# Overview

### What is the feature?

- Adding logic to show the `+` and `ⓘ` buttons on step 8 of the tour which are normally only visible when hovering a collection.
- Adding a footnote to let users know they can navigate the tour using arrow keys.

### What is the Solution?

- Adding logic to handle the hiding/showing of `+` and `ⓘ` on the first collection for slide 8.
- Adding a note to let the users know about navigation hotkeys.

### What areas of the application does this impact?

- Search Tour

# Testing

### Reproduction steps


1. Start the Tour
2. Verify that the first slide has a footnote about the users being able to navigate using the arrow keys
3. Verify that slide 8 which talks about the `+` and `ⓘ` buttons are shown on the first collection in the list.

### Attachments

![Screenshot 2024-12-11 at 2 21 00 PM](https://github.com/user-attachments/assets/26953ff0-1ad5-422a-b1d0-0356291c6681)
![Screenshot 2024-12-12 at 10 05 02 AM](https://github.com/user-attachments/assets/97448743-0dca-4f89-bb05-b86ff789c363)


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
