### PR TITLE
EDSC-4605: Removes handleAlert from Redux

### DIFF
--- a/static/src/js/actions/index.js
+++ b/static/src/js/actions/index.js
@@ -3,7 +3,6 @@ import {
   changePath,
   updateStore
 } from './urlQuery'
-import { handleAlert } from './alerts'
 import {
   createSubscription,
   deleteCollectionSubscription,
@@ -23,7 +22,6 @@ const actions = {
   deleteSubscription,
   getGranuleSubscriptions,
   getSubscriptions,
-  handleAlert,
   removeSubscriptionDisabledFields,
   updateStore,
   updateSubscription,

--- a/static/src/js/util/__tests__/handleAlert.test.ts
+++ b/static/src/js/util/__tests__/handleAlert.test.ts
@@ -1,10 +1,5 @@
 import nock from 'nock'
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-
-import { handleAlert } from '../alerts'
-
-const mockStore = configureMockStore([thunk])
+import { handleAlert } from '../handleAlert'
 
 describe('handleAlert', () => {
   test('calls lambda to log alert', async () => {
@@ -21,17 +16,14 @@ describe('handleAlert', () => {
       })
       .reply(200)
 
-    // MockStore with initialState
-    const store = mockStore({})
-
-    await store.dispatch(handleAlert({
+    handleAlert({
       action: 'mockAction',
       message: 'Mock message',
       resource: 'mockResource',
       requestObject: {
         requestId: 'mockRequestId'
       }
-    }))
+    })
 
     expect(consoleMock).toHaveBeenCalledTimes(1)
     expect(consoleMock).toHaveBeenCalledWith('Action [mockAction] alert: Mock message')

--- a/static/src/js/util/handleAlert.ts
+++ b/static/src/js/util/handleAlert.ts
@@ -1,15 +1,23 @@
 import { v4 as uuidv4 } from 'uuid'
 
-import LoggerRequest from '../util/request/loggerRequest'
-import routerHelper from '../router/router'
+// @ts-expect-error This file does not have types
+import LoggerRequest from './request/loggerRequest'
+import routerHelper, { type Router } from '../router/router'
 
 export const handleAlert = ({
   message,
   action,
   resource,
   requestObject
-}) => () => {
-  const { location } = routerHelper.router
+}: {
+  message: string,
+  action: string,
+  resource?: string,
+  requestObject?: {
+    requestId: string
+  }
+}) => {
+  const { location } = routerHelper.router?.state || {} as Router['state']
 
   let requestId = uuidv4()
   if (requestObject) {

--- a/static/src/js/zustand/slices/__tests__/createProjectSlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createProjectSlice.test.ts
@@ -8,13 +8,12 @@ import { initialGranuleState, initialState } from '../createProjectSlice'
 import configureStore from '../../../store/configureStore'
 
 // @ts-expect-error This file does not have types
-import actions from '../../../actions'
-// @ts-expect-error This file does not have types
 import GranuleRequest from '../../../util/request/granuleRequest'
 
 // @ts-expect-error This file does not have types
 import * as applicationConfig from '../../../../../../sharedUtils/config'
 import { EchoOrderAccessMethod } from '../../types'
+import { handleAlert } from '../../../util/handleAlert'
 
 jest.mock('uuid', () => ({
   v4: jest.fn(() => 'mock-request-id')
@@ -28,15 +27,14 @@ jest.mock('../../../../../../sharedUtils/getClientId', () => ({
 
 jest.mock('../../../store/configureStore', () => jest.fn())
 
-jest.mock('../../../actions', () => ({
-  handleAlert: jest.fn(),
-  handleError: jest.fn()
-}))
-
 jest.spyOn(applicationConfig, 'getEarthdataConfig').mockImplementation(() => ({
   cmrHost: 'https://cmr.example.com',
   graphQlHost: 'https://graphql.example.com',
   opensearchRoot: 'https://cmr.example.com/opensearch'
+}))
+
+jest.mock('../../../util/handleAlert', () => ({
+  handleAlert: jest.fn()
 }))
 
 beforeEach(() => {
@@ -1493,8 +1491,8 @@ describe('createProjectSlice', () => {
 
         await project.getProjectGranules()
 
-        expect(actions.handleAlert).toHaveBeenCalledTimes(1)
-        expect(actions.handleAlert).toHaveBeenCalledWith({
+        expect(handleAlert).toHaveBeenCalledTimes(1)
+        expect(handleAlert).toHaveBeenCalledWith({
           action: 'getProjectGranules',
           message: 'User requested more than 1 granules. Requested 2 granules.',
           resource: 'granules',

--- a/static/src/js/zustand/slices/createProjectSlice.ts
+++ b/static/src/js/zustand/slices/createProjectSlice.ts
@@ -11,9 +11,6 @@ import { getApplicationConfig } from '../../../../../sharedUtils/config'
 import configureStore from '../../store/configureStore'
 
 // @ts-expect-error This file does not have types
-import actions from '../../actions'
-
-// @ts-expect-error This file does not have types
 import { buildAccessMethods } from '../../util/accessMethods/buildAccessMethods'
 // @ts-expect-error This file does not have types
 import { buildCollectionSearchParams, prepareCollectionParams } from '../../util/collections'
@@ -50,6 +47,7 @@ import OpenSearchGranuleRequest from '../../util/request/openSearchGranuleReques
 // @ts-expect-error This file does not have types
 import GraphQlRequest from '../../util/request/graphQlRequest'
 import SavedAccessConfigsRequest from '../../util/request/savedAccessConfigsRequest'
+import { handleAlert } from '../../util/handleAlert'
 
 import getProjectCollections from '../../operations/queries/getProjectCollections'
 
@@ -474,10 +472,6 @@ const createProjectSlice: ImmerStateCreator<ProjectSlice> = (set, get) => ({
     getProjectGranules: async () => {
       const { defaultCmrPageSize, maxCmrPageSize } = getApplicationConfig()
 
-      const {
-        dispatch: reduxDispatch
-      } = configureStore()
-
       const zustandState = get()
       const edlToken = getEdlToken(zustandState)
       const earthdataEnvironment = getEarthdataEnvironment(zustandState)
@@ -547,12 +541,12 @@ const createProjectSlice: ImmerStateCreator<ProjectSlice> = (set, get) => ({
         let pageSize = defaultCmrPageSize
         if (granuleConceptIds.length > 0) {
           if (granuleConceptIds.length > maxCmrPageSize) {
-            reduxDispatch(actions.handleAlert({
+            handleAlert({
               action: 'getProjectGranules',
               message: `User requested more than ${maxCmrPageSize} granules. Requested ${granuleConceptIds.length} granules.`,
               resource: 'granules',
               requestObject
-            }))
+            })
           }
 
           pageSize = Math.min(maxCmrPageSize, granuleConceptIds.length)


### PR DESCRIPTION
# Overview

### What is the feature?

Removes handleAlert from Redux

### What areas of the application does this impact?

This alert is only triggered when the user adds more granules than the max cmr page size (2000). This is only when the user individually adds the granules, not when the collection contains more than 2000.

# Testing

Add individual granules, more than 2000 to your project, ensure the alert lambda is called.
For local testing you can override this value in overrideStatic.config.json (application.maxCmrPageSize), set it to 1, then add two granules and you will see the network request

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
