### PR TITLE
EDSC-4579: Fixing EmergencyNotification when no notification should be present

### DIFF
--- a/static.config.json
+++ b/static.config.json
@@ -52,8 +52,8 @@
     "disableOrdering": "false",
     "disableSwodlr": "false",
     "mapPointsSimplifyThreshold": 2000,
-    "emergencyNotification": "",
-    "emergencyNotificationType": ""
+    "emergencyNotification": "false",
+    "emergencyNotificationType": "error"
   },
   "environment": {
     "test": {

--- a/static/src/js/components/EmergencyNotification/EmergencyNotification.jsx
+++ b/static/src/js/components/EmergencyNotification/EmergencyNotification.jsx
@@ -9,7 +9,7 @@ import Banner from '../Banner/Banner'
  */
 const EmergencyNotification = () => {
   const {
-    emergencyNotification,
+    emergencyNotification = 'false',
     emergencyNotificationType = 'error'
   } = getApplicationConfig()
 
@@ -17,7 +17,7 @@ const EmergencyNotification = () => {
   const [dismissed, setDismissed] = useState(false)
 
   // If there is no emergency notification or it has been dismissed, don't render anything.
-  if (!emergencyNotification || dismissed) {
+  if (emergencyNotification === 'false' || dismissed) {
     return null
   }
 

--- a/static/src/js/components/EmergencyNotification/__tests__/EmergencyNotification.test.jsx
+++ b/static/src/js/components/EmergencyNotification/__tests__/EmergencyNotification.test.jsx
@@ -18,8 +18,8 @@ describe('EmergencyNotification', () => {
   describe('when no notification exists', () => {
     beforeEach(() => {
       jest.spyOn(getApplicationConfig, 'getApplicationConfig').mockImplementation(() => ({
-        emergencyNotification: '',
-        emergencyNotificationType: ''
+        emergencyNotification: 'false',
+        emergencyNotificationType: 'false'
       }))
     })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Deployments failed when trying to set an empty string as the emergency notification variable. To be more explicit we're going to use "false" as the value that should not display a banner

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
