### PR TITLE
EDSC-4490: Fixes normalizeSpatial where polygon points cannot be interpolated

### DIFF
--- a/static/src/js/util/map/__tests__/normalizeSpatial.test.ts
+++ b/static/src/js/util/map/__tests__/normalizeSpatial.test.ts
@@ -1,5 +1,12 @@
 import normalizeSpatial from '../normalizeSpatial'
 
+// @ts-expect-error The file does not have types
+import configureStore from '../../../store/configureStore'
+// @ts-expect-error The file does not have types
+import actions from '../../../actions'
+
+jest.mock('../../../store/configureStore', () => jest.fn())
+
 describe('normalizeSpatial', () => {
   describe('when the granule has no spatial information', () => {
     test('returns null', () => {
@@ -524,6 +531,59 @@ describe('normalizeSpatial', () => {
               ]
             ]
           }
+        })
+      })
+    })
+
+    describe('when the polygon has points that can not be interpolated', () => {
+      test('returns a geojson multi polygon of the original points and logs the error', () => {
+        const handleErrorMock = jest.spyOn(actions, 'handleError').mockImplementation(() => {})
+        const mockDispatch = jest.fn()
+        configureStore.mockReturnValue({
+          dispatch: mockDispatch,
+          getState: () => ({})
+        })
+
+        const granule = {
+          polygons: [
+            ['-90 -180 -90 180 90 180 90 -180 -90 -180']
+          ]
+        }
+
+        const response = normalizeSpatial(granule)
+
+        expect(response).toEqual({
+          geometry: {
+            coordinates: [
+              [
+                [
+                  [-180, -90],
+                  [180, -90],
+                  [180, 90],
+                  [-180, 90],
+                  [-180, -90]
+                ]
+              ]
+            ],
+            type: 'MultiPolygon'
+          },
+          properties: {},
+          type: 'Feature'
+        })
+
+        expect(handleErrorMock).toHaveBeenCalledTimes(2)
+        expect(handleErrorMock).toHaveBeenNthCalledWith(1, {
+          action: 'interpolatePolygon',
+          error: expect.any(Error),
+          message: expect.stringContaining('Error interpolating points: start: 180,-90, end: 180,90. All coordiates: [{"lat":-90,"lng":-180},{"lat":-90,"lng":180},{"lat":90,"lng":180},{"lat":90,"lng":-180},{"lat":-90,"lng":-180}].'),
+          notificationType: 'none'
+        })
+
+        expect(handleErrorMock).toHaveBeenNthCalledWith(2, {
+          action: 'interpolatePolygon',
+          error: expect.any(Error),
+          message: expect.stringContaining('Error interpolating points: start: -180,90, end: -180,-90. All coordiates: [{"lat":-90,"lng":-180},{"lat":-90,"lng":180},{"lat":90,"lng":180},{"lat":90,"lng":-180},{"lat":-90,"lng":-180}].'),
+          notificationType: 'none'
         })
       })
     })

--- a/static/src/js/util/map/normalizeSpatial.ts
+++ b/static/src/js/util/map/normalizeSpatial.ts
@@ -27,6 +27,11 @@ import {
   PolygonString
 } from '../../types/sharedTypes'
 
+// @ts-expect-error The file does not have types
+import configureStore from '../../store/configureStore'
+// @ts-expect-error The file does not have types
+import actions from '../../actions'
+
 const { mapPointsSimplifyThreshold } = getApplicationConfig()
 
 // This function adds points to the polygon so that the polygon follows the curvature of the Earth
@@ -56,29 +61,42 @@ export const interpolatePolygon = (coordinates: { lng: number, lat: number }[]) 
     // Add 10 points to the total to ensure there are always a good number of points for smooth curves
     const numberOfPoints = Math.floor(distancePercentage * maxPoints) + 10
 
-    // Interpolate the points between the two coordinates
-    const turfInterpolated = greatCircle(
-      coordinate,
-      nextCoordinate,
-      { npoints: numberOfPoints }
-    )
+    try {
+      // Interpolate the points between the two coordinates
+      const turfInterpolated = greatCircle(
+        coordinate,
+        nextCoordinate,
+        { npoints: numberOfPoints }
+      )
 
-    flattenEach(turfInterpolated, (currentFeature) => {
-      const flattenedCoords = currentFeature.geometry.coordinates
+      flattenEach(turfInterpolated, (currentFeature) => {
+        const flattenedCoords = currentFeature.geometry.coordinates
 
-      flattenedCoords.forEach((flattenedCoord, index) => {
-        // The first and last points are the same as the original points, don't add them again
-        if (index === 0 || index === flattenedCoords.length - 1) return
+        flattenedCoords.forEach((flattenedCoord, index) => {
+          // The first and last points are the same as the original points, don't add them again
+          if (index === 0 || index === flattenedCoords.length - 1) return
 
-        const nextFlattenedCoord = flattenedCoords[index + 1]
+          const nextFlattenedCoord = flattenedCoords[index + 1]
 
-        // If the next point is too close (< 100km) to the current point, don't add it
-        const pointDistance = distance(flattenedCoord as Coord, nextFlattenedCoord as Coord)
-        if (pointDistance < 100) return
+          // If the next point is too close (< 100km) to the current point, don't add it
+          const pointDistance = distance(flattenedCoord as Coord, nextFlattenedCoord as Coord)
+          if (pointDistance < 100) return
 
-        interpolatedCoordinates.push(flattenedCoord)
+          interpolatedCoordinates.push(flattenedCoord)
+        })
       })
-    })
+    } catch (error) {
+      const {
+        dispatch: reduxDispatch
+      } = configureStore()
+
+      reduxDispatch(actions.handleError({
+        action: 'interpolatePolygon',
+        error,
+        message: `Error interpolating points: start: ${coordinate}, end: ${nextCoordinate}. All coordiates: ${JSON.stringify(coordinates)}. Full error: ${error}`,
+        notificationType: 'none'
+      }))
+    }
   }
 
   // `greatCircle` sometimes changes the last point slightly. We want to keep the original point to ensure the polygon is closed


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes normalizeSpatial where polygon points cannot be interpolated

### What is the Solution?

The points 180,90 and 180,-90 cannot be interpolate by Turf's greatCircle, and it throws an error. If an error occurs while interpolating two points, catch the error, log it, and don't add any extra points to the shape.

### What areas of the application does this impact?

Showing spatial on the map or collection details minimap

# Testing

This collection uses a polygon to represent the whole Earth, and shows the error described above.
http://localhost:8080/search/granules/collection-details?p=C2627883499-LARC_ASDC&pg[0][v]=f&q=CERES%20EBAF

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
