### PR TITLE
EDSC-4025: Added ".prj" to Search by Shape File modal's "Valid format…

### DIFF
--- a/static/src/js/components/ShapefileUploadModal/ShapefileUploadModal.jsx
+++ b/static/src/js/components/ShapefileUploadModal/ShapefileUploadModal.jsx
@@ -53,7 +53,7 @@ const ShapefileUploadModal = () => {
           Valid formats include:
         </p>
         <ul>
-          <li>Shapefile (.zip including .shp, .dbf, and .shx file)</li>
+          <li>Shapefile (.zip including .shp, .dbf, .shx and .prj file)</li>
           <li>Keyhole Markup Language (.kml or .kmz)</li>
           <li>GeoJSON (.json or .geojson)</li>
           <li>GeoRSS (.rss, .georss, or .xml)</li>


### PR DESCRIPTION
Solves issue with uploading shape files

# Overview

### What is the feature?

Shape files cannot be properly uploaded to EDSC.

### What is the Solution?

Need to add all required shape file .zip components. EDSC's instructions need to request the user to include a ".prj" file in their .zip as well.

### What areas of the application does this impact?

- Spatial Search modal, choosing the "File (KML, KMZ, ESRI, ...)" option.

# Testing

### Reproduction steps

- **Environment for testing:** SIT
- **Collection to test with:** N/A

1. Run EDSC locally and click the Spatial Search dropdown.
2. Select the "File (KML, KMZ, ESRI, ...)" option, and the "Valid formats" should include "Shapefile (.zip including .shp, .dbf, **.shx and .prj file**) instead of "Shapefile (.zip including .shp, .dbf, **and .shx file**)"

### Attachments

N/A

# Checklist

Just a simple text display change.

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings