### PR TITLE
EDSC-4597: Fixes user preferences when the user does not have saved preferences

### DIFF
--- a/static/src/js/zustand/selectors/__tests__/earthdataEnvironment.test.ts
+++ b/static/src/js/zustand/selectors/__tests__/earthdataEnvironment.test.ts
@@ -3,6 +3,10 @@ import { getEarthdataEnvironment } from '../earthdataEnvironment'
 
 describe('getEarthdataEnvironment', () => {
   test('returns Earthdata environment from the zustand state', () => {
+    useEdscStore.setState((state) => {
+      state.earthdataEnvironment.currentEnvironment = 'prod'
+    })
+
     expect(getEarthdataEnvironment(useEdscStore.getState())).toEqual('prod')
   })
 })

--- a/static/src/js/zustand/slices/__tests__/createEarthdataEnvironmentSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createEarthdataEnvironmentSlice.test.ts
@@ -1,5 +1,9 @@
 import useEdscStore from '../../useEdscStore'
 
+jest.mock('../../../../../../sharedUtils/deployedEnvironment', () => ({
+  deployedEnvironment: jest.fn().mockReturnValue('prod')
+}))
+
 describe('createEarthdataDownloadRedirectSlice', () => {
   test('sets the default state', () => {
     const zustandState = useEdscStore.getState()

--- a/static/src/js/zustand/slices/__tests__/createProjectSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createProjectSlice.test.ts
@@ -302,6 +302,7 @@ describe('createProjectSlice', () => {
         })
 
         useEdscStore.setState((state) => {
+          state.earthdataEnvironment.currentEnvironment = 'prod'
           state.project.collections.allIds = ['collectionId1', 'collectionId2']
           state.user.edlToken = 'mockEdlToken'
         })

--- a/static/src/js/zustand/slices/__tests__/createTimelineSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createTimelineSlice.test.ts
@@ -134,6 +134,7 @@ describe('createTimelineSlice', () => {
         }])
 
       useEdscStore.setState((state) => {
+        state.earthdataEnvironment.currentEnvironment = 'prod'
         state.collection.collectionId = 'collectionId'
         state.timeline.query = {
           endDate: '2009-12-01T23:59:59.000Z',
@@ -250,6 +251,7 @@ describe('createTimelineSlice', () => {
           .reply(200)
 
         useEdscStore.setState((state) => {
+          state.earthdataEnvironment.currentEnvironment = 'prod'
           state.collection.collectionId = 'collectionId'
           state.timeline.query = {
             endDate: '2009-12-01T23:59:59.000Z',

--- a/static/src/js/zustand/slices/__tests__/createUserSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createUserSlice.test.ts
@@ -55,6 +55,9 @@ describe('createUserSlice', () => {
 
     test('clears the user state and redirects the user', () => {
       const localStorageRemoveItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
+      useEdscStore.setState((state) => {
+        state.earthdataEnvironment.currentEnvironment = 'prod'
+      })
 
       const { logout } = useEdscStore.getState().user
 
@@ -230,6 +233,18 @@ describe('createUserSlice', () => {
         const { map } = useEdscStore.getState()
 
         expect(map.setMapView).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    describe('when the provided preferences are empty', () => {
+      test('sets the sitePreferences to the initialSitePreferences', () => {
+        const { setSitePreferences } = useEdscStore.getState().user
+
+        setSitePreferences({} as PreferencesData)
+
+        const { user } = useEdscStore.getState()
+
+        expect(user.sitePreferences).toEqual(initialSitePreferences)
       })
     })
   })

--- a/static/src/js/zustand/slices/createUserSlice.ts
+++ b/static/src/js/zustand/slices/createUserSlice.ts
@@ -73,6 +73,9 @@ const createUserSlice: ImmerStateCreator<UserSlice> = (set, get) => ({
     },
 
     setSitePreferences: (sitePreferences) => {
+      // If the provided preferences are empty, do not update the state
+      if (isEmpty(sitePreferences)) return
+
       const {
         collectionSort,
         mapView: preferencesMapView = {}


### PR DESCRIPTION
# Overview

### What is the feature?

If the preferences loaded from the database are empty, don't put that into the zustand state in the user slice.

I also fixed some tests that were dependent on your local environment being set to prod

### What areas of the application does this impact?

Users who don't have saved preferences

# Testing

Login with a user that does not have preferences saved.
Ensure collection sort does not show "Unknown"

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
