### PR TITLE
EDSC-4351: Logs out user when database components are disabled

### DIFF
--- a/.github/bundle-size-comment-template.md
+++ b/.github/bundle-size-comment-template.md
@@ -61,13 +61,13 @@
   ```
 </details>
 
-{{#if diff.totalSize includeZero=false}}
+{{#if diff.totalSize > 0 includeZero=false}}
 The full bundle is larger than main by {{diff.totalSize}} kB. :exclamation:
 {{else}}
 The full bundle is smaller than main by {{diff.totalSize}} kB. :tada:
 {{/if}}
 
-{{#if diff.indexJsSize includeZero=false}}
+{{#if diff.indexJsSize > 0 includeZero=false}}
 The index.js is larger than main by {{diff.indexJsSize}} kB. :exclamation:
 {{else}}
 The index.js is smaller than main by {{diff.indexJsSize}} kB. :tada:

--- a/.github/bundle-size-comment-template.md
+++ b/.github/bundle-size-comment-template.md
@@ -10,43 +10,43 @@
     </tr>
   </thead>
 <tbody>
-  <tr style="{{#if diff.totalSize includeZero=false}}{{badStyle}}{{else if diff.totalSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isTotalBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>Total</td>
     <td>{{main.totalSize}} kB</td>
     <td>{{branch.totalSize}} kB</td>
     <td>{{diff.totalSize}} kB</td>
   </tr>
-  <tr style="{{#if diff.indexJsSize includeZero=false}}{{badStyle}}{{else if diff.indexJsSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isJsBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>index.js</td>
     <td>{{main.indexJsSize}} kB</td>
     <td>{{branch.indexJsSize}} kB</td>
     <td>{{diff.indexJsSize}} kB</td>
   </tr>
-  <tr style="{{#if diff.indexJsGzipSize includeZero=false}}{{badStyle}}{{else if diff.indexJsGzipSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isJsGzipBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>index.js (gzip)</td>
     <td>{{main.indexJsGzipSize}} kB</td>
     <td>{{branch.indexJsGzipSize}} kB</td>
     <td>{{diff.indexJsGzipSize}} kB</td>
   </tr>
-  <tr style="{{#if diff.indexJsGzipSize includeZero=false}}{{badStyle}}{{else if diff.indexJsGzipSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isCssBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>index.css</td>
     <td>{{main.indexCssSize}} kB</td>
     <td>{{branch.indexCssSize}} kB</td>
     <td>{{diff.indexCssSize}} kB</td>
   </tr>
-  <tr style="{{#if diff.indexJsGzipSize includeZero=false}}{{badStyle}}{{else if diff.indexJsGzipSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isCssGzipBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>index.css (gzip)</td>
     <td>{{main.indexCssGzipSize}} kB</td>
     <td>{{branch.indexCssGzipSize}} kB</td>
     <td>{{diff.indexCssGzipSize}} kB</td>
   </tr>
-  <tr style="{{#if diff.indexJsGzipSize includeZero=false}}{{badStyle}}{{else if diff.indexJsGzipSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isNumFilesBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>Number of files</td>
     <td>{{main.numFiles}}</td>
     <td>{{branch.numFiles}}</td>
     <td>{{diff.numFiles}}</td>
   </tr>
-  <tr style="{{#if diff.indexJsGzipSize includeZero=false}}{{badStyle}}{{else if diff.indexJsGzipSize includeZero=true}}{{else}}{{goodStyle}}{{/if}}">
+  <tr style="{{#if diff.isBuildTimeBigger}}{{badStyle}}{{else}}{{goodStyle}}{{/if}}">
     <td>Build Time</td>
     <td>{{main.buildTime}} s</td>
     <td>{{branch.buildTime}} s</td>
@@ -61,13 +61,13 @@
   ```
 </details>
 
