### PR TITLE
EDSC-3595: Fixes panels tooltip, fixes error in loading a project page directly

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -113,7 +113,7 @@ const AccessMethod = ({
   const {
     addedGranuleIds = [],
     allIds: granulesAllIds = [],
-    byId: granulesMetadata
+    byId: granulesMetadata = {}
   } = projectCollectionGranules
 
   let granulesToDisplay = []

--- a/static/src/js/components/Panels/Panels.jsx
+++ b/static/src/js/components/Panels/Panels.jsx
@@ -61,8 +61,8 @@ export class Panels extends PureComponent {
     this.onWindowResize = this.onWindowResize.bind(this)
     this.onWindowKeyUp = this.onWindowKeyUp.bind(this)
     this.onPanelHandleClickOrKeypress = this.onPanelHandleClickOrKeypress.bind(this)
-    this.onPanelHandleMouseOver = this.onPanelHandleMouseOver.bind(this)
-    this.onPanelHandleMouseOut = this.onPanelHandleMouseOut.bind(this)
+    this.onPanelHandleMouseEnter = this.onPanelHandleMouseEnter.bind(this)
+    this.onPanelHandleMouseLeave = this.onPanelHandleMouseLeave.bind(this)
     this.onUpdate = this.onUpdate.bind(this)
     this.disableHandleClickEvent = this.disableHandleClickEvent.bind(this)
     this.enableHandleClickEvent = this.enableHandleClickEvent.bind(this)
@@ -207,7 +207,7 @@ export class Panels extends PureComponent {
     onChangePanel(panelId)
   }
 
-  onPanelHandleMouseOver() {
+  onPanelHandleMouseEnter() {
     const { show } = this.state
 
     const nextHandleTooltipState = show ? 'Collapse' : 'Expand'
@@ -222,7 +222,7 @@ export class Panels extends PureComponent {
     }, 0)
   }
 
-  onPanelHandleMouseOut() {
+  onPanelHandleMouseLeave() {
     // Clear the timeout in case the tooltip state has not yet been updated.
     clearTimeout(this.handleTooltipCancelTimeout)
 
@@ -662,10 +662,10 @@ export class Panels extends PureComponent {
                 onMouseDown={this.onMouseDown}
                 onClick={this.onPanelHandleClickOrKeypress}
                 onKeyDown={this.onPanelHandleClickOrKeypress}
-                onMouseOver={this.onPanelHandleMouseOver}
-                onFocus={this.onPanelHandleMouseOver}
-                onMouseOut={this.onPanelHandleMouseOut}
-                onBlur={this.onPanelHandleMouseOut}
+                onMouseEnter={this.onPanelHandleMouseEnter}
+                onFocus={this.onPanelHandleMouseEnter}
+                onMouseLeave={this.onPanelHandleMouseLeave}
+                onBlur={this.onPanelHandleMouseLeave}
               />
             </OverlayTrigger>
           )

--- a/static/src/js/zustand/useEdscStore.ts
+++ b/static/src/js/zustand/useEdscStore.ts
@@ -47,7 +47,9 @@ const useEdscStore = create<EdscStore>()(
         ...createUiSlice(...args)
       }),
       {
-        name: 'edsc-store'
+        name: 'edsc-store',
+        // Enable the devtools in production environments
+        enabled: true
       }
     )
   )


### PR DESCRIPTION
# Overview

### What is the feature?

1. Fixes panels tooltip
2. Fixes error in loading a project page directly with added granules
3. Enables Zustand devtools in production builds

### What areas of the application does this impact?

Panels, project page

# Testing

1. Ensure the panels handle tooltip works as expected.
2. Navigate directly to a [project page with added granules](http://localhost:8080/projects?p=C2515837343-GES_DISC!C2515837343-GES_DISC&pg[1][a]=2519682101!2519682091!GES_DISC&pg[1][v]=t&pg[1][gsk]=-start_date&pg[1][m]=download&pg[1][cd]=f&ee=prod), ensure page loads correctly
3. run `npm run build && npm run preview`, load page and ensure that Redux devtools is showing the Zustand store

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
