### PR TITLE
EDSC-4345: Indicate when collections don't have features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ playwright-coverage
 portals/availablePortals.json
 
 elasticmq.conf
+
+*bundle-size*

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,8 @@
         "redis-mock": "^0.56.3",
         "redux-mock-store": "^1.5.4",
         "s3rver": "^3.7.1",
-        "start-server-and-test": "^2.0.0"
+        "start-server-and-test": "^2.0.0",
+        "vite-bundle-visualizer": "^1.2.1"
       },
       "engines": {
         "yarn": "YARN NO LONGER USED - use npm instead."
@@ -11739,6 +11740,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cache-content-type": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
@@ -13296,6 +13307,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -16921,6 +16942,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-from-esm": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.20"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -16950,6 +16985,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -17195,6 +17241,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -17566,6 +17628,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -24028,6 +24103,24 @@
       "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
       "dev": true
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -26253,6 +26346,60 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -27842,7 +27989,6 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.14"
       }
@@ -28693,6 +28839,25 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-bundle-visualizer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz",
+      "integrity": "sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "import-from-esm": "^1.3.3",
+        "rollup-plugin-visualizer": "^5.11.0",
+        "tmp": "^0.2.1"
+      },
+      "bin": {
+        "vite-bundle-visualizer": "bin.js"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
       }
     },
     "node_modules/vite-plugin-ejs": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "postplaywright": "npx nyc report --reporter=json --reporter=lcov --reporter=clover --report-dir=playwright-coverage",
     "deploy-infrastructure": "cd cdk/earthdata-search-infrastructure && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
     "deploy-application": "cd cdk/earthdata-search && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
-    "deploy-static": "cd cdk/earthdata-search-static && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never"
+    "deploy-static": "cd cdk/earthdata-search-static && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
+    "bundle-size": "NODE_OPTIONS=--max-old-space-size=8192 vite-bundle-visualizer --sourcemap -t raw-data -o bundle-size.json"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.7",
@@ -96,7 +97,8 @@
     "redis-mock": "^0.56.3",
     "redux-mock-store": "^1.5.4",
     "s3rver": "^3.7.1",
-    "start-server-and-test": "^2.0.0"
+    "start-server-and-test": "^2.0.0",
+    "vite-bundle-visualizer": "^1.2.1"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.352.0",