-{{#if diff.totalSize > 0 includeZero=false}}
+{{#if diff.isTotalBigger}}
 The full bundle is larger than main by {{diff.totalSize}} kB. :exclamation:
 {{else}}
 The full bundle is smaller than main by {{diff.totalSize}} kB. :tada:
 {{/if}}
 
-{{#if diff.indexJsSize > 0 includeZero=false}}
+{{#if diff.isJsBigger}}
 The index.js is larger than main by {{diff.indexJsSize}} kB. :exclamation:
 {{else}}
 The index.js is smaller than main by {{diff.indexJsSize}} kB. :tada:

--- a/bin/compareBundleSize.mjs
+++ b/bin/compareBundleSize.mjs
@@ -100,6 +100,15 @@ values.diff = {
   numFiles: parseFloat((values.branch.numFiles - values.main.numFiles).toFixed(2))
 }
 
+// Handlebars helpers
+values.diff.isJsBigger = values.diff.indexJsSize > 0
+values.diff.isJsGzipBigger = values.diff.indexJsGzipSize > 0
+values.diff.isCssBigger = values.diff.indexCssSize > 0
+values.diff.isCssGzipBigger = values.diff.indexCssGzipSize > 0
+values.diff.isTotalBigger = values.diff.totalSize > 0
+values.diff.isBuildTimeBigger = values.diff.buildTime > 0
+values.diff.isNumFilesBigger = values.diff.numFiles > 0
+
 // Read handlebars template file
 const source = fs.readFileSync(templatePath, 'utf8')
 const template = Handlebars.compile(source)

--- a/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.jsx
+++ b/static/src/js/containers/AuthTokenContainer/AuthTokenContainer.jsx
@@ -5,6 +5,8 @@ import { connect } from 'react-redux'
 
 import actions from '../../actions/index'
 
+import { getApplicationConfig } from '../../../../../sharedUtils/config'
+
 export const mapDispatchToProps = (dispatch) => ({
   onSetContactInfoFromJwt:
     (token) => dispatch(actions.setContactInfoFromJwt(token)),
@@ -23,7 +25,17 @@ export const AuthTokenContainer = ({
   onSetUserFromJwt,
   onUpdateAuthToken
 }) => {
+  const { disableDatabaseComponents } = getApplicationConfig()
+
   useEffect(() => {
+    if (disableDatabaseComponents === 'true') {
+      // If we have set `disableDatabaseComponents` to true, we need to clear the authToken
+      // This will ensure that the user does not send requests to our API (which uses the database)
+      onUpdateAuthToken('')
+
+      return
+    }
+
     const jwtToken = get('authToken')
 
     onSetPreferencesFromJwt(jwtToken)

--- a/static/src/js/containers/AuthTokenContainer/__tests__/AuthTokenContainer.test.jsx
+++ b/static/src/js/containers/AuthTokenContainer/__tests__/AuthTokenContainer.test.jsx
@@ -5,6 +5,8 @@ import * as tinyCookie from 'tiny-cookie'
 import actions from '../../../actions'
 import { AuthTokenContainer, mapDispatchToProps } from '../AuthTokenContainer'
 
+import * as getApplicationConfig from '../../../../../../sharedUtils/config'
+
 jest.mock('tiny-cookie', () => ({
   get: jest.fn()
 }))
@@ -69,6 +71,10 @@ describe('AuthTokenContainer component', () => {
       return ''
     })
 
+    jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementationOnce(() => ({
+      disableDatabaseComponents: 'false'
+    }))
+
     const props = {
       children: 'children',
       onSetContactInfoFromJwt: jest.fn(),
@@ -78,13 +84,42 @@ describe('AuthTokenContainer component', () => {
     }
     setup(props)
 
-    expect(props.onUpdateAuthToken).toHaveBeenCalled()
-    expect(props.onUpdateAuthToken.mock.calls[0]).toEqual(['token'])
-    expect(props.onSetContactInfoFromJwt).toHaveBeenCalled()
-    expect(props.onSetContactInfoFromJwt.mock.calls[0]).toEqual(['token'])
-    expect(props.onSetPreferencesFromJwt).toHaveBeenCalled()
-    expect(props.onSetPreferencesFromJwt.mock.calls[0]).toEqual(['token'])
-    expect(props.onSetUserFromJwt).toHaveBeenCalled()
-    expect(props.onSetUserFromJwt.mock.calls[0]).toEqual(['token'])
+    expect(props.onUpdateAuthToken).toHaveBeenCalledTimes(1)
+    expect(props.onUpdateAuthToken).toHaveBeenCalledWith('token')
+
+    expect(props.onSetContactInfoFromJwt).toHaveBeenCalledTimes(1)
+    expect(props.onSetContactInfoFromJwt).toHaveBeenCalledWith('token')
+
+    expect(props.onSetPreferencesFromJwt).toHaveBeenCalledTimes(1)
+    expect(props.onSetPreferencesFromJwt).toHaveBeenCalledWith('token')
+
+    expect(props.onSetUserFromJwt).toHaveBeenCalledTimes(1)
+    expect(props.onSetUserFromJwt).toHaveBeenCalledWith('token')
+  })
+
+  describe('when disableDatabaseComponents is true', () => {
+    test('should call onUpdateAuthToken with an empty string', () => {
+      jest.spyOn(tinyCookie, 'get').mockImplementation((param) => {
+        if (param === 'authToken') return 'token'
+
+        return ''
+      })
+
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        disableDatabaseComponents: 'true'
+      }))
+
+      const props = {
+        children: 'children',
+        onSetContactInfoFromJwt: jest.fn(),
+        onSetPreferencesFromJwt: jest.fn(),
+        onSetUserFromJwt: jest.fn(),
+        onUpdateAuthToken: jest.fn()
+      }
+      setup(props)
+
+      expect(props.onUpdateAuthToken).toHaveBeenCalledTimes(1)
+      expect(props.onUpdateAuthToken).toHaveBeenCalledWith('')
+    })
   })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

When we disable database components, like for a maintance window, we need to log out the user to ensure that they are not sending requests to our API

### What areas of the application does this impact?

Search requests when the config value `disableDatabaseComponents` is set to `"true"`

# Testing

Login, then set `disableDatabaseComponents` to `"true"` in overrideStatic.config.json. Vite will reload the page, check the network tab in your browser devtools to ensure that the collections request went directly to CMR, and not to localhost:3001

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
