### PR TITLE
EDSC-1877: Improve error messaging to make more user friendly

### DIFF
--- a/static/src/js/actions/__tests__/subscriptions.test.js
+++ b/static/src/js/actions/__tests__/subscriptions.test.js
@@ -561,11 +561,13 @@ describe('getSubscriptions', () => {
       expect(storeActions[4]).toEqual({
         type: ADD_ERROR,
         payload: expect.objectContaining({
-          message: 'Error: Token does not exist',
           notificationType: 'banner',
-          title: 'Error retrieving subscription'
+          title: 'Something went wrong fetching collection results'
         })
       })
+
+      expect(storeActions[4].payload.message).toBeDefined()
+      expect(storeActions[4].payload.message.type.name).toBe('FailedToLoadCollectionsMessage')
 
       expect(storeActions[5]).toEqual({
         type: ERRORED_SUBSCRIPTIONS,

--- a/static/src/js/actions/errors.js
+++ b/static/src/js/actions/errors.js
@@ -1,6 +1,8 @@
+import React from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { REMOVE_ERROR, ADD_ERROR } from '../constants/actionTypes'
+import FailedToLoadCollectionsMessage from '../components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage'
 
 import { addToast } from '../util/addToast'
 import { displayNotificationType } from '../constants/enums'
@@ -59,12 +61,37 @@ export const handleError = ({
   // defaulting to the `message` argument provided to this action
   const [defaultErrorMessage = message] = parsedError
 
-  dispatch(addError({
-    id: requestId,
-    title: `Error ${verb} ${resource}`,
-    message: defaultErrorMessage,
-    notificationType
-  }))
+  // Use a custom error banner when the fetchSubscriptions action throws the error
+  if (action === 'fetchSubscriptions') {
+    const handleAlertsClick = () => {
+      const openAlerts = () => {
+        const alertsButton = document.querySelector('.th-status-link')
+
+        if (alertsButton) {
+          alertsButton.click()
+        }
+      }
+
+      // 0ms timeout required for the alerts to open correctly
+      setTimeout(() => openAlerts(), 0)
+    }
+
+    dispatch(addError({
+      id: requestId,
+      title: 'Something went wrong fetching collection results',
+      message: React.createElement(FailedToLoadCollectionsMessage, {
+        onAlertsClick: handleAlertsClick
+      }),
+      notificationType
+    }))
+  } else {
+    dispatch(addError({
+      id: requestId,
+      title: `Error ${verb} ${resource}`,
+      message: defaultErrorMessage,
+      notificationType
+    }))
+  }
 
   if (errorAction) {
     dispatch(errorAction(defaultErrorMessage))

--- a/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.jsx
+++ b/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FaBell } from 'react-icons/fa'
+
+import Button from '../Button/Button'
+
+import './FailedToLoadCollectionsMessage.scss'
+
+const FailedToLoadCollectionsMessage = ({ onAlertsClick }) => (
+  <div className="failed-to-load-collections">
+    <span className="failed-to-load-collections__message-text">
+      Check alerts for outage information or refresh the page.
+    </span>
+    <div className="failed-to-load-collections__see-alerts">
+      <Button
+        onClick={onAlertsClick}
+        icon={FaBell}
+        iconPosition="right"
+        bootstrapVariant="red"
+        bootstrapSize="sm"
+      >
+        See Alerts
+      </Button>
+    </div>
+  </div>
+)
+
+FailedToLoadCollectionsMessage.propTypes = {
+  onAlertsClick: PropTypes.func.isRequired
+}
+
+export default FailedToLoadCollectionsMessage

--- a/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.scss
+++ b/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.scss
@@ -1,0 +1,17 @@
+@use '../../../css/vendor/bootstrap/configuration' as bootstrap;
+@use '../../../css/utils';
+
+.failed-to-load-collections {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  &__message-text {
+    flex: 1;
+    align-self: center;
+  }
+
+  &__see-alerts {
+    margin-left: 1rem;
+  }
+}

--- a/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.scss
+++ b/static/src/js/components/FailedToLoadCollectionsMessage/FailedToLoadCollectionsMessage.scss
@@ -13,5 +13,16 @@
 
   &__see-alerts {
     margin-left: 1rem;
+
+    .button__icon {
+      border: 1px solid utils.$color__spacesuit-white;
+      border-radius: 50%;
+      padding: 0.2rem;
+      width: 1.25rem;
+      height: 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Updated the error banner shown when the CMR request fails to be more user friendly and informative.

### What is the Solution?

- Updated errors.js to have a special case for the `fetchSubscriptions` error.
- Created `FailedToLoadCollectionsMessage.jsx` for displaying of the custom banner content.

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

1. Go into Network tab
2. Block the cmr-graphql-proxy request
3. Load the /search endpoint
4. Verify that the banner displays as expected
5. Verify that clicking the `See Alerts` button opens the alerts dropdown.

### Attachments

<img width="1220" height="298" alt="image" src="https://github.com/user-attachments/assets/e89d3ccf-0429-46bf-b256-60f852fa08b5" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
