### PR TITLE
EDSC-4533: Fixes bug in retrieving granule links for a newly created order

### DIFF
--- a/serverless/src/retrieveGranuleLinks/__tests__/handler.test.js
+++ b/serverless/src/retrieveGranuleLinks/__tests__/handler.test.js
@@ -533,6 +533,66 @@ describe('retrieveGranuleLinks', () => {
     })
   })
 
+  test('returns links from order_information for esi orders', async () => {
+    const expectedResponse = {
+      done: true,
+      links: [
+        'http://example.com/file1',
+        'http://example.com/file2'
+      ]
+    }
+
+    dbTracker.on('query', (query) => {
+      query.response([{
+        access_method: {
+          type: 'ESI',
+          isValid: true
+        },
+        collection_id: 'C1214470488-ASF',
+        granule_params: {
+          exclude: {},
+          options: {},
+          page_num: 1,
+          temporal: '2023-03-26T15:05:48.871Z,2023-03-27T10:48:39.230Z',
+          page_size: 20,
+          concept_id: [],
+          echo_collection_id: 'C1214470488-ASF',
+          two_d_coordinate_system: {}
+        },
+        collection_metadata: {
+          mock: 'metadata'
+        },
+        order_information: {
+          order: {
+            orderId: 5000006631366,
+            Instructions: 'Your request has completed processing. You may retrieve the results from the download URLs until 2025-12-09 11:30:04.525'
+          },
+          downloadUrls: {
+            downloadUrl: [
+              'http://example.com/file1',
+              'http://example.com/file2'
+            ]
+          }
+        }
+      }])
+    })
+
+    const event = {
+      queryStringParameters: {
+        id: '1234567',
+        flattenLinks: true,
+        linkTypes: 'data,s3'
+      }
+    }
+
+    const response = await retrieveGranuleLinks(event, {})
+
+    expect(response).toEqual(expect.objectContaining({
+      body: JSON.stringify(expectedResponse),
+      statusCode: 200
+    }))
+  })
+
   test('returns an error', async () => {
     dbTracker.on('query', (query) => {
       query.reject('Unknown Error')

--- a/serverless/src/util/fetchGranuleLinks.js
+++ b/serverless/src/util/fetchGranuleLinks.js
@@ -75,7 +75,7 @@ export const fetchGranuleLinks = async ({
       if (retrievalCollectionRows.length > 1) {
         // Combine the `order_information` objects from each row into a single object keyed by the `jobID`
         const combinedOrderInformation = retrievalCollectionRows.reduce((acc, curr) => {
-          const { order_information: currentOrderInformation } = curr
+          const { order_information: currentOrderInformation = {} } = curr
           const {
             jobID: jobId
           } = currentOrderInformation
@@ -111,7 +111,7 @@ export const fetchGranuleLinks = async ({
         // Combine the `order_information` objects from each row into a single object keyed by the `jobID`
         const combinedOrderInformation = retrievalCollectionRows.reduce((acc, curr) => {
           const { order_information: currentOrderInformation } = curr
-          const { downloadUrls, order } = currentOrderInformation
+          const { downloadUrls, order = {} } = currentOrderInformation
           const { orderId } = order
 
           // Initialize the accumulator for this jobID if it doesn't exist


### PR DESCRIPTION
# Overview

### What is the feature?

When fetching retrieval links for an ESI order that hasn't been created yet, we need to default the order object to avoid throwing an error

### What areas of the application does this impact?

ESI Orders

# Testing

### Reproduction steps

Place an ESI order, ensure no errors are thrown

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
