### PR TITLE
EDSC-3620: Commafying FacetsItems totals

### DIFF
--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{commafy(facet.count || '')}</span> }
+          { (!applied || !children) && facet.count && <span className="facets-item__total">{commafy(facet.count)}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -9,6 +9,7 @@ import { FaQuestionCircle } from 'react-icons/fa'
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
 import { generateFacetArgs } from '../../util/facets'
+import { commafy } from '../../util/commafy'
 
 import './FacetsItem.scss'
 
@@ -144,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{facet.count}</span> }
+          { (!applied || !children) && <span className="facets-item__total">{`${commafy(facet.count)}`}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{`${commafy(facet.count)}`}</span> }
+          { (!applied || !children) && <span className="facets-item__total">{commafy(facet.count || '')}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>


### PR DESCRIPTION
# Overview

### What is the feature?

Commafying the facet item totals

### What is the Solution?

Calling commafy on the total

### What areas of the application does this impact?

Facets and the Facet modals

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Navigate to EDSC and view the Facet lists. Make sure any facets over 999 have commas.

### Attachments
<img width="877" alt="Screenshot 2025-03-17 at 5 34 34 PM" src="https://github.com/user-attachments/assets/2346733a-3a8b-4659-9595-db12923e3e08" />
<img width="303" alt="Screenshot 2025-03-17 at 5 33 00 PM" src="https://github.com/user-attachments/assets/9639548d-8522-4ec1-9da8-a235c6b7aa90" />


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
