### PR TITLE
EDSC-4579: Adds an emergency notification banner configurable during deployments

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -37,7 +37,8 @@ config="`jq '.application.mapPointsSimplifyThreshold = $newValue' --arg newValue
 config="`jq '.application.nlpSearch = $newValue' --arg newValue $bamboo_NLP_SEARCH <<< $config`"
 config="`jq '.application.placeLabelsStyleUrl = $newValue' --arg newValue $bamboo_PLACE_LABELS_STYLE_URL <<< $config`"
 config="`jq '.environment.production.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
-config="`jq '.environment.production.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"
+config="`jq '.application.emergencyNotification = $newValue' --arg newValue $bamboo_EMERGENCY_NOTIFICATION <<< $config`"
+config="`jq '.application.emergencyNotificationType = $newValue' --arg newValue $bamboo_EMERGENCY_NOTIFICATION_TYPE <<< $config`"
 
 # Overwrite static.config.json with new values
 echo $config > tmp.$$.json && mv tmp.$$.json static.config.json

--- a/static.config.json
+++ b/static.config.json
@@ -51,7 +51,9 @@
     "disableEddDownload": "false",
     "disableOrdering": "false",
     "disableSwodlr": "false",
-    "mapPointsSimplifyThreshold": 2000
+    "mapPointsSimplifyThreshold": 2000,
+    "emergencyNotification": "",
+    "emergencyNotificationType": ""
   },
   "environment": {
     "test": {

--- a/static/src/js/App.jsx
+++ b/static/src/js/App.jsx
@@ -30,6 +30,7 @@ import PortalContainer from './containers/PortalContainer/PortalContainer'
 import AppLayout from './layouts/AppLayout/AppLayout'
 
 import GraphQlProvider from './providers/GraphQlProvider'
+import EmergencyNotification from './components/EmergencyNotification/EmergencyNotification'
 
 // Required for toast notification system
 window.reactToastProvider = React.createRef()
@@ -295,6 +296,7 @@ const App = () => {
 
   return (
     <ErrorBoundary>
+      <EmergencyNotification />
       <Provider store={store}>
         <GraphQlProvider>
           <ToastProvider ref={window.reactToastProvider}>

--- a/static/src/js/components/EmergencyNotification/EmergencyNotification.jsx
+++ b/static/src/js/components/EmergencyNotification/EmergencyNotification.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react'
+
+import { getApplicationConfig } from '../../../../../sharedUtils/config'
+
+import Banner from '../Banner/Banner'
+
+/**
+ * Display an emergency notification banner if configured.
+ */
+const EmergencyNotification = () => {
+  const {
+    emergencyNotification,
+    emergencyNotificationType = 'error'
+  } = getApplicationConfig()
+
+  // The banner will be able to be dismissed, but will always show on page load.
+  const [dismissed, setDismissed] = useState(false)
+
+  // If there is no emergency notification or it has been dismissed, don't render anything.
+  if (!emergencyNotification || dismissed) {
+    return null
+  }
+
+  return (
+    <Banner
+      title={emergencyNotification}
+      type={emergencyNotificationType}
+      onClose={() => setDismissed(true)}
+    />
+  )
+}
+
+export default EmergencyNotification

--- a/static/src/js/components/EmergencyNotification/__tests__/EmergencyNotification.test.jsx
+++ b/static/src/js/components/EmergencyNotification/__tests__/EmergencyNotification.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { act, screen } from '@testing-library/react'
+
+import setupTest from '../../../../../../jestConfigs/setupTest'
+
+import EmergencyNotification from '../EmergencyNotification'
+import Banner from '../../Banner/Banner'
+
+import * as getApplicationConfig from '../../../../../../sharedUtils/config'
+
+jest.mock('../../Banner/Banner', () => jest.fn(({ title }) => <div>{title}</div>))
+
+const setup = setupTest({
+  Component: EmergencyNotification
+})
+
+describe('EmergencyNotification', () => {
+  describe('when no notification exists', () => {
+    beforeEach(() => {
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        emergencyNotification: '',
+        emergencyNotificationType: ''
+      }))
+    })
+
+    test('should not render the banner', () => {
+      setup()
+
+      expect(Banner).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('when a notification exists', () => {
+    beforeEach(() => {
+      jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
+        emergencyNotification: 'Don\'t Panic',
+        emergencyNotificationType: 'info'
+      }))
+    })
+
+    test('should render the banner', () => {
+      setup()
+
+      expect(screen.getByText("Don't Panic")).toBeInTheDocument()
+
+      expect(Banner).toHaveBeenCalledTimes(1)
+      expect(Banner).toHaveBeenCalledWith({
+        title: "Don't Panic",
+        type: 'info',
+        onClose: expect.any(Function)
+      }, {})
+    })
+
+    describe('when dismissing the banner', () => {
+      test('should no longer render the banner', async () => {
+        setup()
+
+        expect(screen.getByText("Don't Panic")).toBeInTheDocument()
+
+        // Mock calling the onClose function
+        await act(() => {
+          Banner.mock.calls[0][0].onClose()
+        })
+
+        expect(screen.queryByText("Don't Panic")).not.toBeInTheDocument()
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Overview

### What is the feature?

Adds an emergency notification banner configurable during deployments

### What areas of the application does this impact?

A new banner

# Testing

### Reproduction steps

Locally set the `application.emergencyNotification` to the message you want to be displayed. `emergencyNotificationType` of `error` will show the banner with a red background

### Attachments

<img width="1401" height="157" alt="Screenshot 2025-10-01 at 11 12 35 AM" src="https://github.com/user-attachments/assets/65e19945-1695-42c7-bc64-79d3481be625" />


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
