### PR TITLE
EDSC-4480: Fixes ChunkedOrderModalContainer

### DIFF
--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -248,7 +248,6 @@ class App extends Component {
                           <AboutCSDAModalContainer />
                           <AboutCwicModalContainer />
                           <EditSubscriptionModalContainer />
-                          <ChunkedOrderModalContainer />
                           <DeprecatedParameterModalContainer />
                           <KeyboardShortcutsModalContainer />
                           <ShapefileDropzoneContainer />
@@ -259,6 +258,7 @@ class App extends Component {
                       <Route path={this.portalPaths('/projects')}>
                         <Suspense fallback={<Spinner type="dots" className="root__spinner spinner spinner--dots spinner--small" />}>
                           <AboutCSDAModalContainer />
+                          <ChunkedOrderModalContainer />
                         </Suspense>
                       </Route>
                       <Route path={this.portalPaths('/downloads')}>


### PR DESCRIPTION
# Overview

### What is the feature?

The ChunkedOrderModalContainer was being loaded on the `/search` route and not on the `/projects` route, where it is needed.

### What areas of the application does this impact?

Submitting an order with more than 2000 granules

# Testing

Submitting [this project](http://localhost:8080/projects?p=!C1908350066-LPDAAC_ECS&pg[1][v]=t&pg[1][m]=esi0&pg[1][cd]=f&q=C1908350066-LPDAAC_ECS&tl=1650438374.511!4!!) should show the modal

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
