### PR TITLE
EDSC-4588: Fixes drawing collection and granule spatial that use Cartesian coordinates

### DIFF
--- a/static/src/js/types/sharedTypes.ts
+++ b/static/src/js/types/sharedTypes.ts
@@ -36,6 +36,9 @@ export type PointString = string
 /** A polygon string following the CMR format This does not check the format of the string but is used to signify that the string should follow a valid datetime string format. */
 export type PolygonString = string
 
+/** The coordinate system used for spatial data */
+export type CoordinateSystem = 'GEODETIC' | 'CARTESIAN'
+
 /** The spatial object */
 export interface Spatial {
   /** The bounding box coordinates, if applied */

--- a/static/src/js/util/collectionMetadata/__tests__/spatial.test.js
+++ b/static/src/js/util/collectionMetadata/__tests__/spatial.test.js
@@ -388,7 +388,7 @@ describe('getCollectionGeoFeatures', () => {
       test('returns normalized feature collection', () => {
         const metadata = {
           boxes: null,
-          coordinateSystem: 'CARTESIAN',
+          coordinateSystem: 'GEODETIC',
           lines: null,
           points: null,
           polygons: [

--- a/static/src/js/util/collectionMetadata/spatial.js
+++ b/static/src/js/util/collectionMetadata/spatial.js
@@ -90,28 +90,41 @@ export const getCollectionGeoFeatures = (collectionMetadata) => {
 
   const {
     boxes,
+    coordinateSystem,
     lines,
     points,
     polygons
   } = collectionMetadata
 
   if (boxes) {
-    const boxFeatures = normalizeSpatial({ boxes })
+    const boxFeatures = normalizeSpatial({
+      boxes,
+      coordinateSystem
+    })
     collectionGeoFeatures.push(boxFeatures)
   }
 
   if (lines) {
-    const linesFeatures = normalizeSpatial({ lines })
+    const linesFeatures = normalizeSpatial({
+      coordinateSystem,
+      lines
+    })
     collectionGeoFeatures.push(linesFeatures)
   }
 
   if (points) {
-    const pointsFeatures = normalizeSpatial({ points })
+    const pointsFeatures = normalizeSpatial({
+      coordinateSystem,
+      points
+    })
     collectionGeoFeatures.push(pointsFeatures)
   }
 
   if (polygons) {
-    const polygonsFeatures = normalizeSpatial({ polygons })
+    const polygonsFeatures = normalizeSpatial({
+      coordinateSystem,
+      polygons
+    })
     collectionGeoFeatures.push(polygonsFeatures)
   }
 

--- a/static/src/js/util/map/drawSpatialSearch.ts
+++ b/static/src/js/util/map/drawSpatialSearch.ts
@@ -11,7 +11,7 @@ import {
 import { splitListOfPoints } from '@edsc/geo-utils'
 
 import { crsProjections, projectionConfigs } from './crs'
-import { interpolateBoxPolygon, interpolatePolygon } from './normalizeSpatial'
+import { interpolateBoxPolygon, interpolateGeodeticPolygon } from './normalizeSpatial'
 import projectionCodes from '../../constants/projectionCodes'
 import {
   spatialSearchMarkerStyle,
@@ -211,7 +211,7 @@ const drawSpatialSearch = ({
     }, [])
 
     // Interpolate the polygon so that it follows the curvature of the earth
-    const interpolatedCoordinates = interpolatePolygon(coordinates)
+    const interpolatedCoordinates = interpolateGeodeticPolygon(coordinates)
 
     const polygon = new Polygon(interpolatedCoordinates)
 

--- a/static/src/js/util/request/granuleRequest.js
+++ b/static/src/js/util/request/granuleRequest.js
@@ -78,7 +78,7 @@ export default class GranuleRequest extends CmrRequest {
       }
 
       // Create a GeoJSON representation of the granule spatial
-      updatedGranule.spatial = normalizeSpatial(granule)
+      updatedGranule.spatial = normalizeSpatial(camelcaseKeys(granule))
 
       return updatedGranule
     })


### PR DESCRIPTION
# Overview

### What is the feature?

When drawing granule spatial on the map and collection spatial on the collection details minimap we were not taking into account the metadata's coordinateSystem value (geodetic or cartesian), and we were treating every spatial value as geodetic.

This PR checks the coordinateSystem and interpolates polygons correctly

### What areas of the application does this impact?

Drawing cartesian values on the map and minimap

# Testing

http://localhost:8080/search/granules/collection-details?p=C3417454635-LARC_ASDC&pg[0][v]=f&pg[0][gsk]=-start_date&q=CER_GEO&lat=8.48295025472955&long=111.94671965435339&zoom=2.553813152415792

### Attachments

Incorrect (curved line at top of polygon): 
<img width="1115" height="550" alt="Screenshot 2025-12-02 at 1 09 37 PM" src="https://github.com/user-attachments/assets/b14fc152-1243-4f79-90e4-456890f5fb31" />

Correct (straight lines):
<img width="1092" height="545" alt="Screenshot 2025-12-02 at 1 10 43 PM" src="https://github.com/user-attachments/assets/fd9578d5-3e12-444a-9bb2-8c493ed76953" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
