### PR TITLE
EDSC-4567: Fixes issue with View All facets modal not requesting increased page size

### DIFF
--- a/static/src/js/actions/__tests__/viewAllFacets.test.js
+++ b/static/src/js/actions/__tests__/viewAllFacets.test.js
@@ -18,6 +18,8 @@ import {
   TOGGLE_VIEW_ALL_FACETS_MODAL
 } from '../../constants/actionTypes'
 
+import * as collectionUtils from '../../util/collections'
+
 const mockStore = configureMockStore([thunk])
 
 describe('updateViewAllFacets', () => {
@@ -142,24 +144,28 @@ describe('getViewAllFacets', () => {
       .post(/collections/)
       .reply(200, stubResponse, { 'cmr-hits': 1 })
 
+    const prepareCollectionParamsSpy = jest.spyOn(collectionUtils, 'prepareCollectionParams')
+
     // MockStore with initialState
     const store = mockStore({
       authToken: '',
       searchResults: {
-        collections: {},
         facets: {},
-        granules: {},
         viewAllFacets: {}
-      },
-      query: {
-        collection: {
-          keyword: 'search keyword'
-        }
       }
     })
 
     // Call the dispatch
     await store.dispatch(getViewAllFacets('Instruments')).then(() => {
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledTimes(1)
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledWith({
+        authToken: '',
+        searchResults: {
+          facets: {},
+          viewAllFacets: { selectedCategory: 'Instruments' }
+        }
+      })
+
       const storeActions = store.getActions()
       expect(storeActions[0]).toEqual({
         type: LOADING_VIEW_ALL_FACETS,
@@ -195,24 +201,28 @@ describe('getViewAllFacets', () => {
         'jwt-token': 'token'
       })
 
+    const prepareCollectionParamsSpy = jest.spyOn(collectionUtils, 'prepareCollectionParams')
+
     // MockStore with initialState
     const store = mockStore({
       authToken: 'token',
       searchResults: {
-        collections: {},
         facets: {},
-        granules: {},
         viewAllFacets: {}
-      },
-      query: {
-        collection: {
-          keyword: 'search keyword'
-        }
       }
     })
 
     // Call the dispatch
     await store.dispatch(getViewAllFacets('Instruments')).then(() => {
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledTimes(1)
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledWith({
+        authToken: 'token',
+        searchResults: {
+          facets: {},
+          viewAllFacets: { selectedCategory: 'Instruments' }
+        }
+      })
+
       const storeActions = store.getActions()
       expect(storeActions[0]).toEqual({
         type: LOADING_VIEW_ALL_FACETS,
@@ -251,24 +261,28 @@ describe('getViewAllFacets', () => {
       .post(/error_logger/)
       .reply(200)
 
+    const prepareCollectionParamsSpy = jest.spyOn(collectionUtils, 'prepareCollectionParams')
+
     // MockStore with initialState
     const store = mockStore({
       authToken: '',
       searchResults: {
-        collections: {},
         facets: {},
-        granules: {},
         viewAllFacets: {}
-      },
-      query: {
-        collection: {
-          keyword: 'search keyword'
-        }
       }
     })
 
     // Call the dispatch
     await store.dispatch(getViewAllFacets('Instruments')).then(() => {
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledTimes(1)
+      expect(prepareCollectionParamsSpy).toHaveBeenCalledWith({
+        authToken: '',
+        searchResults: {
+          facets: {},
+          viewAllFacets: { selectedCategory: 'Instruments' }
+        }
+      })
+
       const storeActions = store.getActions()
       expect(storeActions[0]).toEqual({
         type: LOADING_VIEW_ALL_FACETS,

--- a/static/src/js/actions/viewAllFacets.js
+++ b/static/src/js/actions/viewAllFacets.js
@@ -55,7 +55,18 @@ export const getViewAllFacets = (category = '') => (dispatch, getState) => {
 
   // `onViewAllFacetsLoading` changes the state, use getState() again here to ensure the
   // collection request has the updated state
-  const collectionParams = prepareCollectionParams(state)
+  // EDSC-4567: Temporary fix to get the View All facet modal working correctly. Once
+  // this moves to Zustand in EDSC-4561, this won't be necessary.
+  const collectionParams = prepareCollectionParams({
+    ...state,
+    searchResults: {
+      ...state.searchResults,
+      viewAllFacets: {
+        ...state.searchResults.viewAllFacets,
+        selectedCategory: category
+      }
+    }
+  })
 
   const requestObject = new CollectionRequest(authToken, earthdataEnvironment)
 


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes issue with View All facets modal not requesting increased page size

### What is the Solution?

With the move to Zustand the `selectedCategory` for ViewAll Facets was lost. This PR puts it in the expected location to ensure the modal works correctly. This will be fixed properly when the facets are moved to Zustand in a future ticket.

### What areas of the application does this impact?

View All facets modal

# Testing

Click the View All link for a facet, ensure more than 50 facets are available in the modal

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
