### PR TITLE
EDSC-4514: Fixes issues with spatial queries

### DIFF
--- a/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.jsx
+++ b/static/src/js/components/AccessMethod/__tests__/AccessMethod.test.jsx
@@ -1331,7 +1331,7 @@ describe('AccessMethod component', () => {
                 conceptId: 'collectionId'
               },
               selectedAccessMethod: 'harmony0',
-              spatial: emptySpatial
+              spatial: {}
             }
           })
 

--- a/static/src/js/containers/ProjectPanelsContainer/__tests__/ProjectPanelsContainer.test.jsx
+++ b/static/src/js/containers/ProjectPanelsContainer/__tests__/ProjectPanelsContainer.test.jsx
@@ -188,13 +188,7 @@ describe('ProjectPanelsContainer component', () => {
         byId: {}
       },
       projectCollectionsMetadata: {},
-      spatial: {
-        boundingBox: [],
-        circle: [],
-        line: [],
-        point: [],
-        polygon: []
-      },
+      spatial: {},
       temporal: {},
       ursProfile: {}
     }, {})

--- a/static/src/js/middleware/metrics/__tests__/helpers.test.js
+++ b/static/src/js/middleware/metrics/__tests__/helpers.test.js
@@ -9,13 +9,7 @@ import {
   computeFacets
 } from '../helpers'
 
