### PR TITLE
EDSC-4582: Fixing issue where selecting a ViewAllFacet prevents selecting a subsequent facet

### DIFF
--- a/static/src/js/zustand/slices/__tests__/createFacetParamsSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createFacetParamsSlice.test.ts
@@ -171,7 +171,6 @@ describe('createFacetParamsSlice', () => {
 
       const updatedState = useEdscStore.getState()
       const {
-        collections,
         facetParams: updatedFacetParams,
         query
       } = updatedState
@@ -181,9 +180,6 @@ describe('createFacetParamsSlice', () => {
         customizable: false,
         mapImagery: false
       })
-
-      expect(collections.getCollections).toHaveBeenCalledTimes(1)
-      expect(collections.getCollections).toHaveBeenCalledWith()
 
       expect(query.changeQuery).toHaveBeenCalledTimes(1)
       expect(query.changeQuery).toHaveBeenCalledWith({
@@ -221,7 +217,6 @@ describe('createFacetParamsSlice', () => {
 
           const updatedState = useEdscStore.getState()
           const {
-            collections,
             facetParams: updatedFacetParams,
             query
           } = updatedState
@@ -229,9 +224,6 @@ describe('createFacetParamsSlice', () => {
           expect(updatedFacetParams.cmrFacets).toEqual({
             science_keywords_h: [{ topic: 'Agriculture' }]
           })
-
-          expect(collections.getCollections).toHaveBeenCalledTimes(1)
-          expect(collections.getCollections).toHaveBeenCalledWith()
 
           expect(query.changeQuery).toHaveBeenCalledTimes(1)
           expect(query.changeQuery).toHaveBeenCalledWith({
@@ -268,7 +260,6 @@ describe('createFacetParamsSlice', () => {
 
             const updatedState = useEdscStore.getState()
             const {
-              collections,
               facetParams: updatedFacetParams,
               query
             } = updatedState
@@ -276,9 +267,6 @@ describe('createFacetParamsSlice', () => {
             expect(updatedFacetParams.cmrFacets).toEqual({
               science_keywords_h: []
             })
-
-            expect(collections.getCollections).toHaveBeenCalledTimes(1)
-            expect(collections.getCollections).toHaveBeenCalledWith()
 
             expect(query.changeQuery).toHaveBeenCalledTimes(1)
             expect(query.changeQuery).toHaveBeenCalledWith({
@@ -316,7 +304,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -324,9 +311,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           platforms_h: [{ basis: 'Land-based+Platforms' }]
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -358,7 +342,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -366,9 +349,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           instrument_h: ['AIRS']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -400,7 +380,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -408,9 +387,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           data_center_h: ['Alaska+Satellite+Facility']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -442,7 +418,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -450,9 +425,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           project_h: ['ABoVE']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -484,7 +456,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -492,9 +463,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           processing_level_id_h: ['0+-+Raw+Data']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -526,7 +494,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -534,9 +501,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           granule_data_format_h: ['ASCII']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -568,7 +532,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -576,9 +539,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           two_d_coordinate_system_name: ['CALIPSO']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -610,7 +570,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -618,9 +577,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           horizontal_data_resolution_range: ['0+to+1+meter']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({
@@ -652,7 +608,6 @@ describe('createFacetParamsSlice', () => {
 
         const updatedState = useEdscStore.getState()
         const {
-          collections,
           facetParams: updatedFacetParams,
           query
         } = updatedState
@@ -660,102 +615,6 @@ describe('createFacetParamsSlice', () => {
         expect(updatedFacetParams.cmrFacets).toEqual({
           latency: ['1+to+3+hours']
         })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
-
-        expect(query.changeQuery).toHaveBeenCalledTimes(1)
-        expect(query.changeQuery).toHaveBeenCalledWith({
-          collection: {
-            pageNum: 1
-          }
-        })
-
-        expect(actions.removeSubscriptionDisabledFields).toHaveBeenCalledTimes(1)
-        expect(actions.removeSubscriptionDisabledFields).toHaveBeenCalledWith()
-      })
-    })
-
-    describe('when combining viewAllFacets with cmrFacets', () => {
-      test('combines viewAllFacets and cmrFacets when setCmrFacets is called', () => {
-        useEdscStore.setState((state) => {
-          state.collections.getCollections = jest.fn()
-          state.query.changeQuery = jest.fn()
-          // Set up existing viewAllFacets
-          state.facetParams.viewAllFacets = {
-            instrument_h: ['AIRS']
-          }
-        })
-
-        const zustandState = useEdscStore.getState()
-        const { facetParams } = zustandState
-        const { setCmrFacets } = facetParams
-
-        // Call setCmrFacets with new facets
-        setCmrFacets({
-          science_keywords_h: [{ topic: 'Agriculture' }],
-          data_center_h: ['NASA']
-        })
-
-        const updatedState = useEdscStore.getState()
-        const {
-          collections,
-          facetParams: updatedFacetParams,
-          query
-        } = updatedState
-
-        // Should combine viewAllFacets with the new cmrFacets
-        expect(updatedFacetParams.cmrFacets).toEqual({
-          instrument_h: ['AIRS'],
-          science_keywords_h: [{ topic: 'Agriculture' }],
-          data_center_h: ['NASA']
-        })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
-
-        expect(query.changeQuery).toHaveBeenCalledTimes(1)
-        expect(query.changeQuery).toHaveBeenCalledWith({
-          collection: {
-            pageNum: 1
-          }
-        })
-
-        expect(actions.removeSubscriptionDisabledFields).toHaveBeenCalledTimes(1)
-        expect(actions.removeSubscriptionDisabledFields).toHaveBeenCalledWith()
-      })
-
-      test('handles empty viewAllFacets when combining', () => {
-        useEdscStore.setState((state) => {
-          state.collections.getCollections = jest.fn()
-          state.query.changeQuery = jest.fn()
-          // Set up empty viewAllFacets
-          state.facetParams.viewAllFacets = {}
-        })
-
-        const zustandState = useEdscStore.getState()
-        const { facetParams } = zustandState
-        const { setCmrFacets } = facetParams
-
-        // Call setCmrFacets with new facets
-        setCmrFacets({
-          science_keywords_h: [{ topic: 'Agriculture' }]
-        })
-
-        const updatedState = useEdscStore.getState()
-        const {
-          collections,
-          facetParams: updatedFacetParams,
-          query
-        } = updatedState
-
-        // Should only have the new cmrFacets when viewAllFacets is empty
-        expect(updatedFacetParams.cmrFacets).toEqual({
-          science_keywords_h: [{ topic: 'Agriculture' }]
-        })
-
-        expect(collections.getCollections).toHaveBeenCalledTimes(1)
-        expect(collections.getCollections).toHaveBeenCalledWith()
 
         expect(query.changeQuery).toHaveBeenCalledTimes(1)
         expect(query.changeQuery).toHaveBeenCalledWith({

--- a/static/src/js/zustand/slices/createFacetParamsSlice.ts
+++ b/static/src/js/zustand/slices/createFacetParamsSlice.ts
@@ -58,7 +58,8 @@ const createFacetParamsSlice: ImmerStateCreator<FacetParamsSlice> = (set, get) =
 
       setCmrFacets(viewAllFacets)
 
-      // Clear viewAllFacets after applying them to prevent conflicts with future facet selections
+      // When sending these to CMR in static/src/js/util/collections.js we are overriding the cmrFacets
+      // with the viewAllFacets, so we need to clear the viewAllFacets after applying them
       set((state) => {
         state.facetParams.viewAllFacets = {}
       })
@@ -82,23 +83,12 @@ const createFacetParamsSlice: ImmerStateCreator<FacetParamsSlice> = (set, get) =
         }
       })
 
-      // Fetch collections with the updated feature facets
-      get().collections.getCollections()
-
       // Clear any subscription disabledFields
       reduxDispatch(actions.removeSubscriptionDisabledFields())
     },
     setCmrFacets: (cmrFacets) => {
-      const { viewAllFacets } = get().facetParams
-
-      // We need to set all the facets which were
-      // set in the view all facets modal and the other facets
-      const combinedFacets = {
-        ...viewAllFacets,
-        ...cmrFacets
-      }
       set((state) => {
-        state.facetParams.cmrFacets = combinedFacets
+        state.facetParams.cmrFacets = cmrFacets
       })
 
       const {
@@ -111,9 +101,6 @@ const createFacetParamsSlice: ImmerStateCreator<FacetParamsSlice> = (set, get) =
           pageNum: 1
         }
       })
-
-      // Fetch collections with the updated feature facets
-      get().collections.getCollections()
 
       // Clear any subscription disabledFields
       reduxDispatch(actions.removeSubscriptionDisabledFields())

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -80,6 +80,7 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
         state.granules.granules.collectionConceptId = null
       })
 
+      // Fetch collections with the updated query parameters
       get().collections.getCollections()
 
       // If there is a focused collection, update it's granule search params


### PR DESCRIPTION
# Overview

### What is the feature?

This issue is that selecting a viewAllFacet and then applying should then submit that to CMR but, subsequent facet selections i.e. just clicking on the checkbox interface are not getting applied. Similarly if you select a viewAllFacet and then try to apply a result from the autocomplete search it was not working either

### What is the Solution?
We need to clear the viewAllFacets after they have been applied (i.e.) after that function calls the `setCmrFacets` function so that we don't push the values currently set in viewAllFacets instead of only the current cmrFacets in `static/src/js/util/collections.js`

We are also making extra calls to update collections but, that request is already being facilitated within `changeQuery`

### What areas of the application does this impact?

Facets, zustand state management for facet parameters

# Testing

### Reproduction steps

- **Environment for testing:*Any*
- **Collection to test with:*NA*

1. Ensure that using http://localhost:8080/search?fdc=Atmospheric%20Science%20Data%20Center%20(ASDC) and then selecting ViewAll the Instruments we don't have anything selected (this is to ensure that the viewAll facets aren't overlapping)

2. Ensure that when selecting a facet via autocomplete that the facet is used and can be seen on the view all facets iceBdrige project is a good test case

3. Ensure that when selecting a facet and applying it in the view All then selecting a different facet both are applied into the search

4. Ensure that selecting a facet under View all and then another facet under the same and different view all modal are all applied to the search

5. Feature facets (customizable, Map imagery, avail in cloud) should be unaffected but, we should regression test them anyway here

6. Ensure that if you select the facets for one like instruments that has a View all modal. That those selected ones show up selected in the view all facets modal when its opened up

7. Ensure using the network request that for each selected facet we are only calling CMR once when selecting a facet (in prod we do it twice because of the aforementioned extra collections.getCollections) call)


### Attachments

NA

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
