### PR TITLE
EDSC-4409: Remove the place labels from Earthdata Search

### DIFF
--- a/static/src/js/containers/MapContainer/MapWrapper.jsx
+++ b/static/src/js/containers/MapContainer/MapWrapper.jsx
@@ -177,7 +177,7 @@ const MapWrapper = ({
           />
         </LayersControl.Overlay>
         <LayersControl.Overlay
-          checked={overlays.referenceLabels}
+          checked={false}
           name="Place Labels *"
         >
           <LayerBuilder


### PR DESCRIPTION
# Overview

### What is the feature?

Removing the Place Labels from the map on Earthdata Search.

### What is the Solution?

- Removed the option to add/remove Place Labels on the map so it longer shows place labels.
- Removed Place Labels as an option in User Preferences.

### What areas of the application does this impact?

- EDSC Map
- Leaflet Toolbar
- User Preferences

# Testing

1. Navigate to EDSC home page
2. Verify that Place Labels are not showing anywhere on the map
3. Verify that the Leaflet Toolbar does not have the 'Place Labels' checkbox available beneath 'Borders and Roads' and 'Coastlines'
4. Navigate to User Preferences
5. Verify that 'Place Labels' are no longer present as an option under 'Overlay Layers'

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
