### PR TITLE
EDSC-4285: Improve display of links on cloud access panel on granule results

### DIFF
--- a/static/src/css/modules/_links.scss
+++ b/static/src/css/modules/_links.scss
@@ -31,16 +31,18 @@
   }
 
   &--separated {
-    &:before {
+    &:after {
       display: inline-block;
       margin-left: calc(bootstrap.$spacer / 2);
-      padding-left: calc(bootstrap.$spacer / 2);
+      // -0.25rem is used here to remove the extra space between the separator and the link due to
+      // the trailing space added to inline-block elements.
+      padding-left: calc(bootstrap.$spacer  / 2 - 0.25rem);
       content: '|';
       color: transparent;
       border-left: 1px solid variables.$color__carbon--30;
     }
 
-    &:first-child:before {
+    &:last-child:after {
       display: none;
     }
   }

--- a/static/src/js/components/CollectionDetails/CollectionDetailsCloudAccessInstance.jsx
+++ b/static/src/js/components/CollectionDetails/CollectionDetailsCloudAccessInstance.jsx
@@ -117,10 +117,10 @@ export const CollectionDetailsCloudAccessInstance = ({
         }
         <dt>AWS S3 Credentials</dt>
         <dd className="direct-distribution-information__links--horizontal">
-          <ExternalLink href={s3CredentialsApiEndpoint} className="collection-details-cloud-access-direct-distribution-information__link">
+          <ExternalLink href={s3CredentialsApiEndpoint} className="link--separated collection-details-cloud-access-direct-distribution-information__link">
             Get AWS S3 Credentials
           </ExternalLink>
-          <ExternalLink href={s3CredentialsApiDocumentationUrl} className="link--separated collection-details-cloud-access-direct-distribution-information__link">
+          <ExternalLink href={s3CredentialsApiDocumentationUrl} className="collection-details-cloud-access-direct-distribution-information__link">
             Documentation
           </ExternalLink>
         </dd>

--- a/static/src/js/components/ExternalLink/ExternalLink.jsx
+++ b/static/src/js/components/ExternalLink/ExternalLink.jsx
@@ -14,9 +14,10 @@ export const ExternalLink = ({
   innerLink,
   ...rest
 }) => {
-  const classes = classNames([
-    'external-link link--external',
+  const wrapperClasses = classNames([
     {
+      // If this is an inner link, the external link class needs to be added to the wrapping element
+      'external-link': innerLink,
       'link--light': variant === 'light'
     },
     className
@@ -25,8 +26,8 @@ export const ExternalLink = ({
   // If the link has a parent link this is needed to avoid DOM warnings while keeping styling
   if (innerLink) {
     return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-      <span className={classes} {...rest}>
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <span className={wrapperClasses} {...rest}>
         {children}
         <EDSCIcon
           className="external-link__icon"
@@ -38,15 +39,17 @@ export const ExternalLink = ({
   }
 
   return (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-    <a className={classes} target="_blank" rel="noopener noreferrer" {...rest}>
-      {children}
-      <EDSCIcon
-        className="external-link__icon"
-        icon={ArrowLineDiagonal}
-        size="0.875em"
-      />
-    </a>
+    <span className={wrapperClasses}>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <a className="link link--external" target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+        <EDSCIcon
+          className="external-link__icon"
+          icon={ArrowLineDiagonal}
+          size="0.875em"
+        />
+      </a>
+    </span>
   )
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

For separated links, the underline and spacing was displaying incorrectly.

<img width="658" alt="Screenshot 2025-03-14 at 2 46 57 PM" src="https://github.com/user-attachments/assets/afa775bb-7dee-4ca6-8423-74bdc8887bbe" />
<img width="668" alt="Screenshot 2025-03-14 at 2 47 05 PM" src="https://github.com/user-attachments/assets/fb8790db-8ca6-4b9c-8e38-d45108753197" />

### What is the Solution?

Updated CSS to utilize transform and translateX to center the separator, changed the pseudo element before child (the separator) to use an absolute position relative to its parent(the link), added margin left to the parent to adjust and make room for the separator on every child but the first child.  This avoids the margin being included in the first link in a list.

### What areas of the application does this impact?

_link.scss, CollectionDetailsCloudAccessInstance.jsx, S3LinksPanel.jsx, GranuleResultsDataLinksButton.jsx

# Testing

### Reproduction steps

1. Navigate to collection details page.
2. View relatedUrl links.
3. Navigate to granule results page.
4. Click download granule data button
5. Select AWS S3 Access
6. View AWS S3 Credentials: links

### Attachments

<img width="965" alt="Screenshot 2025-03-14 at 3 08 39 PM" src="https://github.com/user-attachments/assets/12b1e125-f92a-48b4-aa3c-cc0d5c6889f7" />
<img width="733" alt="Screenshot 2025-03-14 at 3 08 34 PM" src="https://github.com/user-attachments/assets/d3e5badd-67b6-4111-bea1-b14c2d4dbb47" />
<img width="768" alt="Screenshot 2025-03-14 at 3 08 29 PM" src="https://github.com/user-attachments/assets/0bb2a144-d5b7-452a-a27c-a24cdd36fb18" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
