### PR TITLE
EDSC-4406: "Download granule data" tooltip is not showing for single granule downloads

### DIFF
--- a/static/src/js/components/Button/Button.jsx
+++ b/static/src/js/components/Button/Button.jsx
@@ -13,6 +13,7 @@ import './Button.scss'
 
 export const Button = React.forwardRef(({
   as,
+  ariaLabel,
   badge,
   badgeVariant,
   bootstrapVariant,
@@ -93,7 +94,7 @@ export const Button = React.forwardRef(({
       title={title || label}
       role="button"
       label={label}
-      aria-label={label}
+      aria-label={ariaLabel || label}
       type={type}
       disabled={disabled || spinner}
       target={target}
@@ -162,6 +163,7 @@ export const Button = React.forwardRef(({
 Button.displayName = 'Button'
 
 Button.defaultProps = {
+  ariaLabel: null,
   as: 'button',
   badge: null,
   badgeVariant: null,
@@ -191,6 +193,7 @@ Button.defaultProps = {
 }
 
 Button.propTypes = {
+  ariaLabel: PropTypes.string,
   as: PropTypes.string,
   badge: PropTypes.oneOfType([
     PropTypes.string,

--- a/static/src/js/components/Button/__tests__/Button.test.jsx
+++ b/static/src/js/components/Button/__tests__/Button.test.jsx
@@ -12,7 +12,8 @@ Enzyme.configure({ adapter: new Adapter() })
 function setup(type) {
   const props = {
     onClick: jest.fn(),
-    label: 'Test Label'
+    label: 'Test Label',
+    ariaLabel: 'Test aria Label'
   }
 
   if (type === 'icon') {
@@ -92,7 +93,7 @@ describe('Button component', () => {
 
   test('should render self with an aria-label', () => {
     const { enzymeWrapper } = setup()
-    expect(enzymeWrapper.find('button').prop('aria-label')).toEqual('Test Label')
+    expect(enzymeWrapper.find('button').prop('aria-label')).toEqual('Test aria Label')
   })
 
   test('should render self with an label', () => {

--- a/static/src/js/components/EDSCTable/EDSCTable.jsx
+++ b/static/src/js/components/EDSCTable/EDSCTable.jsx
@@ -142,7 +142,7 @@ innerElementType.displayName = 'EDSCTableInnerElement'
  * @param {Function} props.loadMoreItems - Callback to load the next page of results.
  * @param {Function} props.initialRowStateAccessor - initialRowStateAccessor to be passed to react-table.
  * @param {Function} props.rowClassNamesFromRowState - Callback to determine the classnames of a row based on its state.
- * @param {Function} props.rowTitleFromRowState - Callback to determine the title attribute of a row based on its state.
+ * @param {Function} props.rowLabelFromRowState - Callback to determine the title attribute of a row based on its state.
  * @param {Function} props.onRowClick - Callback for onRowClick.
  * @param {Function} props.onRowMouseEnter - Callback for onRowMouseEnter.
  * @param {Function} props.onRowMouseLeave - Callback for onRowMouseLeave.
@@ -318,12 +318,14 @@ const EDSCTable = ({
       })
 
       let rowClassesFromState = []
-      const rowTitleFromState = {
+      const rowLabelFromState = {
         ariaLabel: undefined
       }
 
       if (rowClassNamesFromRowState) rowClassesFromState = rowClassNamesFromRowState(row.state)
-      if (rowLabelFromRowState) rowTitleFromState.ariaLabel = rowLabelFromRowState(row.state)
+      if (rowLabelFromRowState) {
+        rowLabelFromState.ariaLabel = rowLabelFromRowState(row.state)
+      }
 
       const { style: rowStyle, ...rowRest } = rowProps
 
@@ -388,7 +390,7 @@ const EDSCTable = ({
             data-testid={rowTestId}
             {...rowEvents}
             {...focusableProps}
-            aria-label={rowTitleFromState.ariaLabel}
+            aria-labelledby={rowLabelFromState.ariaLabel}
           >
             {
               row.cells.map((cell) => {

--- a/static/src/js/components/EDSCTable/EDSCTable.jsx
+++ b/static/src/js/components/EDSCTable/EDSCTable.jsx
@@ -167,7 +167,7 @@ const EDSCTable = ({
   initialRowStateAccessor,
   initialTableState,
   rowClassNamesFromRowState,
-  rowTitleFromRowState,
+  rowLabelFromRowState,
   onRowClick,
   onRowMouseEnter,
   onRowMouseLeave,
@@ -319,11 +319,11 @@ const EDSCTable = ({
 
       let rowClassesFromState = []
       const rowTitleFromState = {
-        title: undefined
+        ariaLabel: undefined
       }
 
       if (rowClassNamesFromRowState) rowClassesFromState = rowClassNamesFromRowState(row.state)
-      if (rowTitleFromRowState) rowTitleFromState.title = rowTitleFromRowState(row.state)
+      if (rowLabelFromRowState) rowTitleFromState.ariaLabel = rowLabelFromRowState(row.state)
 
       const { style: rowStyle, ...rowRest } = rowProps
 
@@ -388,7 +388,7 @@ const EDSCTable = ({
             data-testid={rowTestId}
             {...rowEvents}
             {...focusableProps}
-            {...rowTitleFromState}
+            aria-label={rowTitleFromState.ariaLabel}
           >
             {
               row.cells.map((cell) => {
@@ -519,7 +519,7 @@ EDSCTable.defaultProps = {
   onRowMouseLeave: null,
   onRowMouseUp: null,
   rowClassNamesFromRowState: null,
-  rowTitleFromRowState: null,
+  rowLabelFromRowState: null,
   rowTestId: null,
   setVisibleMiddleIndex: null,
   striped: false,
@@ -544,7 +544,7 @@ EDSCTable.propTypes = {
   onRowMouseLeave: PropTypes.func,
   onRowMouseUp: PropTypes.func,
   rowClassNamesFromRowState: PropTypes.func,
-  rowTitleFromRowState: PropTypes.func,
+  rowLabelFromRowState: PropTypes.func,
   rowTestId: PropTypes.string,
   setVisibleMiddleIndex: PropTypes.func,
   striped: PropTypes.bool,

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
@@ -37,7 +37,8 @@ export const CustomDataLinksToggle = React.forwardRef(({
       type="button"
       icon={Download}
       ref={ref}
-      label="Download granule data"
+      ariaLabel="Download granule data"
+      label=""
       tooltip="Download granule data"
       tooltipId={`download-granule-tooltip-${id}`}
       onClick={handleClick}
@@ -305,7 +306,8 @@ export const GranuleResultsDataLinksButton = ({
           }
         }
         rel="noopener noreferrer"
-        label="Download granule data"
+        ariaLabel="Download granule data"
+        label=""
         tooltip="Download granule data"
         tooltipId={`download-granule-tooltip-${id}`}
         target="_blank"

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
@@ -38,8 +38,6 @@ export const CustomDataLinksToggle = React.forwardRef(({
       icon={Download}
       ref={ref}
       ariaLabel="Download granule data"
-      // Empty label is needed to prevent row title from popping up during table view
-      label=""
       tooltip="Download granule data"
       tooltipId={`download-granule-tooltip-${id}`}
       onClick={handleClick}
@@ -308,8 +306,6 @@ export const GranuleResultsDataLinksButton = ({
         }
         rel="noopener noreferrer"
         ariaLabel="Download granule data"
-        // Empty label is needed to prevent row title from popping up during table view
-        label=""
         tooltip="Download granule data"
         tooltipId={`download-granule-tooltip-${id}`}
         target="_blank"

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
@@ -38,6 +38,7 @@ export const CustomDataLinksToggle = React.forwardRef(({
       icon={Download}
       ref={ref}
       ariaLabel="Download granule data"
+      // Empty label is needed to prevent row title from popping up during table view
       label=""
       tooltip="Download granule data"
       tooltipId={`download-granule-tooltip-${id}`}
@@ -307,6 +308,7 @@ export const GranuleResultsDataLinksButton = ({
         }
         rel="noopener noreferrer"
         ariaLabel="Download granule data"
+        // Empty label is needed to prevent row title from popping up during table view
         label=""
         tooltip="Download granule data"
         tooltipId={`download-granule-tooltip-${id}`}

--- a/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsDataLinksButton.jsx
@@ -306,6 +306,8 @@ export const GranuleResultsDataLinksButton = ({
         }
         rel="noopener noreferrer"
         label="Download granule data"
+        tooltip="Download granule data"
+        tooltipId={`download-granule-tooltip-${id}`}
         target="_blank"
       />
     )

--- a/static/src/js/components/GranuleResults/GranuleResultsItem.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsItem.jsx
@@ -258,7 +258,7 @@ const GranuleResultsItem = forwardRef(({
                       <Button
                         className="button granule-results-item__button granule-results-item__button--add"
                         tooltip="Add granule to project"
-                        label="Add granule to project"
+                        ariaLabel="Add granule to project"
                         tooltipId={`add-granule-tooltip-${id}`}
                         disabled={isOpenSearch}
                         onClick={
@@ -288,7 +288,7 @@ const GranuleResultsItem = forwardRef(({
                         className="button granule-results-item__button granule-results-item__button--remove"
                         tooltip="Remove granule from project"
                         tooltipId={`remove-granule-tooltip-${id}`}
-                        label="Remove granule from project"
+                        ariaLabel="Remove granule from project"
                         onClick={
                           (event) => {
                             onRemoveGranuleFromProjectCollection({

--- a/static/src/js/components/GranuleResults/GranuleResultsTable.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsTable.jsx
@@ -153,12 +153,12 @@ export const GranuleResultsTable = ({
     return classNames
   })
 
-  const rowTitleFromRowState = useCallback(({ isFocusedGranule }) => {
-    let rowTitle = 'Focus granule on map'
+  const rowLabelFromRowState = useCallback(({ isFocusedGranule }) => {
+    let rowLabel = 'Focus granule on map'
 
-    if (isFocusedGranule) rowTitle = 'Unfocus granule on map'
+    if (isFocusedGranule) rowLabel = 'Unfocus granule on map'
 
-    return rowTitle
+    return rowLabel
   })
 
   const onRowClick = useCallback((e, row) => {
@@ -210,7 +210,7 @@ export const GranuleResultsTable = ({
         striped
         initialRowStateAccessor={initialRowStateAccessor}
         rowClassNamesFromRowState={rowClassNamesFromRowState}
-        rowTitleFromRowState={rowTitleFromRowState}
+        rowLabelFromRowState={rowLabelFromRowState}
         onRowMouseEnter={onRowMouseEnter}
         onRowMouseLeave={onRowMouseLeave}
         onRowClick={onRowClick}

--- a/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
@@ -82,6 +82,7 @@ const GranuleResultsTableHeaderCell = (props) => {
                   className="button granule-results-table__granule-action granule-results-table__granule-action--add"
                   type="button"
                   ariaLabel="Add granule to project"
+                  // Empty label is needed to prevent row title from popping up during table view
                   label=""
                   tooltip="Add granule to project"
                   tooltipId={`add-granule-table-tooltip-${id}`}
@@ -112,6 +113,7 @@ const GranuleResultsTableHeaderCell = (props) => {
                   className="button granule-results-table__granule-action granule-results-table__granule-action--remove"
                   type="button"
                   ariaLabel="Remove granule from project"
+                  // Empty label is needed to prevent row title from popping up during table view
                   label=""
                   tooltip="Remove granule from project"
                   tooltipId={`remove-granule-table-tooltip-${id}`}

--- a/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
@@ -81,7 +81,8 @@ const GranuleResultsTableHeaderCell = (props) => {
                 <Button
                   className="button granule-results-table__granule-action granule-results-table__granule-action--add"
                   type="button"
-                  label="Add granule to project"
+                  ariaLabel="Add granule to project"
+                  label=""
                   tooltip="Add granule to project"
                   tooltipId={`add-granule-table-tooltip-${id}`}
                   icon={Plus}
@@ -110,7 +111,8 @@ const GranuleResultsTableHeaderCell = (props) => {
                 <Button
                   className="button granule-results-table__granule-action granule-results-table__granule-action--remove"
                   type="button"
-                  label="Remove granule from project"
+                  ariaLabel="Remove granule from project"
+                  label=""
                   tooltip="Remove granule from project"
                   tooltipId={`remove-granule-table-tooltip-${id}`}
                   icon={Minus}

--- a/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
+++ b/static/src/js/components/GranuleResults/GranuleResultsTableHeaderCell.jsx
@@ -82,8 +82,6 @@ const GranuleResultsTableHeaderCell = (props) => {
                   className="button granule-results-table__granule-action granule-results-table__granule-action--add"
                   type="button"
                   ariaLabel="Add granule to project"
-                  // Empty label is needed to prevent row title from popping up during table view
-                  label=""
                   tooltip="Add granule to project"
                   tooltipId={`add-granule-table-tooltip-${id}`}
                   icon={Plus}
@@ -113,8 +111,6 @@ const GranuleResultsTableHeaderCell = (props) => {
                   className="button granule-results-table__granule-action granule-results-table__granule-action--remove"
                   type="button"
                   ariaLabel="Remove granule from project"
-                  // Empty label is needed to prevent row title from popping up during table view
-                  label=""
                   tooltip="Remove granule from project"
                   tooltipId={`remove-granule-table-tooltip-${id}`}
                   icon={Minus}

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.jsx
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.jsx
@@ -101,6 +101,13 @@ describe('GranuleResultsDataLinksButton component', () => {
 
       expect(enzymeWrapper.type()).toBe(Button)
     })
+
+    test.only('has a tooltip', async () => {
+      const { enzymeWrapper } = setup()
+
+      expect(enzymeWrapper.prop('tooltip')).toBe('Download granule data')
+      expect(enzymeWrapper.prop('tooltipId')).toBe('download-granule-tooltip-G123456789-TEST')
+    })
   })
 
   describe('with multiple granule links', () => {

--- a/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.jsx
+++ b/static/src/js/components/GranuleResults/__tests__/GranuleResultsDataLinksButton.test.jsx
@@ -102,7 +102,7 @@ describe('GranuleResultsDataLinksButton component', () => {
       expect(enzymeWrapper.type()).toBe(Button)
     })
 
-    test.only('has a tooltip', async () => {
+    test('has a tooltip', async () => {
       const { enzymeWrapper } = setup()
 
       expect(enzymeWrapper.prop('tooltip')).toBe('Download granule data')


### PR DESCRIPTION
# Overview

### What is the feature?

Adding missing Download granule tooltip for granules with only one file

### What is the Solution?

Added the tooltip and tooltipId to the button for the single file path cleaned up extra labels on the other buttons and this one. Removed the title from the table row so that it does not appear when hovering over buttons in table view

### What areas of the application does this impact?

Tooltip for single granule downloads; EDSC table; granule results on the table view

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Go to https://search.earthdata.nasa.gov/search/granules?p=C179001903-SEDAC&pg[0][v]=f&pg[0][gsk]=-start_date&fdc=Socioeconomic%20Data%20and%20Applications%20Center%20(SEDAC)&as[organization][0]=Socioeconomic%20Data%20and%20Applications%20Center%20(SEDAC)&tl=1739469321.207!3!!&lat=80.015625
2. Hover your mouse over the download button for the granule. Make sure the "Download Granule Data" tooltip shows up.

### Attachments
![image](https://github.com/user-attachments/assets/6f39c3e8-97fd-4fd9-8d10-614ec4fd0e0f)
![image](https://github.com/user-attachments/assets/23e4fdd5-3d13-452a-bd96-30046160a935)
![image](https://github.com/user-attachments/assets/b6665ee6-0e1d-4c4a-912d-4f714946a7f5)



# Checklist

- [x ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
