### PR TITLE
EDSC-4548: Minify the resulting geoJson file that ogre returns

### DIFF
--- a/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.jsx
+++ b/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.jsx
@@ -95,8 +95,11 @@ export const ShapefileDropzoneContainer = ({
 
           dropzoneEl.removeFile(file)
 
+          // Minify the GeoJSON response from Ogre
+          const minifiedResponse = JSON.parse(JSON.stringify(resp))
+
           // Update the name to the original name (ogre puts a hash into this name field)
-          const updatedResponse = resp
+          const updatedResponse = minifiedResponse
           updatedResponse.name = name
 
           const fileWithIds = addEdscIdsToShapefile(updatedResponse)

--- a/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.jsx
+++ b/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.jsx
@@ -125,6 +125,10 @@ describe('ShapefileDropzoneContainer component', () => {
       const filesizeMock = jest.fn(() => '200KB')
       const onSaveShapefileMock = jest.fn()
 
+      // Mock JSON methods to verify minification
+      const stringifySpy = jest.spyOn(JSON, 'stringify')
+      const parseSpy = jest.spyOn(JSON, 'parse')
+
       const { props } = setup({
         overrideZustandState: {
           shapefile: {
@@ -238,6 +242,11 @@ describe('ShapefileDropzoneContainer component', () => {
         filename: 'test-file-name.zip',
         size: '200KB'
       })
+
+      // Verify minification was performed
+      expect(stringifySpy).toHaveBeenCalledTimes(1)
+      expect(stringifySpy).toHaveBeenCalledWith(mockResponse)
+      expect(parseSpy).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Right now the Ogre api returns a prettified response, and that is sent to the backend.

### What is the Solution?

Minifying the Ogre response so the backend doesn't have to process prettified JSON 

### What areas of the application does this impact?

The Shapefile dropzone container 

# Testing

### Reproduction steps

Ensure that the ogre request response is minfiied and the payload sent reflects that minification.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
