### PR TITLE
EDSC-4070: Improve message when customizing options in a project

### DIFF
--- a/static/src/js/components/ProjectCollections/ProjectCollections.jsx
+++ b/static/src/js/components/ProjectCollections/ProjectCollections.jsx
@@ -107,7 +107,7 @@ const ProjectCollections = ({
               }
               {
                 isValid && (
-                  `Click ${String.fromCharCode(8220)}Edit Options${String.fromCharCode(8221)} above to customize the output for each project.`
+                  `Click ${String.fromCharCode(8220)}Edit Options${String.fromCharCode(8221)} to select options for each collection in your project.`
                 )
               }
               {

--- a/static/src/js/components/ProjectCollections/__tests__/ProjectCollections.test.jsx
+++ b/static/src/js/components/ProjectCollections/__tests__/ProjectCollections.test.jsx
@@ -126,7 +126,7 @@ describe('ProjectCollectionsList component', () => {
 
         setup()
 
-        const message = screen.getByText(`Click ${String.fromCharCode(8220)}Edit Options${String.fromCharCode(8221)} above to customize the output for each project.`)
+        const message = screen.getByText(`Click ${String.fromCharCode(8220)}Edit Options${String.fromCharCode(8221)} to select options for each collection in your project.`)
 
         expect(message).toBeInTheDocument()
       })


### PR DESCRIPTION
# Overview

### What is the feature?

Message on project page reads: Click "Edit Options" to select options for each collection in your project.

### What is the Solution?

Changed the text

### What areas of the application does this impact?

Project Collections

# Testing

### Reproduction steps

- **Environment for testing: any
- **Collection to test with: any

1. Click on any collection that is valid without too man granules and does not need customization and select 'download'
2. Text above 'Download Data' should now read Click “Edit Options” to select options for each collection in your project.

### Attachments


<img width="927" height="798" alt="Screenshot 2025-09-15 at 11 13 18 AM" src="https://github.com/user-attachments/assets/4a58e48e-06b9-45d3-a375-a4343045aa76" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
