### PR TITLE
EDSC-4389: Adds toolConceptId as a permitted parameter

### DIFF
--- a/sharedConstants/nonIndexedCmrKeys.js
+++ b/sharedConstants/nonIndexedCmrKeys.js
@@ -23,6 +23,7 @@ export const collectionRequestNonIndexedCmrKeys = [
   'sort_key',
   'spatial_keyword',
   'tag_key',
+  'tool_concept_id',
   'two_d_coordinate_system_name'
 ]
 

--- a/sharedConstants/permittedCmrKeys.js
+++ b/sharedConstants/permittedCmrKeys.js
@@ -43,6 +43,7 @@ export const collectionRequestPermittedCmrKeys = [
   'standard_product',
   'tag_key',
   'temporal',
+  'tool_concept_id',
   'two_d_coordinate_system_name'
 ]
 

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -170,6 +170,7 @@ export const buildCollectionSearchParams = (params) => {
     standardProduct,
     tagKey,
     temporalString,
+    toolConceptId,
     viewAllFacets,
     viewAllFacetsCategory
   } = params
@@ -265,6 +266,7 @@ export const buildCollectionSearchParams = (params) => {
     standardProduct,
     tagKey,
     temporal: temporalString,
+    toolConceptId,
     twoDCoordinateSystemName: facetsToSend.two_d_coordinate_system_name,
     facetsSize: viewAllFacetsCategory
       ? { [categoryNameToCMRParam(viewAllFacetsCategory)]: 10000 }

--- a/static/src/js/util/request/__tests__/collectionRequest.test.js
+++ b/static/src/js/util/request/__tests__/collectionRequest.test.js
@@ -77,6 +77,7 @@ describe('CollectionRequest#permittedCmrKeys', () => {
       'standard_product',
       'tag_key',
       'temporal',
+      'tool_concept_id',
       'two_d_coordinate_system_name'
     ])
   })
@@ -111,6 +112,7 @@ describe('CollectionRequest#nonIndexedKeys', () => {
       'sort_key',
       'spatial_keyword',
       'tag_key',
+      'tool_concept_id',
       'two_d_coordinate_system_name'
     ])
   })


### PR DESCRIPTION
# Overview

### What is the feature?

Adds toolConceptId as a permitted parameter

### What areas of the application does this impact?

Portal can now use the toolConceptId

# Testing

Follow the [Portal Creation Guide](https://wiki.earthdata.nasa.gov/display/EDSC/Portal+Creation+Guide) to create a test portal with the toolConceptId parameter as part of your query.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
