### PR TITLE
EDSC-4502: Fixes bug in EDD redirect

### DIFF
--- a/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.jsx
+++ b/static/src/js/containers/AuthCallbackContainer/AuthCallbackContainer.jsx
@@ -61,7 +61,12 @@ export const AuthCallbackContainer = ({
         })
 
         // Redirect to the edd callback
-        history.push('/earthdata-download-callback')
+        setTimeout(() => {
+          // There is a bug in this redirect because UrlQueryContainer is triggering updates from both Redux and Zustand (for now). For some reason that is causing the URL to stay on /auth_callback instead of redirecting to /earthdata-download-callback.
+
+          // This setTimeout should only be temporary, it should be removed once UrlQueryContainer is removed.
+          history.push('/earthdata-download-callback')
+        }, 0)
 
         return
       }


### PR DESCRIPTION
# Overview

### What is the feature?

Implementing Zustand has broken the EDD redirect after the user logs in. UrlQueryContainer is being re-rendered an extra time because Redux props are changing, but the Zustand store is also changing. A `setTimeout` in AuthCallbackContainer wrapping the redirect to `/earthdata-download-callback` solves this issue, but it should be removed after UrlQueryContainer is removed (after Zustand is handling the URL)

### What areas of the application does this impact?

Earthdata Download redirects

# Testing

Delete your token from EDD, then start a new download. You will get redirected through EDSC to login with EDL, then ensure EDSC redirects you back to EDD

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