-const emptySpatial = {
-  boundingBox: [],
-  circle: [],
-  line: [],
-  polygon: [],
-  point: []
-}
+const emptySpatial = {}
 
 describe('helpers', () => {
   describe('computeKeyword', () => {

--- a/static/src/js/util/__tests__/createSpatialDisplay.test.js
+++ b/static/src/js/util/__tests__/createSpatialDisplay.test.js
@@ -5,13 +5,7 @@ import createSpatialDisplay, {
 } from '../createSpatialDisplay'
 
 describe('createSpatialDisplay', () => {
-  const spatial = {
-    boundingBox: [],
-    circle: [],
-    line: [],
-    point: [],
-    polygon: []
-  }
+  const spatial = {}
 
   describe('boundingBox', () => {
     test('returns the correct values', () => {

--- a/static/src/js/util/__tests__/timeline.test.js
+++ b/static/src/js/util/__tests__/timeline.test.js
@@ -170,11 +170,7 @@ describe('prepareTimelineParams', () => {
     const baseStateWithOverrides = {
       authToken: 'test-auth-token',
       collectionQuery: {
-        spatial: {
-          boundingBox: [],
-          point: [],
-          polygon: []
-        }
+        spatial: {}
       },
       focusedCollection: '',
       project: {

--- a/static/src/js/util/collections.js
+++ b/static/src/js/util/collections.js
@@ -8,7 +8,6 @@ import { collectionSortKeys } from '../constants/collectionSortKeys'
 
 import useEdscStore from '../zustand/useEdscStore'
 import { getCollectionsQuery } from '../zustand/selectors/query'
-import { pruneSpatial } from './pruneSpatial'
 
 /**
  * Prepare parameters used in getCollections() based on current Redux State
@@ -46,7 +45,7 @@ export const prepareCollectionParams = (state) => {
     line,
     point,
     polygon
-  } = pruneSpatial(spatial)
+  } = spatial
 
   const { viewAllFacets: viewAllFacetsSearchResults = {} } = searchResults
   const { selectedCategory: viewAllFacetsCategory } = viewAllFacetsSearchResults

--- a/static/src/js/util/createSpatialDisplay.js
+++ b/static/src/js/util/createSpatialDisplay.js
@@ -1,6 +1,5 @@
 import { mbr } from '@edsc/geo-utils'
 import { getApplicationConfig } from '../../../../sharedUtils/config'
-import { pruneSpatial } from './pruneSpatial'
 
 const { defaultSpatialDecimalSize } = getApplicationConfig()
 
@@ -62,7 +61,7 @@ export const createSpatialDisplay = (spatial, usingMbr = false) => {
     line,
     point,
     polygon
-  } = pruneSpatial(spatial)
+  } = spatial
 
   if (boundingBox) {
     const splitStr = transformBoundingBoxCoordinates(boundingBox[0])

--- a/static/src/js/util/granules.js
+++ b/static/src/js/util/granules.js
@@ -7,7 +7,6 @@ import { getOpenSearchOsddLink } from '../../../../sharedUtils/getOpenSearchOsdd
 
 import useEdscStore from '../zustand/useEdscStore'
 import { getCollectionsQuery } from '../zustand/selectors/query'
-import { pruneSpatial } from './pruneSpatial'
 
 /**
  * Populate granule payload used to update the store
@@ -79,7 +78,7 @@ export const extractGranuleSearchParams = (state, collectionId) => {
     point,
     polygon,
     line
-  } = pruneSpatial(spatial)
+  } = spatial
 
   const { [collectionId]: collectionQuery = {} } = collectionQueryById
   const { granules: collectionGranuleQuery = {} } = collectionQuery

--- a/static/src/js/util/map/interactions/onClickShapefile.ts
+++ b/static/src/js/util/map/interactions/onClickShapefile.ts
@@ -113,9 +113,14 @@ const onClickShapefile = ({
     selectedFeatures = updatedSelectedFeatures.concat(edscId)
   } else {
     // Remove the feature from the existing spatial query
-    const queryIndex = currentQuery[queryType]?.indexOf(queryValue) || -1
-    currentQuery[queryType]?.splice(queryIndex, 1)
-    query = currentQuery
+    const queryByType = [...currentQuery[queryType] || []]
+    const queryIndex = queryByType.indexOf(queryValue)
+    queryByType.splice(queryIndex!, 1)
+
+    query = {
+      ...currentQuery,
+      [queryType]: queryByType
+    }
 
     // Remove the feature from the selectedFeatures
     const featuresIndex = updatedSelectedFeatures.indexOf(edscId)

--- a/static/src/js/util/timeline.js
+++ b/static/src/js/util/timeline.js
@@ -1,7 +1,5 @@
 import getObjectKeyByValue from './object'
 
-import { pruneSpatial } from './pruneSpatial'
-
 /**
  * Mapping of timeline zoom levels. The Timeline (sometimes) and URL use numbers, CMR uses words
  */
@@ -84,7 +82,7 @@ export const prepareTimelineParams = (state) => {
     boundingBox,
     point,
     polygon
-  } = pruneSpatial(spatial)
+  } = spatial
 
   const { query: timelineQuery } = timeline
   const {

--- a/static/src/js/util/url/__tests__/url.mocks.js
+++ b/static/src/js/util/url/__tests__/url.mocks.js
@@ -30,13 +30,7 @@ export const emptyDecodedResult = {
       keyword: undefined,
       onlyEosdisCollections: undefined,
       overrideTemporal: {},
-      spatial: {
-        boundingBox: [],
-        circle: [],
-        line: [],
-        point: [],
-        polygon: []
-      },
+      spatial: {},
       sortKey: undefined,
       tagKey: undefined,
       temporal: {},

--- a/static/src/js/util/url/url.js
+++ b/static/src/js/util/url/url.js
@@ -211,11 +211,18 @@ export const decodeUrlParams = (paramString) => {
   const mapView = decodeMap(params)
 
   const spatial = {}
-  spatial.point = decodeHelp(params, 'pointSearch') || []
-  spatial.boundingBox = decodeHelp(params, 'boundingBoxSearch') || []
-  spatial.polygon = decodeHelp(params, 'polygonSearch') || []
-  spatial.line = decodeHelp(params, 'lineSearch') || []
-  spatial.circle = decodeHelp(params, 'circleSearch') || []
+
+  // If the decode values don't exist, don't add `undefined` to the spatial object.
+  const decodedBoundingBox = decodeHelp(params, 'boundingBoxSearch')
+  if (decodedBoundingBox) spatial.boundingBox = decodedBoundingBox
+  const decodedCircle = decodeHelp(params, 'circleSearch')
+  if (decodedCircle) spatial.circle = decodedCircle
+  const decodedLine = decodeHelp(params, 'lineSearch')
+  if (decodedLine) spatial.line = decodedLine
+  const decodedPoint = decodeHelp(params, 'pointSearch')
+  if (decodedPoint) spatial.point = decodedPoint
+  const decodedPolygon = decodeHelp(params, 'polygonSearch')
+  if (decodedPolygon) spatial.polygon = decodedPolygon
 
   // Initialize the collection query
   const { collection = {} } = query

--- a/static/src/js/zustand/selectors/__tests__/query.test.ts
+++ b/static/src/js/zustand/selectors/__tests__/query.test.ts
@@ -29,7 +29,13 @@ describe('query selectors', () => {
   describe('getCollectionsQuerySpatial', () => {
     test('returns the collection spatial query', () => {
       const spatialQuery = getCollectionsQuerySpatial(useEdscStore.getState())
-      expect(spatialQuery).toEqual(initialState.collection.spatial)
+      expect(spatialQuery).toEqual({
+        boundingBox: [],
+        circle: [],
+        line: [],
+        point: [],
+        polygon: []
+      })
     })
   })
 

--- a/static/src/js/zustand/selectors/query.ts
+++ b/static/src/js/zustand/selectors/query.ts
@@ -48,7 +48,16 @@ export const getCollectionsQuery = (state: EdscStore) => state.query?.collection
 export const getCollectionsQuerySpatial = (state: EdscStore) => {
   const { spatial } = getCollectionsQuery(state)
 
-  return spatial
+  // Default the spatial values to empty arrays. This ensures code that is looking for
+  // arrays will not break (SpatialDisplay.jsx)
+  return {
+    boundingBox: [],
+    circle: [],
+    line: [],
+    point: [],
+    polygon: [],
+    ...spatial
+  }
 }
 
 /**

--- a/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
@@ -172,8 +172,8 @@ describe('createQuerySlice', () => {
       })
     })
 
-    describe('when there is spatial values', () => {
-      test('it keeps the default spatial values for types without values', async () => {
+    describe('when there are spatial values', () => {
+      test('updates the store', async () => {
         mockGetState.mockReturnValue({
           focusedCollection: ''
         })
@@ -199,9 +199,60 @@ describe('createQuerySlice', () => {
         } = updatedState
 
         expect(updatedQuery.collection.spatial).toEqual({
-          ...initialState.collection.spatial,
           point: ['0,0']
         })
+      })
+
+      test('it changes the spatial values to a new value', async () => {
+        useEdscStore.setState((state) => {
+          state.query.collection.spatial = {
+            point: ['1,1']
+          }
+        })
+
+        const zustandState = useEdscStore.getState()
+        const { query } = zustandState
+        const { changeQuery } = query
+        await changeQuery({
+          collection: {
+            spatial: {
+              polygon: ['-77,38,-77,38,-76,38,-77,38']
+            }
+          }
+        })
+
+        const updatedState = useEdscStore.getState()
+        const {
+          query: updatedQuery
+        } = updatedState
+
+        expect(updatedQuery.collection.spatial).toEqual({
+          polygon: ['-77,38,-77,38,-76,38,-77,38']
+        })
+      })
+
+      test('it removes spatial values', async () => {
+        useEdscStore.setState((state) => {
+          state.query.collection.spatial = {
+            point: ['1,1']
+          }
+        })
+
+        const zustandState = useEdscStore.getState()
+        const { query } = zustandState
+        const { changeQuery } = query
+        await changeQuery({
+          collection: {
+            spatial: {}
+          }
+        })
+
+        const updatedState = useEdscStore.getState()
+        const {
+          query: updatedQuery
+        } = updatedState
+
+        expect(updatedQuery.collection.spatial).toEqual(initialState.collection.spatial)
       })
     })
   })

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -33,13 +33,7 @@ export const initialState = {
     overrideTemporal: {},
     pageNum: 1,
     sortKey: collectionSearchResultsSortKey,
-    spatial: {
-      boundingBox: [],
-      circle: [],
-      line: [],
-      point: [],
-      polygon: []
-    },
+    spatial: {},
     temporal: {}
   },
   region: {
@@ -59,21 +53,32 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
     ...initialState,
 
     changeQuery: async (query) => {
-      set((state) => ({
-        query: {
-          ...state.query,
-          collection: {
-            ...state.query.collection,
-            pageNum: 1,
-            ...query.collection,
-            spatial: {
-              ...initialState.collection.spatial,
-              ...state.query.collection.spatial,
-              ...query.collection?.spatial
+      set((state) => {
+        // Default the spatial value to the existing object
+        let spatialValue = state.query.collection.spatial
+
+        // If the query contains spatial information, use it
+        if (query.collection?.spatial) {
+          spatialValue = query.collection.spatial
+        }
+
+        const newSpatial = {
+          ...initialState.collection.spatial,
+          ...spatialValue
+        }
+
+        return {
+          query: {
+            ...state.query,
+            collection: {
+              ...state.query.collection,
+              pageNum: 1,
+              ...query.collection,
+              spatial: newSpatial
             }
           }
         }
-      }))
+      })
 
       const {
         dispatch: reduxDispatch,


### PR DESCRIPTION
# Overview

### What is the feature?

Bug found: If you add a spatial value, then add a different type spatial value, both values remain in the store.

### What is the Solution?

Check the incoming query within `changeQuery` in `createQuerySlice.ts`. If spatial is included, use it, but default to an empty spatial object.
Refactored the `getCollectionsQuerySpatial` to default values to empty arrays. This avoids the need to save empty arrays in the store.

Also found a bug with deselecting a shapefile feature.

### What areas of the application does this impact?

Spatial queries

# Testing

Spatial bug
* Add a spatial search to the map. 
* Add a different spatial search to the map
* Ensure only the second query exists

Shapefile bug
* Upload a shapefile with one shape
* Click on the shape to deselect it
* Ensure the spatial query is removed from the URL and CMR query

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
