### PR TITLE
EDSC-4432: Order Status Page loading state briefly shows no collections in the order and a broken project link is displayed

### DIFF
--- a/static/src/js/components/OrderStatus/OrderStatus.jsx
+++ b/static/src/js/components/OrderStatus/OrderStatus.jsx
@@ -61,7 +61,7 @@ export const OrderStatus = ({
 
   const {
     collections,
-    id,
+    id: loadedId,
     isLoaded,
     isLoading,
     jsondata = {},
@@ -141,6 +141,8 @@ export const OrderStatus = ({
 
   const eeLink = earthdataEnvironment === deployedEnvironment() ? '' : `?ee=${earthdataEnvironment}`
 
+  const shouldShowLoading = paramsId !== loadedId || (isLoading && !isLoaded)
+
   const introduction = (
     <p>
       {'This page will automatically update as your orders are processed. The Download Status page can be accessed later by visiting '}
@@ -185,7 +187,7 @@ export const OrderStatus = ({
             <Well.Heading>Download Status</Well.Heading>
             <Well.Introduction>{introduction}</Well.Introduction>
             {
-              (!id && !isLoaded) && (
+              shouldShowLoading && (
                 <Skeleton
                   className="order-status__item-skeleton"
                   containerStyle={
@@ -219,7 +221,7 @@ export const OrderStatus = ({
             <Well.Heading>Additional Resources and Documentation</Well.Heading>
             <Well.Section>
               {
-                isLoading && (
+                shouldShowLoading && (
                   <Skeleton
                     className="order-status__item-skeleton"
                     containerStyle={

--- a/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.jsx
+++ b/static/src/js/components/OrderStatus/__tests__/OrderStatus.test.jsx
@@ -40,8 +40,8 @@ describe('OrderStatus component', () => {
     })
 
     expect(screen.getByText('https://search.earthdata.nasa.gov/downloads/7')).toBeInTheDocument()
-    expect(Skeleton).toHaveBeenCalledTimes(1)
-    expect(Skeleton).toHaveBeenCalledWith({
+    expect(Skeleton).toHaveBeenCalledTimes(2)
+    expect(Skeleton).toHaveBeenNthCalledWith(1, {
       className: 'order-status__item-skeleton',
       containerStyle: {
         display: 'inline-block',
@@ -71,18 +71,52 @@ describe('OrderStatus component', () => {
         width: '100%'
       }]
     }, {})
+
+    expect(Skeleton).toHaveBeenNthCalledWith(2, {
+      className: 'order-status__item-skeleton',
+      containerStyle: {
+        display: 'inline-block',
+        height: '175px',
+        width: '100%'
+      },
+      shapes: [{
+        height: 16,
+        left: 0,
+        radius: 2,
+        shape: 'rectangle',
+        top: 2,
+        width: '60%'
+      }, {
+        height: 14,
+        left: 20,
+        radius: 2,
+        shape: 'rectangle',
+        top: 31,
+        width: '50%'
+      }, {
+        height: 14,
+        left: 20,
+        radius: 2,
+        shape: 'rectangle',
+        top: 55,
+        width: '57%'
+      }]
+    }, {})
   })
 
   test('renders itself correctly after initial page load', () => {
     setup()
 
     expect(screen.getByText('Download Status')).toBeInTheDocument()
+    expect(Skeleton).toHaveBeenCalledTimes(0)
   })
 
   test('renders the correct Helmet meta information', async () => {
     setup()
 
     await waitFor(() => expect(document.title).toEqual('Download Status'))
+
+    expect(Skeleton).toHaveBeenCalledTimes(0)
 
     const helmet = Helmet.peek()
 
@@ -131,6 +165,7 @@ describe('OrderStatus component', () => {
 
       const link = screen.getByRole('link', { name: 'http://localhost/downloads/7' })
       expect(link).toBeInTheDocument()
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
 
     test('download status link has correct href when earthdataEnvironment is different than the deployed environment', () => {
@@ -143,6 +178,7 @@ describe('OrderStatus component', () => {
 
       const link = screen.getByRole('link', { name: 'http://localhost/downloads/7?ee=prod' })
       expect(link).toBeInTheDocument()
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
 
     test('status link has correct href', () => {
@@ -150,6 +186,7 @@ describe('OrderStatus component', () => {
 
       const link = screen.getByRole('link', { name: 'Download Status and History' })
       expect(link.href).toEqual('http://localhost/downloads')
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
 
     test('status link has correct href when earthdataEnvironment is different than the deployed environment', () => {
@@ -162,6 +199,7 @@ describe('OrderStatus component', () => {
 
       const link = screen.getByRole('link', { name: 'Download Status and History' })
       expect(link.href).toEqual('http://localhost/downloads?ee=prod')
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -170,6 +208,7 @@ describe('OrderStatus component', () => {
       setup()
 
       expect(screen.getByRole('link', { name: 'http://linkurl.com/test' })).toBeInTheDocument()
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -188,6 +227,7 @@ describe('OrderStatus component', () => {
       expect(within(relatedCollections[0]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_3_111' })).toBeInTheDocument()
       expect(within(relatedCollections[1]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_2_111' })).toBeInTheDocument()
       expect(within(relatedCollections[2]).getByRole('link', { key: 'related-collection-TEST_COLLECTION_1_111' })).toBeInTheDocument()
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -203,6 +243,7 @@ describe('OrderStatus component', () => {
       })
 
       expect(props.onChangePath).toHaveBeenCalledWith('/search?test=source_link')
+      expect(Skeleton).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/static/src/js/components/OrderStatus/__tests__/mocks.js
+++ b/static/src/js/components/OrderStatus/__tests__/mocks.js
@@ -20,7 +20,7 @@ export const retrievalStatusProps = {
     portalId: 'edsc'
   },
   retrieval: {
-    id: 7,
+    id: '7',
     isLoading: false,
     isLoaded: true,
     collections: {
@@ -148,7 +148,7 @@ export const initalizedRetrievalStatusProps = {
 export const retrievalStatusPropsTwo = {
   authToken: 'testToken2',
   retrieval: {
-    id: 7,
+    id: '7',
     collections: {
       byId: {
         1: {
@@ -182,7 +182,7 @@ export const retrievalStatusPropsTwo = {
 export const retrievalStatusPropsEsi = {
   authToken: 'testToken2',
   retrieval: {
-    id: 7,
+    id: '7',
     collections: {
       byId: {
         1: {
@@ -264,7 +264,7 @@ export const retrievalStatusPropsEsi = {
 export const retrievalStatusPropsEchoOrder = {
   authToken: 'testToken2',
   retrieval: {
-    id: 7,
+    id: '7',
     collections: {
       byId: {
         1: {


### PR DESCRIPTION
# Overview

### What is the feature?

A skeleton is displayed for the retrieval intro text so that a user is not shown a broken link
A skeleton is displayed for a order while the order statuses are loading

### What is the Solution?

Pulled id# for link from params
Based loading logic off of id from retrieval as opposed to isLoading from retrieval. isLoading is initiated as false which causes a brief lapse of flawed logic.

### What areas of the application does this impact?

OrderStatus

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: Any

1. Click on a collection and download it's data.
2. Pause the application at the point of retrieving the orderstatus. I've included attachments below of what it looked like before and after. 

### Attachments
Before
<img width="1674" height="758" alt="Screenshot 2025-09-12 at 1 07 47 PM" src="https://github.com/user-attachments/assets/ced9aca7-edd9-424a-8422-4cfc3cb9c708" />

After

<img width="1704" height="852" alt="Screenshot 2025-09-12 at 10 48 29 AM" src="https://github.com/user-attachments/assets/4a4c48ba-f2c3-4a8d-a442-a53ca19bfbf4" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
