### PR TITLE
EDSC-4580: Ensure new granule request happens after excluding a granule

### DIFF
--- a/static/src/js/components/Banner/Banner.scss
+++ b/static/src/js/components/Banner/Banner.scss
@@ -4,6 +4,7 @@
 .banner {
   position: relative;
   display: flex;
+  flex-shrink: 0;
   justify-content: center;
   align-items: center;
   padding: bootstrap.$spacer * .825 2rem;

--- a/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
@@ -630,6 +630,8 @@ describe('createQuerySlice', () => {
 
       expect(updatedQuery.collection.byId.collectionId.granules.excludedGranuleIds).toContain('granuleId')
 
+      expect(granules.granules.collectionConceptId).toBeNull()
+
       expect(eventEmitterEmitMock).toHaveBeenCalledTimes(1)
       expect(eventEmitterEmitMock).toHaveBeenCalledWith('map.layer.collectionId.hoverGranule', {
         granule: null

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -203,6 +203,11 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
         if (collection) {
           collection.granules.excludedGranuleIds.push(granuleId)
         }
+
+        // `granules.getGranules()` has logic to avoid making a duplicate request. In order to ensure
+        // the request is made after excluding a granule, reset the collectionConceptId here before
+        // calling `granules.getGranules()`
+        state.granules.granules.collectionConceptId = null
       })
 
       get().granules.getGranules()


### PR DESCRIPTION
# Overview

### What is the feature?

Ensure new granule request happens after excluding a granule

### What is the Solution?

The logic that was added to `getGranules` to avoid duplicate requests is keeping this request from happening. To ensure the filtered requests isn't seen as duplicate, reset the `granules.granules.collectionConceptId` before calling `getGranules`

### What areas of the application does this impact?

Filtering granules from granule results

# Testing

- Select a collection with granules, take note of total number of granules
- Filter out a granule by clicking on the the more actions button on a granule to "Filter Granule"
- Ensure granule is removed from granule list, removed from map, and total number of granules is 1 less than before

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
