### PR TITLE
EDSC-4573 - Fixing swodlr order

### DIFF
--- a/serverless/src/submitSwodlrOrder/__tests__/handler.test.js
+++ b/serverless/src/submitSwodlrOrder/__tests__/handler.test.js
@@ -46,7 +46,7 @@ describe('submitSwodlrOrder', () => {
 
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get(/granules/)
+      .post(/search\/granules.json/)
       .reply(200, {
         feed: {
           entry: [{
@@ -234,7 +234,7 @@ describe('submitSwodlrOrder', () => {
   test('saves an error message if the create fails from an http error', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get(/granules/)
+      .post(/search\/granules.json/)
       .reply(500, {
         errorType: 'Error',
         errorMessage: 'Unknown Error',
@@ -306,7 +306,7 @@ describe('submitSwodlrOrder', () => {
   test('Doesnt submit download when there are too many granules', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get(/granules/)
+      .post(/search\/granules.json/)
       .reply(200, {
         feed: {
           entry: [
@@ -461,7 +461,7 @@ describe('submitSwodlrOrder', () => {
   test('saves an error message if the create fails in swodlr order', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .get(/granules/)
+      .post(/search\/granules.json/)
       .reply(200, {
         feed: {
           entry: [{

--- a/serverless/src/submitSwodlrOrder/__tests__/retrieveCMRGranules.test.js
+++ b/serverless/src/submitSwodlrOrder/__tests__/retrieveCMRGranules.test.js
@@ -15,7 +15,12 @@ describe('retrieveCMRGranules', () => {
   test('retrieve cmr granules', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .post(/search\/granules.json/)
+      .post('/search/granules.json', (body) => {
+        const params = parseQueryString(body)
+        expect(params.collection_concept_id).toBe('C2799438271-POCLOUD')
+
+        return true
+      })
       .reply(200, {
         feed: {
           entry: [{
@@ -62,7 +67,16 @@ describe('retrieveCMRGranules', () => {
   test('retrieves the granules with the added granule params', async () => {
     nock(/cmr/)
       .matchHeader('Authorization', 'Bearer access-token')
-      .post(/search\/granules.json/)
+      .post('/search/granules.json', (body) => {
+        const params = parseQueryString(body)
+        expect(params.concept_id).toEqual(['G2938390910-POCLOUD', 'G2938390924-POCLOUD'])
+        expect(params.echo_collection_id).toBe('C2799438271-POCLOUD')
+        expect(params.page_num).toBe('1')
+        expect(params.sort_key).toBe('-start_date')
+        expect(params.page_size).toBe('2000')
+
+        return true
+      })
       .reply(200, {
         feed: {
           entry: [{
@@ -130,41 +144,6 @@ describe('retrieveCMRGranules', () => {
         granuleUr: 'SWOT_L2_HR_Raster_250m_UTM34L_N_x_x_x_013_514_086F_20240414T225526_20240414T225547_PIC0_01'
       }
       ]
-    })
-  })
-
-  test('sends all params to CMR', async () => {
-    nock(/cmr/)
-      .matchHeader('Authorization', 'Bearer access-token')
-      .post('/search/granules.json', (body) => {
-        const params = parseQueryString(body)
-
-        // Verify params are sent
-        expect(params.echo_collection_id).toBe('C2799438271-POCLOUD')
-        expect(params.readable_granule_name).toEqual(['*_011_424_027*'])
-        expect(params.page_num).toBe('1')
-
-        return true
-      })
-      .reply(200, {
-        feed: {
-          entry: [{
-            id: 'G1-EDSC',
-            title: 'Granule 1'
-          }]
-        }
-      })
-
-    await retrieveCMRGranules({
-      collectionConceptId: 'C2799438271-POCLOUD',
-      earthdataEnvironment: 'prod',
-      accessToken: 'access-token',
-      granuleParams: {
-        concept_id: [],
-        echo_collection_id: 'C2799438271-POCLOUD',
-        readable_granule_name: ['*_011_424_027*'],
-        page_num: 1
-      }
     })
   })
 })

--- a/serverless/src/submitSwodlrOrder/__tests__/retrieveCMRGranules.test.js
+++ b/serverless/src/submitSwodlrOrder/__tests__/retrieveCMRGranules.test.js
@@ -18,6 +18,7 @@ describe('retrieveCMRGranules', () => {
       .post('/search/granules.json', (body) => {
         const params = parseQueryString(body)
         expect(params.collection_concept_id).toBe('C2799438271-POCLOUD')
+        expect(params.readable_granule_name).toEqual(['*_011_424_027*'])
 
         return true
       })
@@ -37,7 +38,8 @@ describe('retrieveCMRGranules', () => {
     const collectionConceptId = 'C2799438271-POCLOUD'
 
     const granuleParams = {
-      collection_concept_id: collectionConceptId
+      collection_concept_id: collectionConceptId,
+      readable_granule_name: ['*_011_424_027*']
     }
 
     const accessToken = 'access-token'

--- a/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
+++ b/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
@@ -12,18 +12,9 @@ export const retrieveCMRGranules = async ({
   accessToken,
   granuleParams
 }) => {
-  const normalizedParams = { ...granuleParams }
-
-  // Remove concept_id if empty. An empty concept_id array will cause CMR to reject
-  // the query. Removing the empty array allows CMR to search by collection_id
-  // and readable_granule_name instead.
-  if (normalizedParams.concept_id && normalizedParams.concept_id.length === 0) {
-    delete normalizedParams.concept_id
-  }
-
   const granuleResponse = await axios({
     url: `${getEarthdataConfig(earthdataEnvironment).cmrHost}/search/granules.json`,
-    params: normalizedParams,
+    params: granuleParams,
     paramsSerializer: (params) => stringify(
       params,
       {

--- a/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
+++ b/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
@@ -12,11 +12,18 @@ export const retrieveCMRGranules = async ({
   accessToken,
   granuleParams
 }) => {
-  const { concept_id: granuleIds } = granuleParams
+  const normalizedParams = { ...granuleParams }
+
+  // Remove concept_id if empty. An empty concept_id array will cause CMR to reject
+  // the query. Removing the empty array allows CMR to search by collection_id
+  // and readable_granule_name instead.
+  if (normalizedParams.concept_id && normalizedParams.concept_id.length === 0) {
+    delete normalizedParams.concept_id
+  }
 
   const granuleResponse = await axios({
     url: `${getEarthdataConfig(earthdataEnvironment).cmrHost}/search/granules.json`,
-    params: { concept_id: granuleIds },
+    params: normalizedParams,
     paramsSerializer: (params) => stringify(
       params,
       {

--- a/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
+++ b/serverless/src/submitSwodlrOrder/retrieveCMRGranules.js
@@ -13,16 +13,14 @@ export const retrieveCMRGranules = async ({
   granuleParams
 }) => {
   const granuleResponse = await axios({
+    method: 'post',
     url: `${getEarthdataConfig(earthdataEnvironment).cmrHost}/search/granules.json`,
-    params: granuleParams,
-    paramsSerializer: (params) => stringify(
-      params,
-      {
-        indices: false,
-        arrayFormat: 'brackets'
-      }
-    ),
+    data: stringify(granuleParams, {
+      indices: false,
+      arrayFormat: 'brackets'
+    }),
     headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
       Authorization: `Bearer ${accessToken}`,
       'Client-Id': getClientId().background
     }


### PR DESCRIPTION
# Overview

### What is the feature?

- Fixing the `creation failed` error on the SWODLR download status page.
- This was because we were not sending all the `granule_params` with our request to cmr.

### What is the Solution?

- Send all the `granule_params` for Swodlr orders, not just granule `concept_id`

### What areas of the application does this impact?

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:** SWOT Level 2 Water Mask Raster Image Data Product, Version C (C2799438271-POCLOUD)

1. Select a couple granules that support SWODLR orders (use `*_011_424_027*` for granule id filtering)
2. Click Download
3. On the Access Method panel, select SWODLR
4. Click Download Data
5. Ensure that the order succeeds

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
