### PR TITLE
EDSC-3620: Commafying the facet item totals with explicit check for undefined count

### DIFF
--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && (facet.count !== undefined) && <span className="facets-item__total">{commafy(facet.count)}</span> }
+          { (!applied || !children) && (facet.count != null) && <span className="facets-item__total">{commafy(facet.count)}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{commafy(facet.count || '')}</span> }
+          { (!applied || !children) && facet.count && <span className="facets-item__total">{commafy(facet.count)}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -9,6 +9,7 @@ import { FaQuestionCircle } from 'react-icons/fa'
 import EDSCIcon from '../EDSCIcon/EDSCIcon'
 
 import { generateFacetArgs } from '../../util/facets'
+import { commafy } from '../../util/commafy'
 
 import './FacetsItem.scss'
 
@@ -144,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{facet.count}</span> }
+          { (!applied || !children) && <span className="facets-item__total">{`${commafy(facet.count)}`}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && <span className="facets-item__total">{`${commafy(facet.count)}`}</span> }
+          { (!applied || !children) && <span className="facets-item__total">{commafy(facet.count || '')}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>

--- a/static/src/js/components/Facets/FacetsItem.jsx
+++ b/static/src/js/components/Facets/FacetsItem.jsx
@@ -145,7 +145,7 @@ class FacetsItem extends Component {
               )
             }
           </div>
-          { (!applied || !children) && facet.count && <span className="facets-item__total">{commafy(facet.count)}</span> }
+          { (!applied || !children) && (facet.count !== undefined) && <span className="facets-item__total">{commafy(facet.count)}</span> }
         </label>
         { children && <ul className="facets-list">{children}</ul> }
       </li>


### PR DESCRIPTION
# Overview

### What is the feature?

Commafying the facet item totals

### What is the Solution?

Calling commafy on the total only if facet.count is defined.

### What areas of the application does this impact?
Facets and the Facet modals

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Navigate to EDSC and view the Facet lists. Make sure any facets over 999 have commas.
Make sure any facets with 0 such as NISAR are the same color as other totals.

### Attachments

<img width="306" alt="Screenshot 2025-03-19 at 9 52 08 PM" src="https://github.com/user-attachments/assets/56b1b8d5-1faa-4c31-a380-ed2db4c4cbec" />


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
