### PR TITLE
EDSC-4479: Fix temporal selection dropdown uses outside of the landing page

### DIFF
--- a/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetrics.test.jsx
+++ b/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetrics.test.jsx
@@ -1,66 +1,42 @@
-import React from 'react'
 import ReactDOM from 'react-dom'
-import {
-  render,
-  screen,
-  waitFor
-} from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 
-import userEvent from '@testing-library/user-event'
-
-import { BrowserRouter } from 'react-router-dom'
-import { Provider } from 'react-redux'
-import configureMockStore from 'redux-mock-store'
+import setupTest from '../../../../../../jestConfigs/setupTest'
 
 import { AdminRetrievalsMetrics } from '../AdminRetrievalsMetrics'
 
-const mockStore = configureMockStore()
-const store = mockStore({})
-
-const setup = () => {
-  const retrievalsMetrics = {
-    isLoaded: true,
-    isLoading: false,
-    accessMethodType: {},
-    allAccessMethodTypes: [
-    ],
-    multCollectionResponse: [],
-    byAccessMethodType: {},
-    startDate: '',
-    endDate: ''
-  }
-  const onFetchAdminRetrievalsMetrics = jest.fn()
-  const onUpdateAdminRetrievalsMetricsStartDate = jest.fn()
-  const onUpdateAdminRetrievalsMetricsEndDate = jest.fn()
-
-  const props = {
-    onFetchAdminRetrievalsMetrics,
-    onUpdateAdminRetrievalsMetricsStartDate,
-    onUpdateAdminRetrievalsMetricsEndDate,
-    retrievalsMetrics
-  }
-
-  // https://testing-library.com/docs/example-react-router/
-  // Wrapping this in a Redux provider because DatepickerContainer has to be connected to Redux
-  render(
-    <Provider store={store}>
-      <BrowserRouter>
-        <AdminRetrievalsMetrics {...props} />
-      </BrowserRouter>
-    </Provider>
-  )
-
-  return {
-    onFetchAdminRetrievalsMetrics,
-    onUpdateAdminRetrievalsMetricsStartDate,
-    onUpdateAdminRetrievalsMetricsEndDate
-  }
+const defaultRetrievalsMetrics = {
+  isLoaded: true,
+  isLoading: false,
+  accessMethodType: {},
+  allAccessMethodTypes: [],
+  multCollectionResponse: [],
+  byAccessMethodType: {},
+  startDate: '',
+  endDate: ''
 }
+// DatepickerContainer connects to redux store and router
+const setup = setupTest({
+  Component: AdminRetrievalsMetrics,
+  defaultProps: {
+    retrievalsMetrics: defaultRetrievalsMetrics,
+    onFetchAdminRetrievalsMetrics: jest.fn(),
+    onUpdateAdminRetrievalsMetricsStartDate: jest.fn(),
+    onUpdateAdminRetrievalsMetricsEndDate: jest.fn()
+  },
+  withRedux: true,
+  withRouter: true
+})
 
-describe('AdminRetrievals component', () => {
-  test('renders itself correctly', () => {
-    setup()
-    expect(screen.getByText('Enter a value for the temporal filter')).toBeInTheDocument()
+describe('AdminRetrievalsMetrics component', () => {
+  describe('when the component loads', () => {
+    test('prompts the user to enter a temporal filter', () => {
+      setup()
+
+      expect(
+        screen.getByText('Enter a value for the temporal filter')
+      ).toBeInTheDocument()
+    })
   })
 
   describe('when filtering temporally', () => {
@@ -73,12 +49,7 @@ describe('AdminRetrievals component', () => {
     })
 
     test('clicking on the temporal filter modal opens it', async () => {
-      const user = userEvent.setup()
-      const {
-        onFetchAdminRetrievalsMetrics,
-        onUpdateAdminRetrievalsMetricsStartDate,
-        onUpdateAdminRetrievalsMetricsEndDate
-      } = setup()
+      const { user, props } = setup()
 
       const temporalFilterButton = screen.getByRole('button')
       await waitFor(async () => {
@@ -93,11 +64,11 @@ describe('AdminRetrievals component', () => {
       const startDate = screen.getByRole('textbox', { name: 'Start Date' })
       const endDate = screen.getByRole('textbox', { name: 'End Date' })
 
-      await userEvent.click(startDate)
-      await userEvent.type(startDate, validStartDate)
+      await user.click(startDate)
+      await user.type(startDate, validStartDate)
 
-      await userEvent.click(endDate)
-      await userEvent.type(endDate, validEndDate)
+      await user.click(endDate)
+      await user.type(endDate, validEndDate)
 
       const applyBtn = screen.getByRole('button', { name: 'Apply' })
 
@@ -106,13 +77,13 @@ describe('AdminRetrievals component', () => {
         await user.click(applyBtn)
       })
 
-      expect(onUpdateAdminRetrievalsMetricsStartDate).toHaveBeenCalledTimes(1)
-      expect(onUpdateAdminRetrievalsMetricsStartDate).toHaveBeenCalledWith(validStartDate)
+      expect(props.onUpdateAdminRetrievalsMetricsStartDate).toHaveBeenCalledTimes(1)
+      expect(props.onUpdateAdminRetrievalsMetricsStartDate).toHaveBeenCalledWith(validStartDate)
 
-      expect(onUpdateAdminRetrievalsMetricsEndDate).toHaveBeenCalledTimes(1)
-      expect(onUpdateAdminRetrievalsMetricsEndDate).toHaveBeenCalledWith(updatedEndDate)
+      expect(props.onUpdateAdminRetrievalsMetricsEndDate).toHaveBeenCalledTimes(1)
+      expect(props.onUpdateAdminRetrievalsMetricsEndDate).toHaveBeenCalledWith(updatedEndDate)
 
-      expect(onFetchAdminRetrievalsMetrics).toHaveBeenCalledTimes(1)
+      expect(props.onFetchAdminRetrievalsMetrics).toHaveBeenCalledTimes(1)
 
       const startDateHeader = screen.getAllByRole('heading', { level: 5 })[0]
       const endDateHeader = screen.getAllByRole('heading', { level: 5 })[1]

--- a/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetricsList.test.jsx
+++ b/static/src/js/components/AdminRetrievalsMetrics/__tests__/AdminRetrievalsMetricsList.test.jsx
@@ -1,26 +1,26 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+
+import setupTest from '../../../../../../jestConfigs/setupTest'
 
 import { AdminRetrievalsMetricsList } from '../AdminRetrievalsMetricsList'
 
-const setup = (overrideProps) => {
-  const props = {
-    retrievalsMetrics: {
-      isLoaded: true,
-      isLoading: false,
-      accessMethodType: {},
-      allAccessMethodTypes: [
-      ],
-      multCollectionResponse: [],
-      byAccessMethodType: {},
-      startDate: '',
-      endDate: ''
-    },
-    ...overrideProps
-  }
-
-  render(<AdminRetrievalsMetricsList {...props} />)
+const defaultRetrievalsMetrics = {
+  isLoaded: true,
+  isLoading: false,
+  accessMethodType: {},
+  allAccessMethodTypes: [],
+  multCollectionResponse: [],
+  byAccessMethodType: {},
+  startDate: '',
+  endDate: ''
 }
+
+const setup = setupTest({
+  Component: AdminRetrievalsMetricsList,
+  defaultProps: {
+    retrievalsMetrics: defaultRetrievalsMetrics
+  }
+})
 
 describe('AdminRetrievalsList component', () => {
   test('renders itself correctly', () => {
@@ -58,89 +58,91 @@ describe('AdminRetrievalsList component', () => {
 
   test('renders the collections table when collections are provided', () => {
     setup({
-      retrievalsMetrics: {
-        allAccessMethodTypes: [
-          'ESI',
-          'Harmony',
-          'OPeNDAP',
-          'ECHO ORDERS',
-          'download'
-        ],
-        accessMethodType: {},
-        multCollectionResponse: [
-          {
-            retrieval_id: 112,
-            count: '2'
+      overrideProps: {
+        retrievalsMetrics: {
+          allAccessMethodTypes: [
+            'ESI',
+            'Harmony',
+            'OPeNDAP',
+            'ECHO ORDERS',
+            'download'
+          ],
+          accessMethodType: {},
+          multCollectionResponse: [
+            {
+              retrieval_id: 112,
+              count: '2'
+            },
+            {
+              retrieval_id: 5,
+              count: '2'
+            },
+            {
+              retrieval_id: 74,
+              count: '3'
+            },
+            {
+              retrieval_id: 110,
+              count: '2'
+            }
+          ],
+          isLoading: false,
+          isLoaded: true,
+          sortKey: '',
+          pagination: {
+            pageSize: 20,
+            pageNum: 1,
+            pageCount: null,
+            totalResults: null
           },
-          {
-            retrieval_id: 5,
-            count: '2'
-          },
-          {
-            retrieval_id: 74,
-            count: '3'
-          },
-          {
-            retrieval_id: 110,
-            count: '2'
-          }
-        ],
-        isLoading: false,
-        isLoaded: true,
-        sortKey: '',
-        pagination: {
-          pageSize: 20,
-          pageNum: 1,
-          pageCount: null,
-          totalResults: null
-        },
-        startDate: '2019-02-12T00:00:00.000Z',
-        endDate: '2023-09-28T23:59:59.999Z',
-        byAccessMethodType: {
-          ESI: {
-            access_method_type: 'ESI',
-            total_times_access_method_used: '1',
-            average_granule_count: '3',
-            average_granule_link_count: '0',
-            total_granules_retrieved: '3',
-            max_granule_link_count: 0,
-            min_granule_link_count: 0
-          },
-          Harmony: {
-            access_method_type: 'Harmony',
-            total_times_access_method_used: '1',
-            average_granule_count: '59416',
-            average_granule_link_count: null,
-            total_granules_retrieved: '59416',
-            max_granule_link_count: 143,
-            min_granule_link_count: null
-          },
-          OPeNDAP: {
-            access_method_type: 'OPeNDAP',
-            total_times_access_method_used: '2',
-            average_granule_count: '1',
-            average_granule_link_count: null,
-            total_granules_retrieved: '2',
-            max_granule_link_count: null,
-            min_granule_link_count: null
-          },
-          'ECHO ORDERS': {
-            access_method_type: 'ECHO ORDERS',
-            total_times_access_method_used: '3',
-            average_granule_count: '7',
-            average_granule_link_count: null,
-            total_granules_retrieved: '22',
-            max_granule_link_count: null,
-            min_granule_link_count: null
-          },
-          download: {
-            access_method_type: 'download',
-            total_times_access_method_used: '121',
-            average_granule_count: '208',
-            average_granule_link_count: '33',
-            total_granules_retrieved: '25218',
-            max_granule_link_count: 167,
-            min_granule_link_count: 0
+          startDate: '2019-02-12T00:00:00.000Z',
+          endDate: '2023-09-28T23:59:59.999Z',
+          byAccessMethodType: {
+            ESI: {
+              access_method_type: 'ESI',
+              total_times_access_method_used: '1',
+              average_granule_count: '3',
+              average_granule_link_count: '0',
+              total_granules_retrieved: '3',
+              max_granule_link_count: 0,
+              min_granule_link_count: 0
+            },
+            Harmony: {
+              access_method_type: 'Harmony',
+              total_times_access_method_used: '1',
+              average_granule_count: '59416',
+              average_granule_link_count: null,
+              total_granules_retrieved: '59416',
+              max_granule_link_count: 143,
+              min_granule_link_count: null
+            },
+            OPeNDAP: {
+              access_method_type: 'OPeNDAP',
+              total_times_access_method_used: '2',
+              average_granule_count: '1',
+              average_granule_link_count: null,
+              total_granules_retrieved: '2',
+              max_granule_link_count: null,
+              min_granule_link_count: null
+            },
+            'ECHO ORDERS': {
+              access_method_type: 'ECHO ORDERS',
+              total_times_access_method_used: '3',
+              average_granule_count: '7',
+              average_granule_link_count: null,
+              total_granules_retrieved: '22',
+              max_granule_link_count: null,
+              min_granule_link_count: null
+            },
+            download: {
+              access_method_type: 'download',
+              total_times_access_method_used: '121',
+              average_granule_count: '208',
+              average_granule_link_count: '33',
+              total_granules_retrieved: '25218',
+              max_granule_link_count: 167,
+              min_granule_link_count: 0
+            }
           }
         }
       }

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
@@ -23,9 +23,9 @@ import './TemporalSelectionDropdown.scss'
 const TemporalSelectionDropdown = ({
   allowRecurring,
   onChangeQuery,
+  onMetricsTemporalFilter,
   searchParams,
-  temporalSearch,
-  onMetricsTemporalFilter
+  temporalSearch
 }) => {
   const {
     startDate = '',
@@ -371,13 +371,13 @@ const TemporalSelectionDropdown = ({
                 })
               }
             }
+            displayStartDate={datesSelected.start ? temporal.startDate : ''}
+            displayEndDate={datesSelected.end ? temporal.endDate : ''}
+            isHomePage={isHomePage}
             onValid={onValid}
             setEndDate={setEndDate}
             setStartDate={setStartDate}
             temporal={temporal}
-            displayStartDate={datesSelected.start ? temporal.startDate : ''}
-            displayEndDate={datesSelected.end ? temporal.endDate : ''}
-            isHomePage={isHomePage}
           />
         )
       }

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdown.jsx
@@ -377,6 +377,7 @@ const TemporalSelectionDropdown = ({
             temporal={temporal}
             displayStartDate={datesSelected.start ? temporal.startDate : ''}
             displayEndDate={datesSelected.end ? temporal.endDate : ''}
+            isHomePage={isHomePage}
           />
         )
       }

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownMenu.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownMenu.jsx
@@ -16,6 +16,9 @@ import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLink
 const TemporalSelectionDropdownMenu = ({
   allowRecurring,
   disabled,
+  displayStartDate,
+  displayEndDate,
+  isHomePage,
   onApplyClick,
   onClearClick,
   onChangeQuery,
@@ -26,10 +29,7 @@ const TemporalSelectionDropdownMenu = ({
   onValid,
   setEndDate,
   setStartDate,
-  temporal,
-  displayStartDate,
-  displayEndDate,
-  isHomePage
+  temporal
 }) => {
   const classes = {
     btnApply: classNames(
@@ -47,6 +47,17 @@ const TemporalSelectionDropdownMenu = ({
   // For recurring dates we don't show the year, it's displayed on the slider
   const temporalDateFormat = getTemporalDateFormat(isRecurring)
 
+  const clearButton = (
+    <Button
+      className={classes.btnCancel}
+      bootstrapVariant="light"
+      label="Clear"
+      onClick={onClearClick}
+    >
+      Clear
+    </Button>
+  )
+
   const homePageActions = (
     <div className="temporal-selection-dropdown-menu__actions">
       <PortalLinkContainer
@@ -60,14 +71,7 @@ const TemporalSelectionDropdownMenu = ({
       >
         Apply
       </PortalLinkContainer>
-      <Button
-        className={classes.btnCancel}
-        bootstrapVariant="light"
-        label="Clear"
-        onClick={onClearClick}
-      >
-        Clear
-      </Button>
+      {clearButton}
     </div>
   )
 
@@ -83,14 +87,7 @@ const TemporalSelectionDropdownMenu = ({
       >
         Apply
       </Button>
-      <Button
-        className={classes.btnCancel}
-        bootstrapVariant="light"
-        label="Clear"
-        onClick={onClearClick}
-      >
-        Clear
-      </Button>
+      {clearButton}
     </div>
   )
 
@@ -108,7 +105,8 @@ const TemporalSelectionDropdownMenu = ({
       <TemporalSelection
         allowRecurring={allowRecurring}
         controlId="temporal-selection-dropdown"
-        temporal={temporal}
+        displayStartDate={displayStartDate}
+        displayEndDate={displayEndDate}
         format={temporalDateFormat}
         filterType="collection"
         onRecurringToggle={onRecurringToggle}
@@ -119,8 +117,7 @@ const TemporalSelectionDropdownMenu = ({
         onSliderChange={onSliderChange}
         onValid={onValid}
         onInvalid={onInvalid}
-        displayStartDate={displayStartDate}
-        displayEndDate={displayEndDate}
+        temporal={temporal}
       />
       {isHomePage ? homePageActions : searchPageActions}
     </Dropdown.Menu>,

--- a/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownMenu.jsx
+++ b/static/src/js/components/TemporalDisplay/TemporalSelectionDropdownMenu.jsx
@@ -28,7 +28,8 @@ const TemporalSelectionDropdownMenu = ({
   setStartDate,
   temporal,
   displayStartDate,
-  displayEndDate
+  displayEndDate,
+  isHomePage
 }) => {
   const classes = {
     btnApply: classNames(
@@ -45,6 +46,53 @@ const TemporalSelectionDropdownMenu = ({
 
   // For recurring dates we don't show the year, it's displayed on the slider
   const temporalDateFormat = getTemporalDateFormat(isRecurring)
+
+  const homePageActions = (
+    <div className="temporal-selection-dropdown-menu__actions">
+      <PortalLinkContainer
+        className={classes.btnApply}
+        type="button"
+        bootstrapVariant="primary"
+        label="Apply"
+        onClick={onApplyClick}
+        disabled={disabled}
+        to="/search"
+      >
+        Apply
+      </PortalLinkContainer>
+      <Button
+        className={classes.btnCancel}
+        bootstrapVariant="light"
+        label="Clear"
+        onClick={onClearClick}
+      >
+        Clear
+      </Button>
+    </div>
+  )
+
+  const searchPageActions = (
+    <div className="temporal-selection-dropdown-menu__actions">
+      <Button
+        className={classes.btnApply}
+        type="button"
+        bootstrapVariant="primary"
+        label="Apply"
+        onClick={onApplyClick}
+        disabled={disabled}
+      >
+        Apply
+      </Button>
+      <Button
+        className={classes.btnCancel}
+        bootstrapVariant="light"
+        label="Clear"
+        onClick={onClearClick}
+      >
+        Clear
+      </Button>
+    </div>
+  )
 
   return ReactDOM.createPortal(
     <Dropdown.Menu
@@ -74,27 +122,7 @@ const TemporalSelectionDropdownMenu = ({
         displayStartDate={displayStartDate}
         displayEndDate={displayEndDate}
       />
-      <div className="temporal-selection-dropdown-menu__actions">
-        <PortalLinkContainer
-          className={classes.btnApply}
-          type="button"
-          bootstrapVariant="primary"
-          label="Apply"
-          onClick={onApplyClick}
-          disabled={disabled}
-          to="/search"
-        >
-          Apply
-        </PortalLinkContainer>
-        <Button
-          className={classes.btnCancel}
-          bootstrapVariant="light"
-          label="Clear"
-          onClick={onClearClick}
-        >
-          Clear
-        </Button>
-      </div>
+      {isHomePage ? homePageActions : searchPageActions}
     </Dropdown.Menu>,
     document.getElementById('root')
   )

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import TemporalSelectionDropdownMenu from '../TemporalSelectionDropdownMenu'
+import setupTest from '../../../../../../jestConfigs/setupTest'
+
+import PortalLinkContainer from '../../../containers/PortalLinkContainer/PortalLinkContainer'
+import Button from '../../Button/Button'
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({
+    pathname: '/',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'testKey'
+  })
+}))
+
+jest.mock('../../../containers/PortalLinkContainer/PortalLinkContainer', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div />)
+}))
+
+jest.mock('../../Button/Button', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div />)
+}))
+
+// Mock react-bootstrap Dropdown
+jest.mock('react-bootstrap/Dropdown', () => ({
+  __esModule: true,
+  default: {
+    Menu: jest.fn(({ children }) => <div className="dropdown-menu">{children}</div>)
+  }
+}))
+
+const setup = setupTest({
+  ComponentsByRoute: {
+    '/': TemporalSelectionDropdownMenu
+  },
+  defaultPropsByRoute: {
+    '/': {
+      allowRecurring: true,
+      disabled: false,
+      displayStartDate: '',
+      displayEndDate: '',
+      isHomePage: true,
+      onApplyClick: jest.fn(),
+      onChangeQuery: jest.fn(),
+      onChangeRecurring: jest.fn(),
+      onClearClick: jest.fn(),
+      onInvalid: jest.fn(),
+      onRecurringToggle: jest.fn(),
+      onSliderChange: jest.fn(),
+      onValid: jest.fn(),
+      setEndDate: jest.fn(),
+      setStartDate: jest.fn(),
+      temporal: { isRecurring: false }
+    }
+  },
+  withRedux: true,
+  withRouter: true
+})
+
+beforeAll(() => {
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ReactDOM.createPortal = jest.fn((dropdown) => dropdown)
+  window.console.warn = jest.fn()
+})
+
+afterEach(() => {
+  ReactDOM.createPortal.mockClear()
+  window.console.warn.mockClear()
+})
+
+describe('TemporalSelectionDropdownMenu component', () => {
+  test('renders PortalLinkContainer when isHomePage is true', () => {
+    setup({
+      overridePropsByRoute: {
+        '/': {
+          isHomePage: true
+        }
+      }
+    })
+
+    expect(PortalLinkContainer).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders Button twice when isHomePage is false', () => {
+    setup({
+      overridePropsByRoute: {
+        '/': {
+          isHomePage: false
+        }
+      }
+    })
+
+    expect(Button).toHaveBeenCalledTimes(2)
+    expect(PortalLinkContainer).not.toHaveBeenCalled()
+  })
+})

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
@@ -7,25 +7,14 @@ import setupTest from '../../../../../../jestConfigs/setupTest'
 import PortalLinkContainer from '../../../containers/PortalLinkContainer/PortalLinkContainer'
 import Button from '../../Button/Button'
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn().mockReturnValue({
-    pathname: '/',
-    search: '',
-    hash: '',
-    state: null,
-    key: 'testKey'
-  })
-}))
-
 jest.mock('../../../containers/PortalLinkContainer/PortalLinkContainer', () => ({
   __esModule: true,
-  default: jest.fn(() => <div />)
+  default: jest.fn(({ children }) => <div>{children}</div>)
 }))
 
 jest.mock('../../Button/Button', () => ({
   __esModule: true,
-  default: jest.fn(() => <div />)
+  default: jest.fn(({ children }) => <div>{children}</div>)
 }))
 
 // Mock react-bootstrap Dropdown
@@ -37,70 +26,87 @@ jest.mock('react-bootstrap/Dropdown', () => ({
 }))
 
 const setup = setupTest({
-  ComponentsByRoute: {
-    '/': TemporalSelectionDropdownMenu
-  },
-  defaultPropsByRoute: {
-    '/': {
-      allowRecurring: true,
-      disabled: false,
-      displayStartDate: '',
-      displayEndDate: '',
-      isHomePage: true,
-      onApplyClick: jest.fn(),
-      onChangeQuery: jest.fn(),
-      onChangeRecurring: jest.fn(),
-      onClearClick: jest.fn(),
-      onInvalid: jest.fn(),
-      onRecurringToggle: jest.fn(),
-      onSliderChange: jest.fn(),
-      onValid: jest.fn(),
-      setEndDate: jest.fn(),
-      setStartDate: jest.fn(),
-      temporal: { isRecurring: false }
-    }
-  },
-  withRedux: true,
-  withRouter: true
-})
-
-beforeAll(() => {
+  Component: TemporalSelectionDropdownMenu,
+  defaultProps: {
+    allowRecurring: true,
+    disabled: false,
+    displayStartDate: '',
+    displayEndDate: '',
+    isHomePage: true,
+    onApplyClick: jest.fn(),
+    onChangeQuery: jest.fn(),
+    onChangeRecurring: jest.fn(),
+    onClearClick: jest.fn(),
+    onInvalid: jest.fn(),
+    onRecurringToggle: jest.fn(),
+    onSliderChange: jest.fn(),
+    onValid: jest.fn(),
+    setEndDate: jest.fn(),
+    setStartDate: jest.fn(),
+    temporal: { isRecurring: false }
+  }
 })
 
 beforeEach(() => {
-  jest.clearAllMocks()
   ReactDOM.createPortal = jest.fn((dropdown) => dropdown)
-  window.console.warn = jest.fn()
-})
-
-afterEach(() => {
-  ReactDOM.createPortal.mockClear()
-  window.console.warn.mockClear()
 })
 
 describe('TemporalSelectionDropdownMenu component', () => {
-  test('renders PortalLinkContainer when isHomePage is true', () => {
-    setup({
-      overridePropsByRoute: {
-        '/': {
-          isHomePage: true
-        }
-      }
-    })
+  describe('when isHomePage is true', () => {
+    test('renders the Apply button with PortalLinkContainer', () => {
+      const { props } = setup()
 
-    expect(PortalLinkContainer).toHaveBeenCalledTimes(1)
+      expect(PortalLinkContainer).toHaveBeenCalledTimes(1)
+      expect(PortalLinkContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          className: expect.stringContaining('temporal-selection-dropdown-menu__button--apply'),
+          type: 'button',
+          bootstrapVariant: 'primary',
+          label: 'Apply',
+          onClick: props.onApplyClick,
+          disabled: false,
+          to: '/search',
+          children: 'Apply'
+        }),
+        {}
+      )
+    })
   })
 
-  test('renders Button twice when isHomePage is false', () => {
-    setup({
-      overridePropsByRoute: {
-        '/': {
+  describe('when isHomePage is false', () => {
+    test('renders the Apply button with Button and Clear button with Button', () => {
+      const { props } = setup({
+        overrideProps: {
           isHomePage: false
         }
-      }
-    })
+      })
 
-    expect(Button).toHaveBeenCalledTimes(2)
-    expect(PortalLinkContainer).not.toHaveBeenCalled()
+      expect(Button).toHaveBeenCalledTimes(2)
+      expect(Button).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          className: expect.stringContaining('temporal-selection-dropdown-menu__button--apply'),
+          type: 'button',
+          bootstrapVariant: 'primary',
+          label: 'Apply',
+          onClick: props.onApplyClick,
+          disabled: false,
+          children: 'Apply'
+        }),
+        {}
+      )
+
+      expect(Button).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          className: expect.stringContaining('temporal-selection-dropdown-menu__button--cancel'),
+          bootstrapVariant: 'light',
+          label: 'Clear',
+          onClick: props.onClearClick,
+          children: 'Clear'
+        }),
+        {}
+      )
+    })
   })
 })

--- a/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
+++ b/static/src/js/components/TemporalDisplay/__tests__/TemporalSelectionDropdownMenu.test.jsx
@@ -58,8 +58,8 @@ describe('TemporalSelectionDropdownMenu component', () => {
 
       expect(PortalLinkContainer).toHaveBeenCalledTimes(1)
       expect(PortalLinkContainer).toHaveBeenCalledWith(
-        expect.objectContaining({
-          className: expect.stringContaining('temporal-selection-dropdown-menu__button--apply'),
+        {
+          className: 'temporal-selection-dropdown-menu__button temporal-selection-dropdown-menu__button--apply',
           type: 'button',
           bootstrapVariant: 'primary',
           label: 'Apply',
@@ -67,9 +67,18 @@ describe('TemporalSelectionDropdownMenu component', () => {
           disabled: false,
           to: '/search',
           children: 'Apply'
-        }),
+        },
         {}
       )
+
+      expect(Button).toHaveBeenCalledTimes(1)
+      expect(Button).toHaveBeenCalledWith({
+        className: 'temporal-selection-dropdown-menu__button temporal-selection-dropdown-menu__button--cancel',
+        bootstrapVariant: 'light',
+        label: 'Clear',
+        onClick: props.onClearClick,
+        children: 'Clear'
+      }, {})
     })
   })
 
@@ -84,27 +93,27 @@ describe('TemporalSelectionDropdownMenu component', () => {
       expect(Button).toHaveBeenCalledTimes(2)
       expect(Button).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          className: expect.stringContaining('temporal-selection-dropdown-menu__button--apply'),
+        {
+          className: 'temporal-selection-dropdown-menu__button temporal-selection-dropdown-menu__button--apply',
           type: 'button',
           bootstrapVariant: 'primary',
           label: 'Apply',
           onClick: props.onApplyClick,
           disabled: false,
           children: 'Apply'
-        }),
+        },
         {}
       )
 
       expect(Button).toHaveBeenNthCalledWith(
         2,
-        expect.objectContaining({
-          className: expect.stringContaining('temporal-selection-dropdown-menu__button--cancel'),
+        {
+          className: 'temporal-selection-dropdown-menu__button temporal-selection-dropdown-menu__button--cancel',
           bootstrapVariant: 'light',
           label: 'Clear',
           onClick: props.onClearClick,
           children: 'Clear'
-        }),
+        },
         {}
       )
     })


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes the functionality of admin retrievals metrics and using the temporal selection dropdown from the granules page by accounting for the unique feature of when we are on the homepage

### What is the Solution?

Passing in an isHome prop in the temporal selection compoennt flow. 

### What areas of the application does this impact?

This will fix an existing issue on that admin component created during the landing page rewrite

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. In database, spoof multiple entries across various date ranges (if necessary)
2. Go to - http://localhost:8080/admin/retrievals-metrics
4. Ensure you see two textboxes that open a calendar view when clicked
5. Enter a valid date range (try for both calendar selection and manual entry)
6. Ensure appropriate metrics are generated

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
