### PR TITLE
EDSC-4342: Adds features facet icons

### DIFF
--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -11,6 +11,9 @@ import './EDSCIcon.scss'
  * @param {String} className - An optional classname.
  * @param {Object} context - Optional object to pass to `react-icons/IconContext.Provider`
  * @param {String} title - Optional string used as the `title` attribute
+ * @param {String} size - Optional string used as the `size` attribute
+ * @param {String} variant - Optional string that determines the icon's wrapper element and styling. 
+ * @param {Object} ariaLabel - Optional string used as the `aria-label` attribute
  */
 export const EDSCIcon = ({
   icon,
@@ -56,6 +59,7 @@ export const EDSCIcon = ({
           title={title}
           size={size}
           data-testid="edsc-icon"
+          aria-label={ariaLabel}
           {...props}
         />
         {children}
@@ -71,6 +75,7 @@ export const EDSCIcon = ({
           title={title}
           size={size}
           data-testid="edsc-icon-details"
+          aria-label={ariaLabel}
           {...props}
         />
         {children}
@@ -85,6 +90,7 @@ export const EDSCIcon = ({
           className={iconClassNames}
           title={title}
           size={size}
+          aria-label={ariaLabel}
           data-testid="edsc-icon-details"
           {...props}
         />

--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -20,6 +20,7 @@ export const EDSCIcon = ({
   size,
   title,
   variant,
+  label,
   ...props
 }) => {
   if (!icon) return null
@@ -98,6 +99,7 @@ export const EDSCIcon = ({
         className={iconClassNames}
         title={title}
         size={size}
+        aria-label={label}
         data-testid="edsc-icon"
         {...props}
       />
@@ -113,7 +115,8 @@ EDSCIcon.defaultProps = {
   context: null,
   size: '1rem',
   title: null,
-  variant: null
+  variant: null,
+  label: null
 }
 
 EDSCIcon.propTypes = {
@@ -123,7 +126,8 @@ EDSCIcon.propTypes = {
   context: PropTypes.shape({}),
   size: PropTypes.string,
   title: PropTypes.string,
-  variant: PropTypes.string
+  variant: PropTypes.string,
+  label: PropTypes.string
 }
 
 export default EDSCIcon

--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -41,6 +41,7 @@ export const EDSCIcon = ({
         className={iconClassNames}
         title={title}
         data-testid="edsc-icon-simple"
+        aria-label={ariaLabel}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />

--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -20,7 +20,7 @@ export const EDSCIcon = ({
   size,
   title,
   variant,
-  label,
+  ariaLabel,
   ...props
 }) => {
   if (!icon) return null
@@ -99,7 +99,7 @@ export const EDSCIcon = ({
         className={iconClassNames}
         title={title}
         size={size}
-        aria-label={label}
+        aria-label={ariaLabel}
         data-testid="edsc-icon"
         {...props}
       />
@@ -116,7 +116,7 @@ EDSCIcon.defaultProps = {
   size: '1rem',
   title: null,
   variant: null,
-  label: null
+  ariaLabel: null
 }
 
 EDSCIcon.propTypes = {
@@ -127,7 +127,7 @@ EDSCIcon.propTypes = {
   size: PropTypes.string,
   title: PropTypes.string,
   variant: PropTypes.string,
-  label: PropTypes.string
+  ariaLabel: PropTypes.string
 }
 
 export default EDSCIcon

--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -12,7 +12,7 @@ import './EDSCIcon.scss'
  * @param {Object} context - Optional object to pass to `react-icons/IconContext.Provider`
  * @param {String} title - Optional string used as the `title` attribute
  * @param {String} size - Optional string used as the `size` attribute
- * @param {String} variant - Optional string that determines the icon's wrapper element and styling. 
+ * @param {String} variant - Optional string that determines the icon's wrapper element and styling.
  * @param {Object} ariaLabel - Optional string used as the `aria-label` attribute
  */
 export const EDSCIcon = ({

--- a/static/src/js/components/EDSCIcon/EDSCIcon.scss
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.scss
@@ -3,4 +3,9 @@
     color: $color__carbon--40;
     margin-left: 0.25rem;
   }
+
+  &--facet {
+    color: $color__carbon--40;
+    margin-right: 0.25rem;
+  }
 }

--- a/static/src/js/components/EDSCIcon/__tests__/EDSCIcon.test.jsx
+++ b/static/src/js/components/EDSCIcon/__tests__/EDSCIcon.test.jsx
@@ -33,12 +33,22 @@ describe('EDSCIcon component', () => {
   })
 
   describe('when a variant is supplied', () => {
-    test('should add the class name', async () => {
+    test('should add the variant', async () => {
       render(<EDSCIcon variant="test-variant" icon={FaQuestionCircle} />)
 
       const icon = await screen.findByTestId('edsc-icon')
 
       expect(icon.classList.contains('edsc-icon--test-variant')).toBeTruthy()
+    })
+  })
+
+  describe('when an aria-label is supplied', () => {
+    test('should add the aria-label', async () => {
+      render(<EDSCIcon ariaLabel="test-aria-label" icon={FaQuestionCircle} />)
+
+      const icon = await screen.findByTestId('edsc-icon')
+
+      expect(icon.getAttribute('aria-label')).toEqual('test-aria-label')
     })
   })
 

--- a/static/src/js/components/Facets/Facets.jsx
+++ b/static/src/js/components/Facets/Facets.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { camelCase } from 'lodash-es'
 
 import { FaMap } from 'react-icons/fa'
-import { CloudFill } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
+import { CloudFill, Settings } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
 import { changeFeatureFacet, changeCmrFacet } from '../../util/facets'
 
 import FacetsGroup from './FacetsGroup'
@@ -49,7 +49,10 @@ const Facets = (props) => {
     featuresFacet.children.push({
       applied: featureFacets.availableInEarthdataCloud,
       title: 'Available in Earthdata Cloud',
-      icon: CloudFill,
+      iconProps: {
+        icon: CloudFill,
+        label: 'a cloud'
+      },
       type: 'feature'
     })
   }
@@ -58,6 +61,10 @@ const Facets = (props) => {
     featuresFacet.children.push({
       applied: featureFacets.customizable,
       title: 'Customizable',
+      iconProps: {
+        icon: Settings,
+        label: 'a gear'
+      },
       description: 'Include only collections that support customization (temporal, spatial, or variable subsetting, reformatting, etc.)',
       type: 'feature'
     })
@@ -66,7 +73,10 @@ const Facets = (props) => {
   if (showMapImagery) {
     featuresFacet.children.push({
       applied: featureFacets.mapImagery,
-      icon: FaMap,
+      iconProps: {
+        icon: FaMap,
+        label: 'a map'
+      },
       title: 'Map Imagery',
       type: 'feature'
     })

--- a/static/src/js/components/Facets/Facets.jsx
+++ b/static/src/js/components/Facets/Facets.jsx
@@ -51,7 +51,7 @@ const Facets = (props) => {
       title: 'Available in Earthdata Cloud',
       iconProps: {
         icon: CloudFill,
-        label: 'a cloud icon'
+        ariaLabel: 'A cloud icon'
       },
       type: 'feature'
     })
@@ -63,7 +63,7 @@ const Facets = (props) => {
       title: 'Customizable',
       iconProps: {
         icon: Settings,
-        label: 'a gear icon'
+        ariaLabel: 'A gear icon'
       },
       description: 'Include only collections that support customization (temporal, spatial, or variable subsetting, reformatting, etc.)',
       type: 'feature'
@@ -75,7 +75,7 @@ const Facets = (props) => {
       applied: featureFacets.mapImagery,
       iconProps: {
         icon: FaMap,
-        label: 'a map icon'
+        ariaLabel: 'A map icon'
       },
       title: 'Map Imagery',
       type: 'feature'

--- a/static/src/js/components/Facets/Facets.jsx
+++ b/static/src/js/components/Facets/Facets.jsx
@@ -51,7 +51,7 @@ const Facets = (props) => {
       title: 'Available in Earthdata Cloud',
       iconProps: {
         icon: CloudFill,
-        label: 'a cloud'
+        label: 'a cloud icon'
       },
       type: 'feature'
     })
@@ -63,7 +63,7 @@ const Facets = (props) => {
       title: 'Customizable',
       iconProps: {
         icon: Settings,
-        label: 'a gear'
+        label: 'a gear icon'
       },
       description: 'Include only collections that support customization (temporal, spatial, or variable subsetting, reformatting, etc.)',
       type: 'feature'
@@ -75,7 +75,7 @@ const Facets = (props) => {
       applied: featureFacets.mapImagery,
       iconProps: {
         icon: FaMap,
-        label: 'a map'
+        label: 'a map icon'
       },
       title: 'Map Imagery',
       type: 'feature'

--- a/static/src/js/components/Facets/Facets.jsx
+++ b/static/src/js/components/Facets/Facets.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { camelCase } from 'lodash-es'
 
+import { FaMap } from 'react-icons/fa'
+import { CloudFill } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
 import { changeFeatureFacet, changeCmrFacet } from '../../util/facets'
 
 import FacetsGroup from './FacetsGroup'
@@ -47,6 +49,7 @@ const Facets = (props) => {
     featuresFacet.children.push({
       applied: featureFacets.availableInEarthdataCloud,
       title: 'Available in Earthdata Cloud',
+      icon: CloudFill,
       type: 'feature'
     })
   }
@@ -63,6 +66,7 @@ const Facets = (props) => {
   if (showMapImagery) {
     featuresFacet.children.push({
       applied: featureFacets.mapImagery,
+      icon: FaMap,
       title: 'Map Imagery',
       type: 'feature'
     })

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -107,7 +107,7 @@ class FacetsItem extends Component {
           />
           <div className="facets-item__title-container">
             {
-              iconProps.icon && (
+              iconProps?.icon && (
                 <EDSCIcon
                   className="facets-item__icon"
                   icon={iconProps.icon}

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -104,6 +104,15 @@ class FacetsItem extends Component {
             onChange={this.onFacetChange.bind(this, changeHandlerArgs)}
           />
           <span className="facets-item__title">
+            {
+              facet.icon && (
+                <EDSCIcon
+                  className="facets-item__icon"
+                  icon={facet.icon}
+                  data-testid={`facet_item-${kebabCase(facet.title)}-icon`}
+                />
+              )
+            }
             {facet.title}
             {
               facet.description
@@ -149,7 +158,8 @@ FacetsItem.propTypes = {
     children: PropTypes.arrayOf(PropTypes.shape({})),
     count: PropTypes.number,
     title: PropTypes.string,
-    description: PropTypes.string
+    description: PropTypes.string,
+    icon: PropTypes.elementType
   }).isRequired,
   facetCategory: PropTypes.string.isRequired,
   level: PropTypes.number.isRequired,

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -86,6 +86,8 @@ class FacetsItem extends Component {
       `facets-item--level-${level}`
     )
 
+    const { iconProps } = facet
+
     return (
       <li className={className}>
         <label
@@ -105,13 +107,12 @@ class FacetsItem extends Component {
           />
           <div className="facets-item__title-container">
             {
-              facet.iconProps && (
+              iconProps.icon && (
                 <EDSCIcon
                   className="facets-item__icon"
-                  icon={facet.iconProps.icon}
+                  icon={iconProps.icon}
                   variant="facet"
-                  label={facet.iconProps.label || facet.title}
-                  ariaLabel={facet.iconProps.ariaLabel}
+                  ariaLabel={iconProps.ariaLabel}
                 />
               )
             }
@@ -135,6 +136,7 @@ class FacetsItem extends Component {
                     icon={FaQuestionCircle}
                     size="0.625rem"
                     variant="more-info"
+                    ariaLabel="A question mark icon indicating there is more information"
                     data-testid={`facet_item-${kebabCase(facet.title)}-info`}
                   />
                 </OverlayTrigger>
@@ -165,7 +167,6 @@ FacetsItem.propTypes = {
     description: PropTypes.string,
     iconProps: PropTypes.shape({
       icon: PropTypes.elementType,
-      label: PropTypes.string,
       ariaLabel: PropTypes.string
     })
   }).isRequired,

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -111,6 +111,7 @@ class FacetsItem extends Component {
                   icon={facet.iconProps.icon}
                   variant="facet"
                   label={facet.iconProps.label || facet.title}
+                  ariaLabel={facet.iconProps.ariaLabel}
                 />
               )
             }
@@ -164,7 +165,8 @@ FacetsItem.propTypes = {
     description: PropTypes.string,
     iconProps: PropTypes.shape({
       icon: PropTypes.elementType,
-      label: PropTypes.string
+      label: PropTypes.string,
+      ariaLabel: PropTypes.string
     })
   }).isRequired,
   facetCategory: PropTypes.string.isRequired,

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -109,6 +109,7 @@ class FacetsItem extends Component {
                 <EDSCIcon
                   className="facets-item__icon"
                   icon={facet.icon}
+                  variant="facet"
                   data-testid={`facet_item-${kebabCase(facet.title)}-icon`}
                 />
               )

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -103,7 +103,7 @@ class FacetsItem extends Component {
             checked={applied}
             onChange={this.onFacetChange.bind(this, changeHandlerArgs)}
           />
-          <span className="facets-item__title">
+          <div className="facets-item__title-container">
             {
               facet.iconProps && (
                 <EDSCIcon
@@ -114,30 +114,32 @@ class FacetsItem extends Component {
                 />
               )
             }
-            {facet.title}
+            <span className="facets-item__title">
+              {facet.title}
+            </span>
             {
               facet.description
-            && (
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  (
-                    <Tooltip style={{ width: '20rem' }}>
-                      {facet.description}
-                    </Tooltip>
-                  )
-                }
-              >
-                <EDSCIcon
-                  icon={FaQuestionCircle}
-                  size="0.625rem"
-                  variant="more-info"
-                  data-testid={`facet_item-${kebabCase(facet.title)}-info`}
-                />
-              </OverlayTrigger>
-            )
+              && (
+                <OverlayTrigger
+                  placement="top"
+                  overlay={
+                    (
+                      <Tooltip style={{ width: '20rem' }}>
+                        {facet.description}
+                      </Tooltip>
+                    )
+                  }
+                >
+                  <EDSCIcon
+                    icon={FaQuestionCircle}
+                    size="0.625rem"
+                    variant="more-info"
+                    data-testid={`facet_item-${kebabCase(facet.title)}-info`}
+                  />
+                </OverlayTrigger>
+              )
             }
-          </span>
+          </div>
           { (!applied || !children) && <span className="facets-item__total">{facet.count}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -105,12 +105,12 @@ class FacetsItem extends Component {
           />
           <span className="facets-item__title">
             {
-              facet.icon && (
+              facet.iconProps && (
                 <EDSCIcon
                   className="facets-item__icon"
-                  icon={facet.icon}
+                  icon={facet.iconProps.icon}
                   variant="facet"
-                  data-testid={`facet_item-${kebabCase(facet.title)}-icon`}
+                  label={facet.iconProps.label || facet.title}
                 />
               )
             }
@@ -160,7 +160,10 @@ FacetsItem.propTypes = {
     count: PropTypes.number,
     title: PropTypes.string,
     description: PropTypes.string,
-    icon: PropTypes.elementType
+    iconProps: PropTypes.shape({
+      icon: PropTypes.elementType,
+      label: PropTypes.string
+    })
   }).isRequired,
   facetCategory: PropTypes.string.isRequired,
   level: PropTypes.number.isRequired,

--- a/static/src/js/components/Facets/FacetsItem.scss
+++ b/static/src/js/components/Facets/FacetsItem.scss
@@ -66,11 +66,6 @@
     color: $color__carbon--90;
     font-size: 0.825rem;
   }
-
-  &__icon {
-    color: $color__carbon--40;
-    margin-right: 0.25rem;
-  }
 }
 
 .facets__list {

--- a/static/src/js/components/Facets/FacetsItem.scss
+++ b/static/src/js/components/Facets/FacetsItem.scss
@@ -66,6 +66,11 @@
     color: $color__carbon--90;
     font-size: 0.825rem;
   }
+
+  &__icon {
+    color: $color__carbon--40;
+    margin-right: 0.25rem;
+  }
 }
 
 .facets__list {

--- a/static/src/js/components/Facets/FacetsItem.scss
+++ b/static/src/js/components/Facets/FacetsItem.scss
@@ -46,6 +46,12 @@
     }
   }
 
+  &__title-container {
+    display: flex;
+    align-items: center;
+    flex: 1;
+  }
+
   &__title {
     display: inline-block;
     text-overflow: ellipsis;

--- a/static/src/js/components/Facets/__tests__/Facets.test.jsx
+++ b/static/src/js/components/Facets/__tests__/Facets.test.jsx
@@ -3,7 +3,6 @@ import {
   act,
   render,
   screen,
-  waitFor,
   within
 } from '@testing-library/react'
 

--- a/static/src/js/components/Facets/__tests__/Facets.test.jsx
+++ b/static/src/js/components/Facets/__tests__/Facets.test.jsx
@@ -3,6 +3,7 @@ import {
   act,
   render,
   screen,
+  waitFor,
   within
 } from '@testing-library/react'
 
@@ -262,11 +263,15 @@ describe('Facets Features Map Imagery component', () => {
     const user = userEvent.setup()
 
     // Check for Map Imagery icon
-    const mapImageryIcon = screen.getByTestId('facet_item-map-imagery-icon')
+    const mapImageryIcon = screen.getByLabelText('a map')
     expect(mapImageryIcon).toBeInTheDocument()
 
+    // Check for Customizable icon
+    const customizableIcon = screen.getByLabelText('a gear')
+    expect(customizableIcon).toBeInTheDocument()
+
     // Check for Cloud icon
-    const cloudIcon = screen.queryByTestId('facet_item-available-in-earthdata-cloud-icon')
+    const cloudIcon = screen.queryByLabelText('a cloud')
     expect(cloudIcon).not.toBeInTheDocument()
 
     const featuresElements = screen.getAllByText('Features')

--- a/static/src/js/components/Facets/__tests__/Facets.test.jsx
+++ b/static/src/js/components/Facets/__tests__/Facets.test.jsx
@@ -262,15 +262,15 @@ describe('Facets Features Map Imagery component', () => {
     const user = userEvent.setup()
 
     // Check for Map Imagery icon
-    const mapImageryIcon = screen.getByLabelText('a map icon')
+    const mapImageryIcon = screen.getByLabelText('A map icon')
     expect(mapImageryIcon).toBeInTheDocument()
 
     // Check for Customizable icon
-    const customizableIcon = screen.getByLabelText('a gear icon')
+    const customizableIcon = screen.getByLabelText('A gear icon')
     expect(customizableIcon).toBeInTheDocument()
 
     // Check for Cloud icon
-    const cloudIcon = screen.queryByLabelText('a cloud icon')
+    const cloudIcon = screen.queryByLabelText('A cloud icon')
     expect(cloudIcon).not.toBeInTheDocument()
 
     const featuresElements = screen.getAllByText('Features')

--- a/static/src/js/components/Facets/__tests__/Facets.test.jsx
+++ b/static/src/js/components/Facets/__tests__/Facets.test.jsx
@@ -223,7 +223,7 @@ function setup(overrideProps = {}) {
 }
 
 describe('Facets Features Map Imagery component', () => {
-  test('only renders enabled feature FacetsGroup', async () => {
+  test('allows toggling Map Imagery checkbox', async () => {
     setup({
       portal: {
         features: {
@@ -246,7 +246,7 @@ describe('Facets Features Map Imagery component', () => {
     expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(1)
   })
 
-  test('only renders enabled feature FacetsGroup', async () => {
+  test('renders feature facets with tooltips and icons', async () => {
     setup({
       portal: {
         features: {
@@ -260,6 +260,14 @@ describe('Facets Features Map Imagery component', () => {
     })
 
     const user = userEvent.setup()
+
+    // Check for Map Imagery icon
+    const mapImageryIcon = screen.getByTestId('facet_item-map-imagery-icon')
+    expect(mapImageryIcon).toBeInTheDocument()
+
+    // Check for Cloud icon
+    const cloudIcon = screen.queryByTestId('facet_item-available-in-earthdata-cloud-icon')
+    expect(cloudIcon).not.toBeInTheDocument()
 
     const featuresElements = screen.getAllByText('Features')
     expect(featuresElements).toHaveLength(1)

--- a/static/src/js/components/Facets/__tests__/Facets.test.jsx
+++ b/static/src/js/components/Facets/__tests__/Facets.test.jsx
@@ -263,15 +263,15 @@ describe('Facets Features Map Imagery component', () => {
     const user = userEvent.setup()
 
     // Check for Map Imagery icon
-    const mapImageryIcon = screen.getByLabelText('a map')
+    const mapImageryIcon = screen.getByLabelText('a map icon')
     expect(mapImageryIcon).toBeInTheDocument()
 
     // Check for Customizable icon
-    const customizableIcon = screen.getByLabelText('a gear')
+    const customizableIcon = screen.getByLabelText('a gear icon')
     expect(customizableIcon).toBeInTheDocument()
 
     // Check for Cloud icon
-    const cloudIcon = screen.queryByLabelText('a cloud')
+    const cloudIcon = screen.queryByLabelText('a cloud icon')
     expect(cloudIcon).not.toBeInTheDocument()
 
     const featuresElements = screen.getAllByText('Features')


### PR DESCRIPTION
# Overview

### What is the feature?

The Facets for the "Available in Earthdata Cloud" and "Map Imagery" Should have icons added to them these should match icons used in static/src/js/components/CollectionResults/CollectionResultsItem.jsx for consistency

### What is the Solution?

Facets and FacetItem components will allow for adding of icons to facets via a new icon prop

### What areas of the application does this impact?

Facets.jsx and FacetsItem.jsx

# Testing

### Reproduction steps

On main search page with collection results, there should now be icons for cloud and map imagery feature

### Attachments

[facets](<img width="301" alt="Screenshot 2025-01-29 at 8 00 46 AM" src="https://github.com/user-attachments/assets/32cbd37c-fc41-4a51-89d4-d6290709cc96" />)

![image](https://github.com/user-attachments/assets/5444f0cd-e9ff-43b9-8348-cb72e853ea36)

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
