### PR TITLE
EDSC-4423 Render colormaps on the open layers map

### DIFF
--- a/serverless/src/util/getQueueUrl.js
+++ b/serverless/src/util/getQueueUrl.js
@@ -20,7 +20,7 @@ export const getQueueUrl = (queueName) => {
     case QUEUE_NAMES.CatalogRestOrderQueue:
       return isOffline ? `${localPrefix}CatalogRestOrderQueue` : process.env.CATALOG_REST_QUEUE_URL
     case QUEUE_NAMES.ColorMapQueue:
-      return isOffline ? `${localPrefix}ColorMapQueue` : process.env.COLOR_MAP_QUEUE_URL
+      return isOffline ? `${localPrefix}ColorMapsProcessingQueue` : process.env.COLOR_MAP_QUEUE_URL
     case QUEUE_NAMES.CmrOrderingOrderQueue:
       return isOffline ? `${localPrefix}CmrOrderingOrderQueue` : process.env.CMR_ORDERING_ORDER_QUEUE_URL
     case QUEUE_NAMES.HarmonyOrderQueue:

--- a/static/src/js/components/Legend/Legend.scss
+++ b/static/src/js/components/Legend/Legend.scss
@@ -18,28 +18,6 @@
     pointer-events: none;
   }
 
-  &__bar {
-    margin: 0.125rem;
-    display: block;
-    height: 1rem;
-    width: 15rem;
-    border-radius: 0.125rem;
-    opacity: 0;
-    visibility: visible;
-    transition: opacity 0.2s ease;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-
-    &:hover {
-      cursor: crosshair;
-    }
-
-    .legend--is-colormap-rendered & {
-      visibility: visible;
-      opacity: 1;
-    }
-  }
-
   &__labels {
     display: flex;
     justify-content: space-between;

--- a/static/src/js/components/Legend/LegendControl.jsx
+++ b/static/src/js/components/Legend/LegendControl.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Control from 'ol/control/Control'
+import Legend from './Legend'
+
+/**
+ * OpenLayers control for displaying the Legend component
+ * @param {Object} options - The options to configure the LegendControl
+ * @param {Object} options.colorMap - The colormap data to display in the legend
+ * @param {Boolean} options.isFocusedCollectionPage - Whether the current page is a focused collection page
+ * @param {HTMLElement} options.target - The target element for the control
+ */
+export class LegendControl extends Control {
+  constructor(options) {
+    const element = document.createElement('div')
+    element.className = 'ol-control edsc-map-legend'
+
+    super({
+      element,
+      target: options.target
+    })
+
+    this.colorMap = options.colorMap
+    this.isFocusedCollectionPage = options.isFocusedCollectionPage
+    this.render()
+  }
+
+  render() {
+    if (this.isFocusedCollectionPage && this.colorMap && Object.keys(this.colorMap).length > 0) {
+      console.log('rendering legend')
+      ReactDOM.render(
+        <Legend colorMap={this.colorMap} />,
+        this.element
+      )
+    } else {
+      console.log('unmounting legend')
+      ReactDOM.render(null, this.element)
+    }
+  }
+}

--- a/static/src/js/components/Legend/LegendControl.jsx
+++ b/static/src/js/components/Legend/LegendControl.jsx
@@ -8,7 +8,7 @@ import Legend from './Legend'
  * @param {Object} options - The options to configure the LegendControl
  * @param {Object} options.colorMap - The colormap data to display in the legend
  * @param {Boolean} options.isFocusedCollectionPage - Whether the current page is a focused collection page
- * @param {HTMLElement} options.target - The target element for the control
+ * @param {HTMLElement|string} [options.target] - The DOM element or element ID where this control should be rendered instead of the default map controls container
  */
 export class LegendControl extends Control {
   constructor(options) {
@@ -22,19 +22,9 @@ export class LegendControl extends Control {
 
     this.colorMap = options.colorMap
     this.isFocusedCollectionPage = options.isFocusedCollectionPage
-    this.render()
-  }
-
-  render() {
-    if (this.isFocusedCollectionPage && this.colorMap && Object.keys(this.colorMap).length > 0) {
-      console.log('rendering legend')
-      ReactDOM.render(
-        <Legend colorMap={this.colorMap} />,
-        this.element
-      )
-    } else {
-      console.log('unmounting legend')
-      ReactDOM.render(null, this.element)
-    }
+    ReactDOM.render(
+      <Legend colorMap={this.colorMap} />,
+      this.element
+    )
   }
 }

--- a/static/src/js/components/Map/Map.jsx
+++ b/static/src/js/components/Map/Map.jsx
@@ -85,7 +85,7 @@ const createView = ({
   return view
 }
 
-// Scale controls and attribution
+// TODO Might want to move these out of this file at some point
 const scaleMetric = new ScaleLine({
   className: 'edsc-map-scale-metric',
   units: 'metric'
@@ -134,6 +134,8 @@ const Map = ({
 }) => {
   // This is the width of the side panels. We need to know this so we can adjust the padding
   // on the map view when the panels are resized.
+  // We adjust the padding so that centering the map on a point will center the point in the
+  // viewable area of the map and not behind a panel.
   const { panelsWidth } = useContext(PanelWidthContext)
 
   // Create a ref for the map and the map dome element
@@ -219,7 +221,32 @@ const Map = ({
     })
 
     return () => map.setTarget(null)
-  }, [projectionCode, isFocusedCollectionPage, colorMap])
+  }, [projectionCode])
+
+  useEffect(() => {
+    // When colorMap or isFocusedCollectionPage changes, remove the existing legend control
+    // and add a new one if necessary.
+    const map = mapRef.current
+    const controls = map.getControls()
+    const legendControl = controls.getArray().find(
+      (control) => control instanceof LegendControl
+    )
+
+    // Always remove existing legend control if present
+    if (legendControl) {
+      controls.remove(legendControl)
+    }
+
+    // Add new legend control only if on focused collection page and colorMap exists
+    if (isFocusedCollectionPage && colorMap && Object.keys(colorMap).length > 0) {
+      controls.push(
+        new LegendControl({
+          colorMap,
+          isFocusedCollectionPage
+        })
+      )
+    }
+  }, [isFocusedCollectionPage, colorMap])
 
   useEffect(() => {
     // When the panelsWidth changes, update the padding on the map view.

--- a/static/src/js/components/Map/Map.jsx
+++ b/static/src/js/components/Map/Map.jsx
@@ -4,7 +4,6 @@ import React, {
   useRef
 } from 'react'
 import PropTypes from 'prop-types'
-
 import OlMap from 'ol/Map'
 import View from 'ol/View'
 import ScaleLine from 'ol/control/ScaleLine'
@@ -18,6 +17,7 @@ import { FaHome } from 'react-icons/fa'
 
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
 import ZoomControl from './ZoomControl'
+import { LegendControl } from '../Legend/LegendControl'
 import ProjectionSwitcherControl from './ProjectionSwitcherControl'
 
 import PanelWidthContext from '../../contexts/PanelWidthContext'
@@ -85,7 +85,7 @@ const createView = ({
   return view
 }
 
-// TODO Might want to move these out of this file at some point
+// Scale controls and attribution
 const scaleMetric = new ScaleLine({
   className: 'edsc-map-scale-metric',
   units: 'metric'
@@ -118,21 +118,22 @@ const zoomControl = (projectionCode) => new ZoomControl({
  * @param {String} params.projectionCode Projection code of the map
  * @param {Number} params.rotation Rotation of the map
  * @param {Number} params.zoom Zoom level of the map
+ * @param {Object} params.colorMap Color map for the focused collection
  * @param {Function} params.onChangeMap Function to call when the map is updated
  * @param {Function} params.onChangeProjection Function to call when the projection is changed
  */
 const Map = ({
   center,
+  colorMap,
+  isFocusedCollectionPage,
+  onChangeMap,
+  onChangeProjection,
   projectionCode,
   rotation,
-  zoom,
-  onChangeMap,
-  onChangeProjection
+  zoom
 }) => {
   // This is the width of the side panels. We need to know this so we can adjust the padding
   // on the map view when the panels are resized.
-  // We adjust the padding so that centering the map on a point will center the point in the
-  // viewable area of the map and not behind a panel.
   const { panelsWidth } = useContext(PanelWidthContext)
 
   // Create a ref for the map and the map dome element
@@ -148,6 +149,10 @@ const Map = ({
         zoomControl(projectionCode),
         new ProjectionSwitcherControl({
           onChangeProjection
+        }),
+        new LegendControl({
+          colorMap,
+          isFocusedCollectionPage
         })
       ],
       interactions: defaultInteractions().extend([
@@ -214,7 +219,7 @@ const Map = ({
     })
 
     return () => map.setTarget(null)
-  }, [projectionCode])
+  }, [projectionCode, isFocusedCollectionPage, colorMap])
 
   useEffect(() => {
     // When the panelsWidth changes, update the padding on the map view.
@@ -325,7 +330,9 @@ Map.propTypes = {
   rotation: PropTypes.number.isRequired,
   zoom: PropTypes.number.isRequired,
   onChangeMap: PropTypes.func.isRequired,
-  onChangeProjection: PropTypes.func.isRequired
+  onChangeProjection: PropTypes.func.isRequired,
+  isFocusedCollectionPage: PropTypes.bool.isRequired,
+  colorMap: PropTypes.shape({}).isRequired
 }
 
 export default Map

--- a/static/src/js/components/Map/Map.scss
+++ b/static/src/js/components/Map/Map.scss
@@ -3,13 +3,18 @@
 .edsc-map-zoom,
 .edsc-map-projection-switcher,
 .edsc-map-scale-imperial,
-.edsc-map-scale-metric {
+.edsc-map-scale-metric,
+.edsc-map-legend {
   position: absolute;
   z-index: 10;
-  right: .75rem;
+  right: 0.75rem;
   color: utils.$color__spacesuit-white;
   background-color: utils.$color__carbon--70;
   text-shadow: utils.$shadow__panel-dark;
+}
+
+.edsc-map-legend {
+  top: 45px;
 }
 
 .edsc-map-scale-imperial {
@@ -26,11 +31,6 @@
 
 .edsc-map-zoom {
   bottom: 92px;
-}
-
-.edsc-map-legend {
-  right: .75rem;
-  top: 40px;
 }
 
 .edsc-map-projection-switcher {

--- a/static/src/js/components/Map/Map.scss
+++ b/static/src/js/components/Map/Map.scss
@@ -3,18 +3,10 @@
 .edsc-map-zoom,
 .edsc-map-projection-switcher,
 .edsc-map-scale-imperial,
-.edsc-map-legend {
-  position: absolute;
-  z-index: 1;
-  right: 0.5rem;
-  background-color: transparent;
-  bottom: 310px;
-  line-height: 1.5;
-}
 .edsc-map-scale-metric {
   position: absolute;
   z-index: 10;
-  right: 0.5rem;
+  right: .75rem;
   color: utils.$color__spacesuit-white;
   background-color: utils.$color__carbon--70;
   text-shadow: utils.$shadow__panel-dark;
@@ -34,6 +26,11 @@
 
 .edsc-map-zoom {
   bottom: 92px;
+}
+
+.edsc-map-legend {
+  right: .75rem;
+  top: 40px;
 }
 
 .edsc-map-projection-switcher {

--- a/static/src/js/components/Map/Map.scss
+++ b/static/src/js/components/Map/Map.scss
@@ -3,6 +3,14 @@
 .edsc-map-zoom,
 .edsc-map-projection-switcher,
 .edsc-map-scale-imperial,
+.edsc-map-legend {
+  position: absolute;
+  z-index: 1;
+  right: 0.5rem;
+  background-color: transparent;
+  bottom: 310px;
+  line-height: 1.5;
+}
 .edsc-map-scale-metric {
   position: absolute;
   z-index: 10;
@@ -67,5 +75,31 @@
     height: 1.75rem;
     background-color: none;
     border: none;
+  }
+}
+
+.ol-viewport {
+  .legend {
+    &__bar {
+      margin: 0.125rem;
+      display: block;
+      height: 1rem;
+      width: 15rem;
+      border-radius: 0.125rem;
+      opacity: 0;
+      visibility: visible;
+      transition: opacity 0.2s ease;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+  
+      &:hover {
+        cursor: crosshair;
+      }
+    }
+
+    &--is-colormap-rendered .legend__bar {
+      visibility: visible;
+      opacity: 1;
+    }
   }
 }

--- a/static/src/js/components/Map/Map.scss
+++ b/static/src/js/components/Map/Map.scss
@@ -14,6 +14,7 @@
 }
 
 .edsc-map-legend {
+  background-color: transparent;
   top: 45px;
 }
 

--- a/static/src/js/containers/MapContainer/MapContainer.jsx
+++ b/static/src/js/containers/MapContainer/MapContainer.jsx
@@ -244,13 +244,16 @@ export const MapContainer = (props) => {
     callbackOnChangeMap({ ...newMap })
   }, [projection])
 
+  // Get the metadata for the currently focused collection, or an empty object if no collection is focused
   const focusedCollectionMetadata = useMemo(() => collectionsMetadata[focusedCollectionId] || {}, [focusedCollectionId, collectionsMetadata])
 
+  // Get the colormap data for the currently focused collection
   const colorMapState = useMemo(() => {
     const { tags } = focusedCollectionMetadata
     const [gibsTag] = getValueForTag('gibs', tags) || []
     let colorMapData = {}
 
+    // If the collection has a GIBS tag and the GIBS layer is available for the current projection, use the colormap data
     if (gibsTag && hasGibsLayerForProjection(gibsTag, projection)) {
       const { product } = gibsTag
       colorMapData = colormapsMetadata[product] || {}

--- a/static/src/js/containers/MapContainer/MapContainer.jsx
+++ b/static/src/js/containers/MapContainer/MapContainer.jsx
@@ -35,12 +35,12 @@ import { projectionConfigs } from '../../util/map/crs'
 import murmurhash3 from '../../util/murmurhash3'
 import hasGibsLayerForProjection from '../../util/hasGibsLayerForProjection'
 import { getValueForTag } from '../../../../../sharedUtils/tags'
-// Import '../../util/map/sphericalPolygon'
+// import '../../util/map/sphericalPolygon'
 
 // import 'leaflet/dist/leaflet.css'
 import './MapContainer.scss'
 
-// Import MapWrapper from './MapWrapper'
+// import MapWrapper from './MapWrapper'
 import Map from '../../components/Map/Map'
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/static/src/js/containers/MapContainer/MapContainer.jsx
+++ b/static/src/js/containers/MapContainer/MapContainer.jsx
@@ -259,7 +259,8 @@ export const MapContainer = (props) => {
     return colorMapData
   }, [focusedCollectionMetadata, colormapsMetadata, projection])
 
-  const { colorMapData: colorMap } = colorMapState
+ 
+  const { colorMapData: colorMap = {} } = colorMapState
 
   // Projection switching in leaflet is not supported. Here we render MapWrapper with a key of the projection prop.
   // So when the projection is changed in ProjectionSwitcher this causes the map to unmount and remount a new instance,

--- a/tests/e2e/map/map_granules.spec.js
+++ b/tests/e2e/map/map_granules.spec.js
@@ -36,7 +36,7 @@ import opensearchGranulesHeaders from './__mocks__/opensearch_granules/granules.
 import opensearchGranulesTimelineBody from './__mocks__/opensearch_granules/timeline.body.json'
 import opensearchGranulesTimelineHeaders from './__mocks__/opensearch_granules/timeline.headers.json'
 
-test.describe.skip('Map: Granule interactions', () => {
+test.describe('Map: Granule interactions', () => {
   test.beforeEach(async ({ page, context, browserName }) => {
     await setupTests({
       browserName,
@@ -51,7 +51,7 @@ test.describe.skip('Map: Granule interactions', () => {
     })
   })
 
-  test.describe('When viewing granule results', () => {
+  test.describe.skip('When viewing granule results', () => {
     test.describe('When viewing CMR granules', () => {
       test.beforeEach(async ({ page }) => {
         const conceptId = 'C1214470488-ASF'
@@ -367,10 +367,11 @@ test.describe.skip('Map: Granule interactions', () => {
     })
 
     test('displays the color map on the page', async ({ page }) => {
+      await page.getByTestId('legend').scrollIntoViewIfNeeded()
       await expect(page).toHaveScreenshot('colormap-screenshot.png', {
         clip: {
           x: 1138,
-          y: 263,
+          y: 433,
           width: 252,
           height: 47
         }
@@ -413,7 +414,7 @@ test.describe.skip('Map: Granule interactions', () => {
           await expect(page).toHaveScreenshot('colormap-2-screenshot.png', {
             clip: {
               x: 1138,
-              y: 260,
+              y: 433,
               width: 252,
               height: 47
             }
@@ -427,7 +428,7 @@ test.describe.skip('Map: Granule interactions', () => {
 
     test.describe('when switching the projection', () => {
       test.beforeEach(async ({ page }) => {
-        await page.getByTestId('projection-switcher__arctic').click()
+        await page.getByLabel('North Polar Stereographic').click()
       })
 
       test('does not show the colormap', async ({ page }) => {
@@ -436,7 +437,7 @@ test.describe.skip('Map: Granule interactions', () => {
 
       test.describe('when switching back to the geographic projection', () => {
         test.beforeEach(async ({ page }) => {
-          await page.getByTestId('projection-switcher__geo').click()
+          await page.getByLabel('Geographic (Equirectangular)').click()
         })
 
         test('displays the colormap', async ({ page }) => {
@@ -446,7 +447,7 @@ test.describe.skip('Map: Granule interactions', () => {
     })
   })
 
-  test.describe('when viewing a granule that crosses the antimeridian twice', () => {
+  test.describe.skip('when viewing a granule that crosses the antimeridian twice', () => {
     test.beforeEach(async ({ page }) => {
       const conceptId = 'C1258816710-ASDC_DEV2'
 

--- a/tests/e2e/map/map_granules.spec.js
+++ b/tests/e2e/map/map_granules.spec.js
@@ -370,8 +370,8 @@ test.describe('Map: Granule interactions', () => {
       await page.getByTestId('legend').scrollIntoViewIfNeeded()
       await expect(page).toHaveScreenshot('colormap-screenshot.png', {
         clip: {
-          x: 1138,
-          y: 433,
+          x: 1135,
+          y: 85,
           width: 252,
           height: 47
         }
@@ -413,8 +413,8 @@ test.describe('Map: Granule interactions', () => {
 
           await expect(page).toHaveScreenshot('colormap-2-screenshot.png', {
             clip: {
-              x: 1138,
-              y: 433,
+              x: 1135,
+              y: 85,
               width: 252,
               height: 47
             }


### PR DESCRIPTION
# Overview

### What is the feature?

Add the existing Legend component into the OpenLayers controls framework

### What is the Solution?

Created a OpenLayers control (LegendControl.jsx) wrapping the Legend.jsx component, added into the OpenLayers map controls object, moved the existing gibs color map logics into MapContainer, added/moved css into Map.scss file to css the new LegendControl, reenabled and fixed color map playwright e2e tests.

### What areas of the application does this impact?

The new OpenLayers map is impacted.

# Testing

### Reproduction steps

- **Environment for testing:**
- Prod data
- **Collection to test with:**
- C1243477369-GES_DISC

1. Search C1243477369-GES_DISC
2. Navigate to focused collection page
3. Verify colormap/legend is rendered with the other map controls

### Attachments

<img width="1061" alt="Screenshot 2025-03-11 at 1 00 19 PM" src="https://github.com/user-attachments/assets/eecf23c7-cc01-4605-bd02-60495881b101" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