--- a/static/src/js/components/CollectionResults/CollectionResultsItem.jsx
+++ b/static/src/js/components/CollectionResults/CollectionResultsItem.jsx
@@ -254,14 +254,27 @@ export const CollectionResultsItem = forwardRef(({
                   )
                 }
                 {
-                  hasMapImagery && (
+                  cloudHosted && (
                     <MetaIcon
-                      id="feature-icon-list-view__map-imagery"
-                      icon={FaMap}
-                      iconProps={{ size: '0.975rem' }}
-                      label="Map Imagery"
+                      id="feature-icon-list-view__earthdata-cloud"
+                      icon={CloudFill}
+                      iconProps={{ size: '1rem' }}
+                      label="Earthdata Cloud"
                       tooltipClassName="collection-results-item__tooltip"
-                      tooltipContent="Supports advanced map visualizations using the GIBS tile service"
+                      tooltipContent="Dataset is available in the Earthdata Cloud"
+                    />
+                  )
+                }
+                {
+                  !cloudHosted && (
+                    <MetaIcon
+                      id="feature-icon-list-view__earthdata-cloud"
+                      icon={CloudFill}
+                      iconProps={{ size: '1rem' }}
+                      label="Not hosted in Earthdata Cloud"
+                      notAvailable
+                      tooltipClassName="collection-results-item__tooltip"
+                      tooltipContent="Dataset is not available in the Earthdata Cloud"
                     />
                   )
                 }
@@ -278,15 +291,39 @@ export const CollectionResultsItem = forwardRef(({
                   )
                 }
                 {
-                  cloudHosted && (
+                  !supportsDataCustomizations && (
                     <MetaIcon
-                      id="feature-icon-list-view__earthdata-cloud"
-                      icon={CloudFill}
-                      iconProps={{ size: '1rem' }}
-                      label="Earthdata Cloud"
-                      metadata="Earthdata Cloud"
+                      id="feature-icon-list-view__customize"
+                      icon={Settings}
+                      label="No customizations"
+                      notAvailable
+                      tooltipClassName="collection-results-item__tooltip text-align-left"
+                      tooltipContent="No customization support"
+                    />
+                  )
+                }
+                {
+                  hasMapImagery && (
+                    <MetaIcon
+                      id="feature-icon-list-view__map-imagery"
+                      icon={FaMap}
+                      iconProps={{ size: '0.975rem' }}
+                      label="Map Imagery"
                       tooltipClassName="collection-results-item__tooltip"
-                      tooltipContent="Dataset is available in the Earthdata Cloud"
+                      tooltipContent="Supports advanced map visualizations using the GIBS tile service"
+                    />
+                  )
+                }
+                {
+                  !hasMapImagery && (
+                    <MetaIcon
+                      id="feature-icon-list-view__map-imagery"
+                      icon={FaMap}
+                      iconProps={{ size: '0.975rem' }}
+                      label="No map imagery"
+                      notAvailable
+                      tooltipClassName="collection-results-item__tooltip"
+                      tooltipContent="No map visualization support"
                     />
                   )
                 }

--- a/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.jsx
+++ b/static/src/js/components/CollectionResults/__tests__/CollectionResultsItem.test.jsx
@@ -276,29 +276,31 @@ describe('CollectionResultsList component', () => {
     })
 
     describe('map imagery', () => {
-      test('does not render when hasMapImagery not set', async () => {
-        setup()
-
-        await waitFor(() => {
-          expect(screen.queryByText('Map Imagery')).not.toBeInTheDocument()
-        })
-      })
-
-      describe('renders correctly when set', () => {
-        test('renders the badge correctly', async () => {
-          setup({
+      describe('when map imagery is not available', () => {
+        test('renders the badge correctly and tooltip correctly', async () => {
+          const { user } = setup({
             collectionMetadata: {
               ...collectionListItemProps.collectionMetadata,
-              hasMapImagery: true
+              hasMapImagery: false
             }
           })
 
-          await waitFor(() => {
-            expect(screen.getByText('Map Imagery')).toBeInTheDocument()
-          })
-        })
+          const icon = await screen.findByText('No map imagery')
 
-        test('renders a tooltip correctly', async () => {
+          await waitFor(() => {
+            expect(icon).toBeInTheDocument()
+          })
+
+          await waitFor(async () => {
+            await user.hover(icon)
+          })
+
+          expect(screen.getByText('No map visualization support')).toBeInTheDocument()
+        })
+      })
+
+      describe('when map imagery is available', () => {
+        test('renders the badge correctly and tooltip correctly', async () => {
           const { user } = setup({
             collectionMetadata: {
               ...collectionListItemProps.collectionMetadata,
@@ -306,10 +308,17 @@ describe('CollectionResultsList component', () => {
             }
           })
 
-          user.hover(screen.getByText('Map Imagery'))
+          const icon = await screen.findByText('Map Imagery')
+
           await waitFor(() => {
-            expect(screen.getByText('Supports advanced map visualizations using the GIBS tile service')).toBeInTheDocument()
+            expect(icon).toBeInTheDocument()
           })
+
+          await waitFor(async () => {
+            await user.hover(icon)
+          })
+
+          expect(screen.getByText('Supports advanced map visualizations using the GIBS tile service')).toBeInTheDocument()
         })
       })
     })
@@ -319,7 +328,7 @@ describe('CollectionResultsList component', () => {
         setup()
 
         await waitFor(() => {
-          expect(screen.queryByText('Map Imagery')).not.toBeInTheDocument()
+          expect(screen.queryByText('Near Real Time')).not.toBeInTheDocument()
         })
       })
 
@@ -378,18 +387,99 @@ describe('CollectionResultsList component', () => {
       })
     })
 
-    // TODO Skipping for now fix this when we have edsc-icons no longer utilize test-ids and use `img` as a role
-    describe('customize', () => {
-      test.skip('does not render when no customization flags are true', async () => {
-        setup({
-          collection: collectionListItemProps.collectionMetadata
+    describe('customizations', () => {
+      describe('when customizations are not available', () => {
+        test('renders the badge correctly and tooltip correctly', async () => {
+          const { user } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata,
+              hasVariables: true
+            }
+          })
+
+          const icon = await screen.findByText('Customize')
+
+          await waitFor(() => {
+            expect(icon).toBeInTheDocument()
+          })
+
+          await waitFor(async () => {
+            await user.hover(icon)
+          })
+
+          expect(screen.getByText('Supports customization:')).toBeInTheDocument()
+          expect(screen.getByText('Variable subset')).toBeInTheDocument()
+        })
+      })
+
+      describe('when customizations are available', () => {
+        test('renders the badge correctly and tooltip correctly', async () => {
+          const { user } = setup({
+            collectionMetadata: {
+              ...collectionListItemProps.collectionMetadata
+            }
+          })
+
+          const icon = await screen.findByText('No customizations')
+
+          await waitFor(() => {
+            expect(icon).toBeInTheDocument()
+          })
+
+          await waitFor(async () => {
+            await user.hover(icon)
+          })
+
+          expect(screen.getByText('No customization support')).toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('cloud hosted', () => {
+    describe('when the collection is not hosted in the cloud', () => {
+      test('renders the badge correctly and tooltip correctly', async () => {
+        const { user } = setup({
+          collectionMetadata: {
+            ...collectionListItemProps.collectionMetadata,
+            cloudHosted: false
+          }
         })
 
+        const icon = await screen.findByText('Not hosted in Earthdata Cloud')
+
         await waitFor(() => {
+          expect(icon).toBeInTheDocument()
         })
-        // Const metaContainer = enzymeWrapper.find('.collection-results-item__meta')
-        // const featureItem = metaContainer.find('#feature-icon-list-view__customize')
-        // expect(featureItem.length).toEqual(0)
+
+        await waitFor(async () => {
+          await user.hover(icon)
+        })
+
+        expect(screen.getByText('Dataset is not available in the Earthdata Cloud')).toBeInTheDocument()
+      })
+    })
+
+    describe('when the collection is hosted in the cloud', () => {
+      test('renders the badge correctly and tooltip correctly', async () => {
+        const { user } = setup({
+          collectionMetadata: {
+            ...collectionListItemProps.collectionMetadata,
+            cloudHosted: true
+          }
+        })
+
+        const icon = await screen.findByText('Earthdata Cloud')
+
+        await waitFor(() => {
+          expect(icon).toBeInTheDocument()
+        })
+
+        await waitFor(async () => {
+          await user.hover(icon)
+        })
+
+        expect(screen.getByText('Dataset is available in the Earthdata Cloud')).toBeInTheDocument()
       })
     })
   })

--- a/static/src/js/components/EDSCIcon/EDSCIcon.jsx
+++ b/static/src/js/components/EDSCIcon/EDSCIcon.jsx
@@ -46,6 +46,7 @@ export const EDSCIcon = forwardRef(({
         title={title}
         data-testid="edsc-icon-simple"
         aria-label={ariaLabel}
+        role="graphics-symbol"
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />
@@ -66,6 +67,7 @@ export const EDSCIcon = forwardRef(({
           size={size}
           data-testid="edsc-icon"
           aria-label={ariaLabel}
+          role="graphics-symbol"
           {...props}
         />
         {children}
@@ -85,6 +87,7 @@ export const EDSCIcon = forwardRef(({
           size={size}
           data-testid="edsc-icon-details"
           aria-label={ariaLabel}
+          role="graphics-symbol"
           {...props}
         />
         {children}
@@ -104,6 +107,7 @@ export const EDSCIcon = forwardRef(({
           size={size}
           aria-label={ariaLabel}
           data-testid="edsc-icon-details"
+          role="graphics-symbol"
           {...props}
         />
         {children}
@@ -122,6 +126,7 @@ export const EDSCIcon = forwardRef(({
         size={size}
         aria-label={ariaLabel}
         data-testid="edsc-icon"
+        role="graphics-symbol"
         {...props}
       />
       {children}

--- a/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleDownloadButton.jsx
@@ -39,7 +39,7 @@ export const GranuleDownloadButton = (props) => {
   if (tooManyGranules) {
     return (
       <OverlayTrigger
-        placement="bottom"
+        placement="top"
         overlay={
           (
             <Tooltip
@@ -62,7 +62,7 @@ export const GranuleDownloadButton = (props) => {
             className="granule-results-actions__download-all-button"
             dataTestId="granule-results-actions__download-all-button"
             badge={badge}
-            bootstrapVariant="secondary"
+            bootstrapVariant="primary"
             icon={Download}
             variant="full"
             label={buttonText}

--- a/static/src/js/components/GranuleResults/GranuleResultsActions.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsActions.scss
@@ -179,11 +179,6 @@
       align-items: center;
       justify-content: center;
     }
-
-    &:disabled {
-      background-color: utils.$color__carbon--60;
-      color: utils.$color__spacesuit-white;
-    }
   }
 
   &__project-pill-icon {

--- a/static/src/js/components/GranuleResults/GranuleResultsActions.scss
+++ b/static/src/js/components/GranuleResults/GranuleResultsActions.scss
@@ -179,6 +179,11 @@
       align-items: center;
       justify-content: center;
     }
+
+    &:disabled {
+      background-color: utils.$color__carbon--60;
+      color: utils.$color__spacesuit-white;
+    }
   }
 
   &__project-pill-icon {

--- a/static/src/js/components/GranuleResultsHighlights/GranuleResultsHighlights.scss
+++ b/static/src/js/components/GranuleResultsHighlights/GranuleResultsHighlights.scss
@@ -74,4 +74,8 @@
     padding: 0.325rem;
     text-align: center;
   }
+
+  &__empty {
+    margin: 0.75rem;
+  }
 }

--- a/static/src/js/components/MetaIcon/MetaIcon.jsx
+++ b/static/src/js/components/MetaIcon/MetaIcon.jsx
@@ -4,6 +4,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
+import NotAvailableIcon from '../NotAvailableIcon/NotAvailableIcon'
 
 import './MetaIcon.scss'
 
@@ -15,6 +16,7 @@ import './MetaIcon.scss'
  * @param {String} props.id - A unique element id.
  * @param {String|Element} props.label - Text or element to be used as the screen reader text label.
  * @param {String|Element} props.metadata - Text or element to be shown in the metadata pill.
+ * @param {Boolean} props.notAvailable - A boolean to show the not available icon.
  * @param {String} props.placement - A string to set the tooltip placement.
  * @param {String} props.tooltipClassName - A custom class name for tooltip.
  * @param {String|Element} props.tooltipContent - Text or element to be displayed in the tooltip.
@@ -26,18 +28,26 @@ export const MetaIcon = ({
   id,
   label,
   metadata,
+  notAvailable,
   placement,
   tooltipClassName,
   tooltipContent
 }) => {
   const component = (
     <span className={`meta-icon ${className}`}>
-      <EDSCIcon
-        className="meta-icon__icon"
-        size="1rem"
-        icon={icon}
-        {...iconProps}
-      />
+      <span className="meta-icon__icon-wrapper">
+        <EDSCIcon
+          className="meta-icon__icon"
+          size="1rem"
+          icon={icon}
+          {...iconProps}
+        />
+        {
+          notAvailable && (
+            <NotAvailableIcon size="1rem" />
+          )
+        }
+      </span>
       {
         label && (
           <span className="meta-icon__label visually-hidden">
@@ -84,6 +94,7 @@ MetaIcon.defaultProps = {
   className: '',
   iconProps: {},
   metadata: '',
+  notAvailable: false,
   placement: 'top',
   tooltipClassName: '',
   tooltipContent: null
@@ -109,6 +120,7 @@ MetaIcon.propTypes = {
     PropTypes.node,
     PropTypes.string
   ]),
+  notAvailable: PropTypes.bool,
   placement: PropTypes.string,
   tooltipClassName: PropTypes.string,
   tooltipContent: PropTypes.oneOfType([

--- a/static/src/js/components/MetaIcon/MetaIcon.scss
+++ b/static/src/js/components/MetaIcon/MetaIcon.scss
@@ -11,12 +11,20 @@
   letter-spacing: 0.01em;
 
   &__icon {
+    grid-area: 1 / 1 / 2 / 2;
     color: utils.$color__carbon--50;
     font-size: 0.75rem;
 
     .meta-icon:hover & {
       color: utils.$color__carbon--60;
     }
+  }
+
+  &__icon-wrapper {
+    display: grid;
+    grid-template-rows: 1fr;
+    grid-template-columns: 1fr;
+    place-items: center;
   }
 
   &__metadata {

--- a/static/src/js/components/MetaIcon/__tests__/MetaIcon.test.jsx
+++ b/static/src/js/components/MetaIcon/__tests__/MetaIcon.test.jsx
@@ -6,6 +6,9 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 
 import EDSCIcon from '../../EDSCIcon/EDSCIcon'
 import MetaIcon from '../MetaIcon'
+import NotAvailableIcon from '../../NotAvailableIcon/NotAvailableIcon'
+
+jest.mock('../../NotAvailableIcon/NotAvailableIcon', () => jest.fn(() => <div />))
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -116,6 +119,16 @@ describe('MetaIcon component', () => {
       })
 
       expect(enzymeWrapper.find('.meta-icon__metadata').text()).toEqual('test-metadata')
+    })
+  })
+
+  describe('when notAvailable is provided', () => {
+    test('should show the notAvailableIcon', () => {
+      const { enzymeWrapper } = setup({
+        notAvailable: true
+      })
+
+      expect(enzymeWrapper.find(NotAvailableIcon).length).toEqual(1)
     })
   })
 })

--- a/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
+++ b/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
@@ -10,6 +10,7 @@ const NotAvailableIcon = ({ size }) => (
     xmlns="http://www.w3.org/2000/svg"
     className="meta-icon__icon"
     role="graphics-symbol"
+    aria-label="A slash icon"
   >
     <path id="forground" fillRule="evenodd" clipRule="evenodd" d="M18.1484 20.0001L-0.000119153 1.85162L1.71094 0.140564L19.8594 18.2891L18.1484 20.0001Z" fill="currentColor" />
     <path id="background" fillRule="evenodd" clipRule="evenodd" d="M19.3584 18.7901L1.20992 0.641646L1.85156 0L20.0001 18.1485L19.3584 18.7901Z" fill="white" />

--- a/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
+++ b/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
@@ -14,7 +14,6 @@ const NotAvailableIcon = ({ size }) => (
     <path id="forground" fillRule="evenodd" clipRule="evenodd" d="M18.1484 20.0001L-0.000119153 1.85162L1.71094 0.140564L19.8594 18.2891L18.1484 20.0001Z" fill="currentColor" />
     <path id="background" fillRule="evenodd" clipRule="evenodd" d="M19.3584 18.7901L1.20992 0.641646L1.85156 0L20.0001 18.1485L19.3584 18.7901Z" fill="white" />
   </svg>
-
 )
 
 NotAvailableIcon.defaultProps = {

--- a/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
+++ b/static/src/js/components/NotAvailableIcon/NotAvailableIcon.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const NotAvailableIcon = ({ size }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="meta-icon__icon"
+    role="graphics-symbol"
+  >
+    <path id="forground" fillRule="evenodd" clipRule="evenodd" d="M18.1484 20.0001L-0.000119153 1.85162L1.71094 0.140564L19.8594 18.2891L18.1484 20.0001Z" fill="currentColor" />
+    <path id="background" fillRule="evenodd" clipRule="evenodd" d="M19.3584 18.7901L1.20992 0.641646L1.85156 0L20.0001 18.1485L19.3584 18.7901Z" fill="white" />
+  </svg>
+
+)
+
+NotAvailableIcon.defaultProps = {
+  size: '1rem'
+}
+
+NotAvailableIcon.propTypes = {
+  size: PropTypes.string
+}
+
+export default NotAvailableIcon

--- a/static/src/js/components/NotAvailableIcon/__tests__/NotAvailableIcon.test.jsx
+++ b/static/src/js/components/NotAvailableIcon/__tests__/NotAvailableIcon.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import NotAvailableIcon from '../NotAvailableIcon'
+
+describe('NotAvailableIcon component', () => {
+  test('sets width and height correctly', () => {
+    render(<NotAvailableIcon size="1rem" />)
+
+    const svg = screen.getByRole('graphics-symbol')
+
+    expect(svg).toHaveAttribute('width', '1rem')
+    expect(svg).toHaveAttribute('height', '1rem')
+  })
+})

--- a/static/src/js/components/SearchPanels/SearchPanels.jsx
+++ b/static/src/js/components/SearchPanels/SearchPanels.jsx
@@ -434,7 +434,7 @@ class SearchPanels extends PureComponent {
 
     if (isInternationalInteragency) {
       consortiumInfo = (
-        <Col className="search-panels__note">
+        <Col className="search-panels__note ms-3">
           {'This is '}
           <span className="search-panels__note-emph search-panels__note-emph--opensearch">Int&apos;l / Interagency Data</span>
           {' data. Searches will be performed by external services which may vary in performance and available features. '}
@@ -467,7 +467,7 @@ class SearchPanels extends PureComponent {
               {consortiumInfo}
               {
                 collectionIsCSDA && (
-                  <Col className="search-panels__note">
+                  <Col className="search-panels__note ms-3">
                     {'This collection is made available through the '}
                     <span className="search-panels__note-emph search-panels__note-emph--csda">NASA Commercial Smallsat Data Acquisition (CSDA) Program</span>
                     {' for NASA funded researchers. Access to the data will require additional authentication. '}

--- a/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.jsx
+++ b/static/src/js/components/SearchPanels/__tests__/SearchPanels.test.jsx
@@ -584,7 +584,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[1].props
 
-        expect(messageProps.className).toEqual('search-panels__note')
+        expect(messageProps.className).toEqual('search-panels__note ms-3')
         expect(shallow(messageProps.children[1]).text()).toContain('NASA Commercial Smallsat Data Acquisition (CSDA) Program')
       })
 
@@ -644,7 +644,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
 
-        expect(messageProps.className).toEqual('search-panels__note')
+        expect(messageProps.className).toEqual('search-panels__note ms-3')
         expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
       })
 
@@ -700,7 +700,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
 
-        expect(messageProps.className).toEqual('search-panels__note')
+        expect(messageProps.className).toEqual('search-panels__note ms-3')
         expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
       })
 
@@ -733,7 +733,7 @@ describe('SearchPanels component', () => {
         const granuleResultsPanelProps = granuleResultsPanel.props()
         const messageProps = granuleResultsPanelProps.headerMessage.props.children[0].props
 
-        expect(messageProps.className).toEqual('search-panels__note')
+        expect(messageProps.className).toEqual('search-panels__note ms-3')
         expect(shallow(messageProps.children[1]).text()).toContain('Int\'l / Interagency Data')
       })
 

--- a/static/src/js/components/Timeline/Timeline.scss
+++ b/static/src/js/components/Timeline/Timeline.scss
@@ -17,7 +17,8 @@
 
     &:hover,
     &:active {
-      color: utils.$color__carbon--5
+      color: utils.$color__carbon--5;
+      background-color: utils.$color__carbon--90;
     }
 
     &--open {


### PR DESCRIPTION
# Overview

### What is the feature?

Indicate when collections don't have features.

Various other visual updates found after the bootstrap upgrade.

### What is the Solution?

We are now always showing the 3 feature facet icons in the collection results list. When the collection does not have that feature we are displaying a slash through the icon, and updating the tooltip accordingly.

### What areas of the application does this impact?

Collection results list items

# Testing

View the collection results list. Check/uncheck the feature facets to see variations of icons

### Attachments

<img width="217" alt="Screenshot 2025-02-13 at 5 04 40 PM" src="https://github.com/user-attachments/assets/f9667fbf-c1ab-4e3a-ab0f-41ee97d0bcba" />
<img width="126" alt="Screenshot 2025-02-13 at 5 04 47 PM" src="https://github.com/user-attachments/assets/451d3f11-a69a-4655-be24-2476545dee6b" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
