### PR TITLE
EDSC-4386: Improving display of collection names in timeline

### DIFF
--- a/static/src/js/components/Timeline/Timeline.scss
+++ b/static/src/js/components/Timeline/Timeline.scss
@@ -4,6 +4,21 @@
   position: relative;
   z-index: 3;
 
+  // TODO: These overrides should not be necessary and should be fixed in EDSC-4473
+  .edsc-timeline-primary-section__title {
+    color: utils.$color__spacesuit-white;
+    line-height: 1;
+    font-size: 1rem;
+    font-weight: 400;
+  }
+
+  // TODO: These overrides should not be necessary and should be fixed in EDSC-4473
+  .edsc-timeline-primary-section__entry {
+    text-shadow:
+      1px 1px 0 rgba(utils.$color__carbon-black, 0.75),
+      0 0 0.75rem rgba(utils.$color__carbon-black, 0.75);
+  }
+
   &__container {
     display: flex;
 


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes issue with the timeline collection names

### What is the Solution?

Temporarily adding some overrides in Earthdata Search to fix some unintended overrides. Long term, this will be fixed in Timeline via EDSC-4473.

### What areas of the application does this impact?

Timeline

# Testing

### Reproduction steps

- **Environment for testing:** Any
- **Collection to test with:** Any

1. Focus on a collection and view the timeline
2. Confirm text is displayed as intended

### Attachments

Improved collection names:
<img width="933" alt="image" src="https://github.com/user-attachments/assets/14e22aad-0422-46b4-bab3-8abafd47dbfc" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
