### PR TITLE
EDSC-4574 - Preventing calls to timeline without a collection

### DIFF
--- a/serverless/src/timelineSearch/__tests__/handler.test.js
+++ b/serverless/src/timelineSearch/__tests__/handler.test.js
@@ -56,7 +56,9 @@ describe('timelineSearch', () => {
     const event = {
       body: JSON.stringify({
         requestId: 'asdf-1234-qwer-5678',
-        params: {}
+        params: {
+          concept_id: ['C10000-EDSC']
+        }
       })
     }
 
@@ -78,7 +80,9 @@ describe('timelineSearch', () => {
     const event = {
       body: JSON.stringify({
         requestId: 'asdf-1234-qwer-5678',
-        params: {}
+        params: {
+          concept_id: ['C10000-EDSC']
+        }
       })
     }
 
@@ -90,5 +94,54 @@ describe('timelineSearch', () => {
     const [errorMessage] = errors
 
     expect(errorMessage).toEqual('Error: Code Exception Occurred')
+  })
+
+  test('returns 400 when concept_id is missing', async () => {
+    const event = {
+      body: JSON.stringify({
+        requestId: 'asdf-1234-qwer-5678',
+        params: {
+          end_date: '2023-12-08T13:00:00.000Z',
+          interval: 'minute',
+          start_date: '2023-12-06T01:00:00.000Z'
+        }
+      })
+    }
+
+    const response = await timelineSearch(event, {})
+
+    expect(response.statusCode).toEqual(400)
+
+    const { body } = response
+    const parsedBody = JSON.parse(body)
+    const { errors } = parsedBody
+    const [errorMessage] = errors
+
+    expect(errorMessage).toEqual('Timeline requests must include at least one collection concept_id')
+  })
+
+  test('returns 400 when concept_id is an empty array', async () => {
+    const event = {
+      body: JSON.stringify({
+        requestId: 'asdf-1234-qwer-5678',
+        params: {
+          concept_id: [],
+          end_date: '2023-12-08T13:00:00.000Z',
+          interval: 'minute',
+          start_date: '2023-12-06T01:00:00.000Z'
+        }
+      })
+    }
+
+    const response = await timelineSearch(event, {})
+
+    expect(response.statusCode).toEqual(400)
+
+    const { body } = response
+    const parsedBody = JSON.parse(body)
+    const { errors } = parsedBody
+    const [errorMessage] = errors
+
+    expect(errorMessage).toEqual('Timeline requests must include at least one collection concept_id')
   })
 })

--- a/serverless/src/timelineSearch/handler.js
+++ b/serverless/src/timelineSearch/handler.js
@@ -30,11 +30,26 @@ const timelineSearch = async (event) => {
 
   const { body, headers } = event
 
-  const { requestId } = JSON.parse(body)
+  const { requestId, params: requestParams = {} } = JSON.parse(body)
 
   const { defaultResponseHeaders } = getApplicationConfig()
 
   const earthdataEnvironment = determineEarthdataEnvironment(headers)
+
+  // Validate that concept_id is present and not empty
+  // This prevents unbounded timeline requests to CMR that search across all collections
+  const { concept_id: conceptId } = requestParams
+
+  if (!conceptId || (Array.isArray(conceptId) && conceptId.length === 0)) {
+    return {
+      isBase64Encoded: false,
+      statusCode: 400,
+      headers: defaultResponseHeaders,
+      body: JSON.stringify({
+        errors: ['Timeline requests must include at least one collection concept_id']
+      })
+    }
+  }
 
   try {
     return doSearchRequest({

--- a/static/src/js/actions/__tests__/urlQuery.test.js
+++ b/static/src/js/actions/__tests__/urlQuery.test.js
@@ -799,8 +799,8 @@ describe('changePath', () => {
       expect(collections.getCollections).toHaveBeenCalledTimes(1)
       expect(collections.getCollections).toHaveBeenCalledWith()
 
-      expect(timeline.getTimeline).toHaveBeenCalledTimes(1)
-      expect(timeline.getTimeline).toHaveBeenCalledWith()
+      // Timeline should not be fetched when there's no collection or project collections
+      expect(timeline.getTimeline).toHaveBeenCalledTimes(0)
 
       expect(handleErrorMock).toHaveBeenCalledTimes(1)
       expect(handleErrorMock).toHaveBeenCalledWith(expect.objectContaining({

--- a/static/src/js/actions/urlQuery.js
+++ b/static/src/js/actions/urlQuery.js
@@ -230,7 +230,7 @@ export const changePath = (path = '') => async (dispatch) => {
   }
 
   // Fetch collections in the project
-  const { project = {} } = decodedParams || {}
+  const { focusedCollection, project = {} } = decodedParams || {}
   const { collections: projectCollections = {} } = project
   const { allIds = [] } = projectCollections
 
@@ -247,7 +247,12 @@ export const changePath = (path = '') => async (dispatch) => {
   }
 
   const { getTimeline } = timeline
-  getTimeline()
+
+  // Only fetch timeline data if there's a focused collection or project collections
+  // This prevents unbounded timeline requests to CMR without collection_id
+  if (focusedCollection || allIds.length > 0) {
+    getTimeline()
+  }
 
   return null
 }

--- a/static/src/js/zustand/slices/__tests__/createTimelineSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createTimelineSlice.test.ts
@@ -275,6 +275,49 @@ describe('createTimelineSlice', () => {
 
         expect(window.dataLayer.push).toHaveBeenCalledTimes(0)
       })
+
+      test('sets intervals to empty when conceptId is empty array', async () => {
+        configureStore.mockReturnValue({
+          getState: () => ({
+            authToken: 'mock-token'
+          })
+        })
+
+        useEdscStore.setState((state) => {
+          state.collection.collectionId = ''
+          state.timeline.query = {
+            endDate: '2009-12-01T23:59:59.000Z',
+            interval: TimelineInterval.Day,
+            startDate: '1979-01-01T00:00:00.000Z'
+          }
+
+          state.timeline.intervals = {
+            collectionId: [
+              [
+                1298937600,
+                1304208000,
+                3
+              ]
+            ]
+          }
+
+          state.project.collections.allIds = []
+        })
+
+        const zustandState = useEdscStore.getState()
+        const { timeline } = zustandState
+        const { getTimeline } = timeline
+
+        await getTimeline()
+
+        await waitFor(() => {
+          const updatedState = useEdscStore.getState()
+          const { timeline: updatedTimeline } = updatedState
+          expect(updatedTimeline.intervals).toEqual({})
+        })
+
+        expect(window.dataLayer.push).toHaveBeenCalledTimes(0)
+      })
     })
 
     describe('when there is a request error', () => {

--- a/static/src/js/zustand/slices/createTimelineSlice.ts
+++ b/static/src/js/zustand/slices/createTimelineSlice.ts
@@ -86,6 +86,15 @@ const createTimelineSlice: ImmerStateCreator<TimelineSlice> = (set, get) => ({
         startDate
       } = timelineParams
 
+      // Don't allow timeline requests when there are no collections
+      if (!conceptId || (Array.isArray(conceptId) && conceptId.length === 0)) {
+        set((state) => {
+          state.timeline.intervals = {}
+        })
+
+        return
+      }
+
       const requestObject = new TimelineRequest(authToken, earthdataEnvironment)
 
       cancelToken = requestObject.getCancelToken()


### PR DESCRIPTION
# Overview

### What is the feature?

- EDSC was sending timeline requests to CMR without `collection_id` during page navigation, causing CMR to search across many collections.
- The feature was to prevent these timeline from happening when there is no valid `collection_id` array.

### What is the Solution?

- Added conditional check in `urlQuery.js` to only call `getTimeline()` when there's a focused collection or project collections
- Added logic in `timelineSearch/handler.js` to reject requests missing collection_id
- Added early return in `createTimelineSlice.ts` to prevent requests when `conceptId is` empty

### What areas of the application does this impact?

- Timeline
- urlQuery

# Testing

### Reproduction steps

1. Open your browser's Network tab
2. Go to EDSC and focus a collection
3. Click "Back to Search Results"
4. Verify in Network tab: You should see no new `timeline` requests after navigation

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
