### PR TITLE
Update config.json: ECSE-1796 - renamed portal to Standard Data Produ…

### DIFF
--- a/portals/standardproducts/config.json
+++ b/portals/standardproducts/config.json
@@ -1,15 +1,15 @@
 {
-  "pageTitle": "Standard Products",
+  "pageTitle": "Standard Data Products",
   "parentConfig": "edsc",
   "portalBrowser": true,
-  "moreInfoUrl": "https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-standard-products",
+  "moreInfoUrl": "https://www.earthdata.nasa.gov/learn/earth-observation-data-basics/standard-data-products",
   "query": {
     "hasGranulesOrCwic": null,
     "standardProduct": true
   },
   "title": {
-    "primary": "Standard Products",
-    "secondary": "NASA EOSDIS Earth Science Standard Products"
+    "primary": "Standard Data Products",
+    "secondary": "NASA ESDIS Earth Science Standard Data Products"
   },
   "ui": {
     "showNonEosdisCheckbox": false,


### PR DESCRIPTION
…cts and change references to Standard Data Products.

# Overview

### What is the feature?

- EDSC "Standard Products" portal has been renamed to "Standard Data Products" portal
- In the description, change 'EOSDIS' to 'ESDIS'
- Make change in both Browse Portals' pop-up and in portals upper left title header.

### What is the Solution?

Portal name change that was requested by NASA HQ.

### What areas of the application does this impact?

Earthdata Search Client (EDSC) and ESDC Portals.

# Testing

### Reproduction steps

- **Environment for testing: Local test development environment on MacBook.**
- **Collection to test with: all NASA Standard Data Products.**
See EDSC ReadME: https://github.com/mmorahan/earthdata-search/blob/master/README.md

1. Review upper left corner for Portal name.
2. Click on Portal's logo box the link should go to "https://www.earthdata.nasa.gov/learn/earth-observation-data-basics/standard-data-products".
3. Click on "Browse Portals" box and then look for the "Standard Data Products" Portal's link box.
4. Click on the "More Info" link to be redirected to "https://www.earthdata.nasa.gov/learn/earth-observation-data-basics/standard-data-products".

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
![Standard_Data_Products_portal](https://github.com/user-attachments/assets/7be21b89-daaf-4637-9f71-f63b0818b649)

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
