### PR TITLE
EDSC-4349: Adjustments to spatial filter dropdowns and buttons

### DIFF
--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.jsx
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.jsx
@@ -8,10 +8,11 @@ import {
 
 import {
   FaCrop,
-  FaMapMarker,
   FaCircle,
   FaFile
 } from 'react-icons/fa'
+
+import { Map } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
 
 import { eventEmitter } from '../../events/events'
 
@@ -90,29 +91,22 @@ const SpatialSelectionDropdown = (props) => {
         <Dropdown.Item
           className="spatial-selection-dropdown__button"
           as={Button}
-          icon="edsc-icon-poly-open edsc-icon-fw"
+          icon="edsc-icon-poly edsc-icon-fw"
           onClick={() => onItemClick('polygon')}
           label="Select Polygon"
+          aria-label="Select Polygon"
         >
           <span>Polygon</span>
         </Dropdown.Item>
         <Dropdown.Item
           className="spatial-selection-dropdown__button"
           as={Button}
-          icon="edsc-icon-rect-open edsc-icon-fw"
+          icon="edsc-icon-rect edsc-icon-fw"
           onClick={() => onItemClick('rectangle')}
           label="Select Rectangle"
+          aria-label="Select Rectangle"
         >
           <span>Rectangle</span>
-        </Dropdown.Item>
-        <Dropdown.Item
-          className="spatial-selection-dropdown__button"
-          as={Button}
-          icon={FaMapMarker}
-          onClick={() => onItemClick('point')}
-          label="Select Point"
-        >
-          <span>Point</span>
         </Dropdown.Item>
         <Dropdown.Item
           className="spatial-selection-dropdown__button"
@@ -120,8 +114,19 @@ const SpatialSelectionDropdown = (props) => {
           icon={FaCircle}
           onClick={() => onItemClick('circle')}
           label="Select Circle"
+          aria-label="Select Circle"
         >
           <span>Circle</span>
+        </Dropdown.Item>
+        <Dropdown.Item
+          className="spatial-selection-dropdown__button"
+          as={Button}
+          icon={Map}
+          onClick={() => onItemClick('point')}
+          label="Select Point"
+          aria-label="Select Point"
+        >
+          <span>Point</span>
         </Dropdown.Item>
         <Dropdown.Item
           className="spatial-selection-dropdown__button"
@@ -129,6 +134,7 @@ const SpatialSelectionDropdown = (props) => {
           icon={FaFile}
           onClick={() => onItemClick('file')}
           label="Select Shapefile"
+          aria-label="Select Shapefile"
           disabled={disableShapefileSearch}
         >
           {

--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.jsx
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.jsx
@@ -93,8 +93,6 @@ const SpatialSelectionDropdown = (props) => {
           as={Button}
           icon="edsc-icon-poly edsc-icon-fw"
           onClick={() => onItemClick('polygon')}
-          label="Select Polygon"
-          aria-label="Select Polygon"
         >
           <span>Polygon</span>
         </Dropdown.Item>
@@ -103,8 +101,6 @@ const SpatialSelectionDropdown = (props) => {
           as={Button}
           icon="edsc-icon-rect edsc-icon-fw"
           onClick={() => onItemClick('rectangle')}
-          label="Select Rectangle"
-          aria-label="Select Rectangle"
         >
           <span>Rectangle</span>
         </Dropdown.Item>
@@ -113,8 +109,6 @@ const SpatialSelectionDropdown = (props) => {
           as={Button}
           icon={FaCircle}
           onClick={() => onItemClick('circle')}
-          label="Select Circle"
-          aria-label="Select Circle"
         >
           <span>Circle</span>
         </Dropdown.Item>
@@ -123,8 +117,6 @@ const SpatialSelectionDropdown = (props) => {
           as={Button}
           icon={Map}
           onClick={() => onItemClick('point')}
-          label="Select Point"
-          aria-label="Select Point"
         >
           <span>Point</span>
         </Dropdown.Item>
@@ -133,8 +125,6 @@ const SpatialSelectionDropdown = (props) => {
           as={Button}
           icon={FaFile}
           onClick={() => onItemClick('file')}
-          label="Select Shapefile"
-          aria-label="Select Shapefile"
           disabled={disableShapefileSearch}
         >
           {

--- a/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.scss
+++ b/static/src/js/components/SpatialDisplay/SpatialSelectionDropdown.scss
@@ -19,6 +19,11 @@
     .button__contents {
       line-height: 1.25rem;
     }
+
+    .dropdown-item {
+      text-align: left;
+      justify-content: flex-start;
+    }
   }
 
   &__button {

--- a/static/src/js/components/SpatialDisplay/__tests__/SpatialSelectionDropdown.test.js
+++ b/static/src/js/components/SpatialDisplay/__tests__/SpatialSelectionDropdown.test.js
@@ -40,11 +40,11 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    expect(screen.getByRole('button', { name: 'Select Polygon' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Select Rectangle' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Select Point' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Select Circle' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Select Shapefile' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Polygon' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Rectangle' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Point' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Circle' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'File (KML, KMZ, ESRI, …)' })).toBeInTheDocument()
   })
 
   test('clicking the polygon dropdown emits an event and tracks metric', async () => {
@@ -59,7 +59,7 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    await user.click(screen.getByRole('button', { name: 'Select Polygon' }))
+    await user.click(screen.getByRole('button', { name: 'Polygon' }))
 
     expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
     expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.drawStart', { type: 'polygon' })
@@ -80,7 +80,7 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    await user.click(screen.getByRole('button', { name: 'Select Rectangle' }))
+    await user.click(screen.getByRole('button', { name: 'Rectangle' }))
 
     expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
     expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.drawStart', { type: 'rectangle' })
@@ -101,7 +101,7 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    await user.click(screen.getByRole('button', { name: 'Select Point' }))
+    await user.click(screen.getByRole('button', { name: 'Point' }))
 
     expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
     expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.drawStart', { type: 'marker' })
@@ -122,7 +122,7 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    await user.click(screen.getByRole('button', { name: 'Select Circle' }))
+    await user.click(screen.getByRole('button', { name: 'Circle' }))
 
     expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
     expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.drawStart', { type: 'circle' })
@@ -141,7 +141,7 @@ describe('SpatialSelectionDropdown component', () => {
       await user.click(dropdownSelectionButton)
     })
 
-    await user.click(screen.getByRole('button', { name: 'Select Shapefile' }))
+    await user.click(screen.getByRole('button', { name: 'File (KML, KMZ, ESRI, …)' }))
 
     expect(onToggleShapefileUploadModal).toHaveBeenCalledTimes(1)
     expect(onToggleShapefileUploadModal).toHaveBeenCalledWith(true)
@@ -166,7 +166,7 @@ describe('SpatialSelectionDropdown component', () => {
         await user.click(dropdownSelectionButton)
       })
 
-      const shapeFileSelectionButton = screen.getByRole('button', { name: 'Select Shapefile' })
+      const shapeFileSelectionButton = screen.getByRole('button', { name: 'File (KML, KMZ, ESRI, …)' })
       await user.click(shapeFileSelectionButton)
 
       expect(shapeFileSelectionButton).toBeDisabled()

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -536,13 +536,13 @@ const SpatialSelection = (props) => {
       const buttons = drawToolbar.querySelectorAll('.leaflet-draw-draw-circle, .leaflet-draw-draw-polygon, .leaflet-draw-draw-rectangle, .leaflet-draw-draw-marker')
       buttons.forEach((button) => {
         if (button.classList.contains('leaflet-draw-draw-circle')) {
-          button.setAttribute('aria-label', 'Search by spatial circle')
+          button.setAttribute('aria-label', 'Draw by a spatial circle')
         } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
-          button.setAttribute('aria-label', 'Search by spatial polygon')
+          button.setAttribute('aria-label', 'Draw by a spatial polygon')
         } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
-          button.setAttribute('aria-label', 'Search by spatial rectangle')
+          button.setAttribute('aria-label', 'Draw by a spatial rectangle')
         } else if (button.classList.contains('leaflet-draw-draw-marker')) {
-          button.setAttribute('aria-label', 'Search by spatial coordinate')
+          button.setAttribute('aria-label', 'Draw by a spatial coordinate')
         }
       })
     }

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -539,7 +539,7 @@ const SpatialSelection = (props) => {
           button.setAttribute('aria-label', 'Draw a spatial circle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
           button.setAttribute('aria-label', 'Draw a spatial polygon on the map to select a spatial extent')
-        } else if (button.classList.contains('leaflet-draw-draw-rectangle on the map to select a spatial extent')) {
+        } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
           button.setAttribute('aria-label', 'Draw a spatial rectangle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-marker')) {
           button.setAttribute('aria-label', 'Draw a spatial coordinate on the map to select a spatial extent')

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -529,6 +529,23 @@ const SpatialSelection = (props) => {
   // Callback from EditControl, called when the controls are mounted
   const onMounted = (newDrawControl) => {
     drawControl.current = newDrawControl
+
+    // Add aria-labels to draw buttons
+    const drawToolbar = document.querySelector('.leaflet-draw-toolbar')
+    if (drawToolbar) {
+      const buttons = drawToolbar.querySelectorAll('.leaflet-draw-draw-circle, .leaflet-draw-draw-polygon, .leaflet-draw-draw-rectangle, .leaflet-draw-draw-marker')
+      buttons.forEach((button) => {
+        if (button.classList.contains('leaflet-draw-draw-circle')) {
+          button.setAttribute('aria-label', 'Search by spatial circle')
+        } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
+          button.setAttribute('aria-label', 'Search by spatial polygon')
+        } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
+          button.setAttribute('aria-label', 'Search by spatial rectangle')
+        } else if (button.classList.contains('leaflet-draw-draw-marker')) {
+          button.setAttribute('aria-label', 'Search by spatial coordinate')
+        }
+      })
+    }
   }
 
   // Trigger a leaflet drawing from the spatial dropdown

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -536,13 +536,13 @@ const SpatialSelection = (props) => {
       const buttons = drawToolbar.querySelectorAll('.leaflet-draw-draw-circle, .leaflet-draw-draw-polygon, .leaflet-draw-draw-rectangle, .leaflet-draw-draw-marker')
       buttons.forEach((button) => {
         if (button.classList.contains('leaflet-draw-draw-circle')) {
-          button.setAttribute('aria-label', 'Draw a spatial circle')
+          button.setAttribute('aria-label', 'Draw a spatial circle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
-          button.setAttribute('aria-label', 'Draw a spatial polygon')
-        } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
-          button.setAttribute('aria-label', 'Draw a spatial rectangle')
+          button.setAttribute('aria-label', 'Draw a spatial polygon on the map to select a spatial extent')
+        } else if (button.classList.contains('leaflet-draw-draw-rectangle on the map to select a spatial extent')) {
+          button.setAttribute('aria-label', 'Draw a spatial rectangle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-marker')) {
-          button.setAttribute('aria-label', 'Draw a spatial coordinate')
+          button.setAttribute('aria-label', 'Draw a spatial coordinate on the map to select a spatial extent')
         }
       })
     }

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -536,13 +536,13 @@ const SpatialSelection = (props) => {
       const buttons = drawToolbar.querySelectorAll('.leaflet-draw-draw-circle, .leaflet-draw-draw-polygon, .leaflet-draw-draw-rectangle, .leaflet-draw-draw-marker')
       buttons.forEach((button) => {
         if (button.classList.contains('leaflet-draw-draw-circle')) {
-          button.setAttribute('aria-label', 'Draw a spatial circle on the map to select a spatial extent')
+          button.setAttribute('aria-label', 'Draw a circle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
-          button.setAttribute('aria-label', 'Draw a spatial polygon on the map to select a spatial extent')
+          button.setAttribute('aria-label', 'Draw a polygon on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
-          button.setAttribute('aria-label', 'Draw a spatial rectangle on the map to select a spatial extent')
+          button.setAttribute('aria-label', 'Draw a rectangle on the map to select a spatial extent')
         } else if (button.classList.contains('leaflet-draw-draw-marker')) {
-          button.setAttribute('aria-label', 'Draw a spatial coordinate on the map to select a spatial extent')
+          button.setAttribute('aria-label', 'Draw a coordinate on the map to select a spatial extent')
         }
       })
     }

--- a/static/src/js/components/SpatialSelection/SpatialSelection.jsx
+++ b/static/src/js/components/SpatialSelection/SpatialSelection.jsx
@@ -536,13 +536,13 @@ const SpatialSelection = (props) => {
       const buttons = drawToolbar.querySelectorAll('.leaflet-draw-draw-circle, .leaflet-draw-draw-polygon, .leaflet-draw-draw-rectangle, .leaflet-draw-draw-marker')
       buttons.forEach((button) => {
         if (button.classList.contains('leaflet-draw-draw-circle')) {
-          button.setAttribute('aria-label', 'Draw by a spatial circle')
+          button.setAttribute('aria-label', 'Draw a spatial circle')
         } else if (button.classList.contains('leaflet-draw-draw-polygon')) {
-          button.setAttribute('aria-label', 'Draw by a spatial polygon')
+          button.setAttribute('aria-label', 'Draw a spatial polygon')
         } else if (button.classList.contains('leaflet-draw-draw-rectangle')) {
-          button.setAttribute('aria-label', 'Draw by a spatial rectangle')
+          button.setAttribute('aria-label', 'Draw a spatial rectangle')
         } else if (button.classList.contains('leaflet-draw-draw-marker')) {
-          button.setAttribute('aria-label', 'Draw by a spatial coordinate')
+          button.setAttribute('aria-label', 'Draw a spatial coordinate')
         }
       })
     }

--- a/tests/e2e/map/map_spatial.spec.js
+++ b/tests/e2e/map/map_spatial.spec.js
@@ -90,7 +90,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Draw a spatial coordinate on the map to select a spatial extent' }).click()
+        await page.getByRole('link', { name: 'Draw a coordinate on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -173,7 +173,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Draw a spatial coordinate on the map to select a spatial extent' }).click()
+        await page.getByRole('link', { name: 'Draw a coordinate on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -274,7 +274,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Draw a spatial circle on the map to select a spatial extent' }).click()
+        await page.getByRole('link', { name: 'Draw a circle on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)
@@ -364,7 +364,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Draw a spatial circle on the map to select a spatial extent' }).click()
+        await page.getByRole('link', { name: 'Draw a circle on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)

--- a/tests/e2e/map/map_spatial.spec.js
+++ b/tests/e2e/map/map_spatial.spec.js
@@ -54,7 +54,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the point spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Point' }).click()
+        await page.getByRole('button', { name: 'Point' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -90,7 +90,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Search by spatial coordinate' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial coordinate' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -127,7 +127,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the point spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Point' }).click()
+        await page.getByRole('button', { name: 'Point' }).click()
 
         // Enter the spatial point
         await page.getByTestId('spatial-display_point').focus()
@@ -173,7 +173,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Search by spatial coordinate' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial coordinate' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -234,7 +234,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the circle spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Circle' }).click()
+        await page.getByRole('button', { name: 'Circle' }).click()
 
         // Add the circle to the map
         await page.mouse.move(1000, 500)
@@ -274,7 +274,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Search by spatial circle' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial circle' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)
@@ -315,7 +315,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the circle spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Circle' }).click()
+        await page.getByRole('button', { name: 'Circle' }).click()
 
         // Enter the circle values
         await page.getByTestId('spatial-display_circle-center').focus()
@@ -364,7 +364,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Search by spatial circle' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial circle' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)
@@ -431,7 +431,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the bounding box spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Rectangle' }).click()
+        await page.getByRole('button', { name: 'Rectangle' }).click()
 
         // Add the bounding box to the map
         await page.mouse.click(1000, 500)
@@ -510,7 +510,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the bounding box spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Rectangle' }).click()
+        await page.getByRole('button', { name: 'Rectangle' }).click()
 
         // Enter the bounding box values
         await page.getByTestId('spatial-display_southwest-point').focus()
@@ -562,7 +562,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the bounding box spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Rectangle' }).click()
+        await page.getByRole('button', { name: 'Rectangle' }).click()
 
         // Add the bounding box to the map
         await page.mouse.click(1000, 500)
@@ -627,7 +627,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the polygon spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Polygon' }).click()
+        await page.getByRole('button', { name: 'Polygon' }).click()
 
         // Add the polygon to the map
         await page.mouse.click(1000, 500)
@@ -741,7 +741,7 @@ test.describe('Map: Spatial interactions', () => {
 
         // Select the polygon spatial type
         await page.getByRole('button', { name: 'spatial-selection-dropdown' }).click()
-        await page.getByRole('button', { name: 'Select Polygon' }).click()
+        await page.getByRole('button', { name: 'Polygon' }).click()
 
         // Add the polygon to the map
         await page.mouse.click(1000, 500)

--- a/tests/e2e/map/map_spatial.spec.js
+++ b/tests/e2e/map/map_spatial.spec.js
@@ -90,7 +90,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Draw a spatial coordinate' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial coordinate on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -173,7 +173,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the point spatial type
-        await page.getByRole('link', { name: 'Draw a spatial coordinate' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial coordinate on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.click(1000, 500)
@@ -274,7 +274,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Draw a spatial circle' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial circle on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)
@@ -364,7 +364,7 @@ test.describe('Map: Spatial interactions', () => {
         await page.goto('/')
 
         // Select the circle spatial type
-        await page.getByRole('link', { name: 'Draw a spatial circle' }).click()
+        await page.getByRole('link', { name: 'Draw a spatial circle on the map to select a spatial extent' }).click()
 
         // Add the point to the map
         await page.mouse.move(1000, 500)


### PR DESCRIPTION
# Overview

### What is the feature?

Ensuring the spatial buttons and consistent in both order and style, and adding aria-labels to them.

### What is the Solution?

Updating the icons for spatial filter buttons to all match the same visual style. Making the spatial dropdown filters be left-aligned. Adding aria-labels to all the spatial filter buttons.

### What areas of the application does this impact?

- Spatial Filter Dropdown
- Leaflet Spatial Filter Buttons

# Testing

### Reproduction steps

1. Verify that the Spatial Filter Dropdown is left aligned and that the styles and order match the leaflet buttons.
2. Ensure all buttons still work as expected.

### Attachments

![Screenshot 2025-01-02 at 1 48 45 PM](https://github.com/user-attachments/assets/8a23f8c3-00bf-44c2-a9b5-2bd5f3fa18ab)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
