### PR TITLE
EDSC-4539: Fixes shapefile upload modal

### DIFF
--- a/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.jsx
+++ b/static/src/js/containers/ShapefileDropzoneContainer/ShapefileDropzoneContainer.jsx
@@ -1,4 +1,4 @@
-import React, {} from 'react'
+import React from 'react'
 
 import { eventEmitter } from '../../events/events'
 import { shapefileEventTypes } from '../../constants/eventTypes'
@@ -6,8 +6,7 @@ import { shapefileEventTypes } from '../../constants/eventTypes'
 import ShapefileDropzone from '../../components/Dropzone/ShapefileDropzone'
 
 import useEdscStore from '../../zustand/useEdscStore'
-import { isModalOpen, setOpenModalFunction } from '../../zustand/selectors/ui'
-import { MODAL_NAMES } from '../../constants/modalNames'
+import { setOpenModalFunction } from '../../zustand/selectors/ui'
 
 // Add an edscId to each feature in the shapefile
 const addEdscIdsToShapefile = (file) => {
@@ -58,7 +57,6 @@ export const ShapefileDropzoneContainer = () => {
     onSaveShapefile: state.shapefile.saveShapefile,
     removeSpatialFilter: state.query.removeSpatialFilter
   }))
-  const isOpen = useEdscStore((state) => isModalOpen(state, MODAL_NAMES.SHAPEFILE_UPLOAD))
   const setOpenModal = useEdscStore(setOpenModalFunction)
 
   return (
@@ -75,7 +73,7 @@ export const ShapefileDropzoneContainer = () => {
           onShapefileLoading(name)
 
           // Ensure the shapefile is closed
-          if (isOpen) setOpenModal(null)
+          setOpenModal(null)
         }
       }
       onSuccess={

--- a/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.jsx
+++ b/static/src/js/containers/ShapefileDropzoneContainer/__tests__/ShapefileDropzoneContainer.test.jsx
@@ -60,6 +60,11 @@ describe('ShapefileDropzoneContainer component', () => {
         overrideZustandState: {
           shapefile: {
             setLoading: onShapefileLoadingMock
+          },
+          ui: {
+            modals: {
+              openModal: MODAL_NAMES.SHAPEFILE_UPLOAD
+            }
           }
         }
       })
@@ -80,41 +85,9 @@ describe('ShapefileDropzoneContainer component', () => {
 
       expect(onShapefileLoadingMock).toHaveBeenCalledTimes(1)
       expect(onShapefileLoadingMock).toHaveBeenCalledWith('test-file-name.zip')
-    })
 
-    describe('when the shapefile modal is open', () => {
-      test('calls setOpenModal to close the modal', async () => {
-        const eventEmitterEmitMock = jest.spyOn(EventEmitter.eventEmitter, 'emit')
-        eventEmitterEmitMock.mockImplementation(() => jest.fn())
-        const onSaveShapefileMock = jest.fn()
-
-        const { zustandState } = setup({
-          overrideZustandState: {
-            shapefile: {
-              saveShapefile: onSaveShapefileMock
-            },
-            ui: {
-              modals: {
-                openModal: MODAL_NAMES.SHAPEFILE_UPLOAD
-              }
-            }
-          }
-        })
-
-        const mockFile = {
-          name: 'test-file-name.zip'
-        }
-
-        const componentProps = ShapefileDropzone.mock.calls[0][0]
-        const { onSending } = componentProps
-
-        await act(() => {
-          onSending(mockFile)
-        })
-
-        expect(zustandState.ui.modals.setOpenModal).toHaveBeenCalledTimes(1)
-        expect(zustandState.ui.modals.setOpenModal).toHaveBeenCalledWith(null)
-      })
+      expect(zustandState.ui.modals.setOpenModal).toHaveBeenCalledTimes(1)
+      expect(zustandState.ui.modals.setOpenModal).toHaveBeenCalledWith(null)
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

The shapefile upload modal was not closing correctly when uploading a shapefile. Instead of closing the modal in onSuccess or onError, I changed it to close in onSending

### What areas of the application does this impact?

Shapefile uploading when the modal is open

# Testing

Open the shapefile upload modal (either from map controls or the spatial dropdown.
Upload a shapefile (either selecting a file or dropping a file)
Ensure the modal closes

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
