### PR TITLE
EDSC-4593: Fixes deployments

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -34,7 +34,7 @@ config="`jq '.application.orderStatusRefreshTime = $newValue' --arg newValue $ba
 config="`jq '.application.orderStatusRefreshTimeCreating = $newValue' --arg newValue $bamboo_ORDER_STATUS_REFRESH_TIME_CREATING <<< $config`"
 config="`jq '.application.collectionSearchResultsSortKey = $newValue' --arg newValue $bamboo_COLLECTION_SEARCH_RESULTS_SORT_KEY <<< $config`"
 config="`jq '.application.mapPointsSimplifyThreshold = $newValue' --arg newValue $bamboo_MAP_POINTS_SIMPLIFY_THRESHOLD <<< $config`"
-config="`jq '.application.numberOfGranules = $newValue' --arg newValue $bamboo_NUMBER_OF_GRANULES <<< $config`"
+config="`jq '.application.numberOfGranules = $newValue' --arg newValue "$bamboo_NUMBER_OF_GRANULES" <<< $config`"
 config="`jq '.application.placeLabelsStyleUrl = $newValue' --arg newValue $bamboo_PLACE_LABELS_STYLE_URL <<< $config`"
 config="`jq '.environment.production.apiHost = $newValue' --arg newValue $bamboo_API_HOST <<< $config`"
 config="`jq '.environment.production.edscHost = $newValue' --arg newValue $bamboo_EDSC_HOST <<< $config`"


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes deployments when the bamboo_NUMBER_OF_GRANULES variable will have spaces

### What areas of the application does this impact?

Deploying

# Testing

Deploy the app

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
