### PR TITLE
EDSC-4514: Fixes issue with double fetching granules

### DIFF
--- a/static/src/js/actions/__tests__/focusedCollection.test.js
+++ b/static/src/js/actions/__tests__/focusedCollection.test.js
@@ -836,7 +836,7 @@ describe('changeFocusedCollection', () => {
       getFocusedCollectionMock.mockImplementationOnce(() => jest.fn())
 
       const getTimelineMock = jest.fn()
-      const changeGranuleQueryMock = jest.fn()
+      const initializeGranuleQueryMock = jest.fn()
       useEdscStore.setState((state) => ({
         ...state,
         timeline: {
@@ -851,7 +851,7 @@ describe('changeFocusedCollection', () => {
           }
         },
         query: {
-          changeGranuleQuery: changeGranuleQueryMock
+          initializeGranuleQuery: initializeGranuleQueryMock
         }
       }))
 
@@ -878,8 +878,8 @@ describe('changeFocusedCollection', () => {
       expect(getTimelineMock).toHaveBeenCalledTimes(1)
       expect(getTimelineMock).toHaveBeenCalledWith()
 
-      expect(changeGranuleQueryMock).toHaveBeenCalledTimes(1)
-      expect(changeGranuleQueryMock).toHaveBeenCalledWith({
+      expect(initializeGranuleQueryMock).toHaveBeenCalledTimes(1)
+      expect(initializeGranuleQueryMock).toHaveBeenCalledWith({
         collectionId: 'C1000000000-EDSC',
         query: {}
       })
@@ -932,7 +932,7 @@ describe('changeFocusedCollection', () => {
       getFocusedCollectionMock.mockImplementationOnce(() => jest.fn())
 
       const getTimelineMock = jest.fn()
-      const changeGranuleQueryMock = jest.fn()
+      const initializeGranuleQueryMock = jest.fn()
       useEdscStore.setState((state) => ({
         ...state,
         timeline: {
@@ -947,7 +947,7 @@ describe('changeFocusedCollection', () => {
           }
         },
         query: {
-          changeGranuleQuery: changeGranuleQueryMock
+          initializeGranuleQuery: initializeGranuleQueryMock
         }
       }))
 
@@ -974,8 +974,8 @@ describe('changeFocusedCollection', () => {
       expect(getTimelineMock).toHaveBeenCalledTimes(1)
       expect(getTimelineMock).toHaveBeenCalledWith()
 
-      expect(changeGranuleQueryMock).toHaveBeenCalledTimes(1)
-      expect(changeGranuleQueryMock).toHaveBeenCalledWith({
+      expect(initializeGranuleQueryMock).toHaveBeenCalledTimes(1)
+      expect(initializeGranuleQueryMock).toHaveBeenCalledWith({
         collectionId: 'C1000000000-EDSC',
         query: { sortKey: '-start_date' }
       })

--- a/static/src/js/actions/focusedCollection.js
+++ b/static/src/js/actions/focusedCollection.js
@@ -456,7 +456,7 @@ export const changeFocusedCollection = (collectionId) => (dispatch, getState) =>
     } = useEdscStore.getState()
     const { preferences: preferencesValues } = preferences
     const { granuleSort: granuleSortPreference } = preferencesValues
-    const { changeGranuleQuery } = query
+    const { initializeGranuleQuery } = query
 
     const granuleQuery = {}
 
@@ -464,7 +464,7 @@ export const changeFocusedCollection = (collectionId) => (dispatch, getState) =>
       granuleQuery.sortKey = granuleSortPreference
     }
 
-    changeGranuleQuery({
+    initializeGranuleQuery({
       collectionId,
       query: granuleQuery
     })

--- a/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
@@ -38,6 +38,7 @@ describe('createQuerySlice', () => {
       changeRegionQuery: expect.any(Function),
       clearFilters: expect.any(Function),
       excludeGranule: expect.any(Function),
+      initializeGranuleQuery: expect.any(Function),
       removeSpatialFilter: expect.any(Function),
       undoExcludeGranule: expect.any(Function)
     })
@@ -509,6 +510,33 @@ describe('createQuerySlice', () => {
 
       expect(actions.getSearchGranules).toHaveBeenCalledTimes(1)
       expect(actions.getSearchGranules).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('initializeGranuleQuery', () => {
+    test('sets the granule query', () => {
+      const collectionId = 'collectionId'
+      const granuleQuery = {
+        sortKey: '-start_date'
+      }
+
+      const zustandState = useEdscStore.getState()
+      const { query } = zustandState
+      const { initializeGranuleQuery } = query
+      initializeGranuleQuery({
+        collectionId,
+        query: granuleQuery
+      })
+
+      const updatedState = useEdscStore.getState()
+      const {
+        query: updatedQuery
+      } = updatedState
+
+      expect(updatedQuery.collection.byId.collectionId.granules).toEqual({
+        ...initialGranuleState,
+        ...granuleQuery
+      })
     })
   })
 

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -232,6 +232,17 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
       reduxDispatch(actions.getSearchGranules())
     },
 
+    initializeGranuleQuery: ({ collectionId, query }) => {
+      set((state) => {
+        state.query.collection.byId[collectionId] = {
+          granules: {
+            ...initialGranuleState,
+            ...query
+          }
+        }
+      })
+    },
+
     removeSpatialFilter: async () => {
       await get().query.changeQuery({
         collection: {

--- a/static/src/js/zustand/types.ts
+++ b/static/src/js/zustand/types.ts
@@ -736,6 +736,16 @@ export type QuerySlice = {
       /** The granule ID to exclude */
       granuleId: string
     }) => void
+    /** Initialize the granule query without fetching granules */
+    initializeGranuleQuery: ({
+      collectionId,
+      query
+    }: {
+      /** The collection ID to update */
+      collectionId: string
+      /** The new query params */
+      query: Partial<GranuleQuery>
+    }) => void
     /** Function to remove the spatial filter */
     removeSpatialFilter: () => void
     /** Function to undo the last excluded granule */


### PR DESCRIPTION
# Overview

### What is the feature?

With the addition of the query zustand slice a bug was introduced that would cause the first page of granule results to be fetched twice. This was because I had changed a call to initialize a granule query to use the `changeGranuleQuery` function, which triggers a call to `getSearchGranules`. 

### What is the Solution?

This PR reintroduces the `initializeGranuleQuery` call, which is resonsible for defaulting the sort key query to the correct value based on user preferences.

### What areas of the application does this impact?

Navigating to the granule results list from the collection results list

# Testing

Click on the first collection result while watching the network dev tools, ensure only one request is called for fetching granules

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
