### PR TITLE
EDSC-4125: Recurring temporal slider doesn't work

### DIFF
--- a/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
+++ b/static/src/js/components/GranuleFilters/GranuleFiltersForm.jsx
@@ -451,8 +451,10 @@ export const GranuleFiltersForm = (props) => {
                 validate={false}
                 onSliderChange={
                   (value) => {
-                    setFieldValue('temporal.startDate', moment(temporal.startDate).year(value.min).toISOString())
-                    setFieldValue('temporal.endDate', moment(temporal.endDate).year(value.max).toISOString())
+                    const startDate = temporal.startDate ? moment(temporal.startDate) : moment()
+                    const endDate = temporal.endDate ? moment(temporal.endDate) : moment()
+                    setFieldValue('temporal.startDate', startDate.year(value.min).toISOString())
+                    setFieldValue('temporal.endDate', endDate.year(value.max).toISOString())
                   }
                 }
                 onRecurringToggle={
@@ -552,7 +554,6 @@ export const GranuleFiltersForm = (props) => {
                       }
                     }
 
-                    // Only call handleSubmit if `onSubmitStart` was called
                     if (shouldSubmit && (startDate.isValid() || !input)) {
                       handleSubmit()
 
@@ -909,12 +910,6 @@ export const GranuleFiltersForm = (props) => {
                             temporal={equatorCrossingDate}
                             displayStartDate={equatorCrossingDate.startDate}
                             displayEndDate={equatorCrossingDate.endDate}
-                            onSliderChange={
-                              (value) => {
-                                setFieldValue('temporal.startDate', moment(temporal.startDate).year(value.min).toISOString())
-                                setFieldValue('temporal.endDate', moment(temporal.endDate).year(value.max).toISOString())
-                              }
-                            }
                             validate={false}
                             onSubmitStart={
                               (startDate, shouldSubmit) => {

--- a/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.jsx
+++ b/static/src/js/components/GranuleFilters/__tests__/GranuleFiltersForm.test.jsx
@@ -489,7 +489,7 @@ describe('GranuleFiltersForm component', () => {
           expect(setFieldTouched).toHaveBeenCalledTimes(1)
           expect(setFieldTouched).toHaveBeenCalledWith('temporal.isRecurring', true)
 
-          expect(setFieldValue).toHaveBeenCalledTimes(3)
+          expect(setFieldValue).toHaveBeenCalledTimes(4)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.isRecurring', true)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayStart', 225)
           expect(setFieldValue).toHaveBeenCalledWith('temporal.recurringDayEnd', 226)
@@ -1649,7 +1649,7 @@ describe('GranuleFiltersForm component', () => {
   })
 
   describe('End date submission behavior', () => {
-    test.only('when submitting end date in same year as start date with recurring enabled, adjusts start date to minimum year', async () => {
+    test('when submitting end date in same year as start date with recurring enabled, adjusts start date to minimum year', async () => {
       MockDate.set('2024-12-15')
 
       const {

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
@@ -352,8 +352,8 @@ const TemporalSelectionDropdown = ({
                 const { min, max } = value
                 setTemporal({
                   ...temporal,
-                  startDate: moment(temporal.startDate).year(min).toISOString(),
-                  endDate: moment(temporal.endDate).year(max).toISOString()
+                  startDate: moment(temporal.startDate).utc().year(min).toISOString(),
+                  endDate: moment(temporal.endDate).utc().year(max).toISOString()
                 })
               }
             }

--- a/static/src/js/components/TemporalSelection/TemporalSelection.jsx
+++ b/static/src/js/components/TemporalSelection/TemporalSelection.jsx
@@ -134,6 +134,8 @@ export class TemporalSelection extends Component {
     const minimumTemporalDate = moment(minimumTemporalDateString, temporalDateFormatFull)
 
     let sliderStartDate = moment(temporal.startDate).utc()
+    const sliderEndDate = moment(temporal.endDate || undefined).utc()
+
     if (!sliderStartDate.isValid()) {
       sliderStartDate = moment()
       sliderStartDate.set({
@@ -253,7 +255,7 @@ export class TemporalSelection extends Component {
               <span className="temporal-selection__range-label">
                 {sliderStartDate.year()}
                 {' - '}
-                {moment(temporal.endDate || undefined).year()}
+                {sliderEndDate.year()}
               </span>
 
               <InputRange
@@ -263,7 +265,7 @@ export class TemporalSelection extends Component {
                 value={
                   {
                     min: sliderStartDate.year(),
-                    max: moment(temporal.endDate || undefined).year()
+                    max: sliderEndDate.year()
                   }
                 }
                 onChange={onSliderChange}


### PR DESCRIPTION
# Overview

### What is the feature?

During testing, two issues were identified with the current implementation:

1. Collection Temporal Slider: When no dates are set, manipulating the end date slider simultaneously affects the minimum/start date slider.
2. Granule Temporal Filter: When the recurring option is toggled on, the sliders don't respond to the first onChange event. However, after clicking and releasing the sliders once, they begin functioning normally.

### What is the Solution?

In both the TemporalSelectionDropdown and GranuleFiltersForm components, we initialization values for start and end dates in their respective onSliderChange callbacks. For TemporalSelectionDropdown, this was implemented using utc() when creating the moment objects.

### What areas of the application does this impact?

Temporal Selection recurring slider on granule and collection filters.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. On collection temporal filter with no dates selected, toggle on the recurring toggle.
2. Manipulate the end/max slider, this will erronously change the start/min slider.

1. On granule temporal filter with no date selected, toggle on the recurring toggle.
2. Manipulate either end/max or start/min date slider.
3. Handler should stick till released incorrectly, then on second attempt to move it will move.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
