### PR TITLE
EDSC-4667: Pressing 'Enter' in Granules Subscription Name Field brings you pack to /search

### DIFF
--- a/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
+++ b/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
@@ -223,7 +223,17 @@ export const SubscriptionsBody = ({
               Subscribe to be notified by email when new data matching your search query becomes available.
             </p>
             <div className="subscriptions-body__query">
-              <Form>
+              <Form
+                onSubmit={
+                  (e) => {
+                    e.preventDefault()
+                    if (!displayWarning) {
+                      setSubmittingNewSubscription(true)
+                      handleCreateSubscription()
+                    }
+                  }
+                }
+              >
                 <div className="subscriptions-body__query-primary">
                   <h4 className="subscriptions-body__query-primary-heading h6">Create a new subscription</h4>
                   <Form.Group className="subscriptions-body__form-group subscriptions-body__form-group--coords mb-3">
@@ -305,13 +315,7 @@ export const SubscriptionsBody = ({
                     label="Create Subscription"
                     spinner={submittingNewSubscription}
                     icon={Plus}
-                    onClick={
-                      async () => {
-                        setSubmittingNewSubscription(true)
-
-                        handleCreateSubscription()
-                      }
-                    }
+                    type="submit"
                   >
                     Create Subscription
                   </Button>

--- a/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
+++ b/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
@@ -224,6 +224,7 @@ export const SubscriptionsBody = ({
             </p>
             <div className="subscriptions-body__query">
               <Form
+                // Natively triggers both when a user clicks submit or hits enter
                 onSubmit={
                   (e) => {
                     e.preventDefault()

--- a/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
+++ b/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
@@ -144,7 +144,104 @@ describe('SubscriptionsBody component', () => {
       const button = screen.getByRole('button', { name: 'Create Subscription' })
       await user.click(button)
 
-      expect(addToast).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledTimes(1)
+      })
+
+      expect(addToast).toHaveBeenCalledWith('Subscription created', {
+        appearance: 'success',
+        autoDismiss: true
+      })
+    })
+
+    test('submits the form when Enter is pressed in the input field', async () => {
+      const { user } = setup({
+        overrideZustandState: {
+          query: {
+            collection: {
+              hasGranulesOrCwic: true,
+              spatial: {
+                point: ['39.76036, -78.7812']
+              }
+            }
+          }
+        },
+        overrideApolloClientMocks: [{
+          request: {
+            query: SUBSCRIPTIONS,
+            variables: {
+              params: {
+                subscriberId: 'testuser',
+                type: 'collection'
+              }
+            }
+          },
+          result: {
+            data: {
+              subscriptions: {
+                items: []
+              }
+            }
+          }
+        }, {
+          request: {
+            query: CREATE_SUBSCRIPTION,
+            variables: {
+              params: {
+                subscriberId: 'testuser',
+                name: 'Dataset Search Subscription (Point)',
+                type: 'collection',
+                query: 'has_granules_or_cwic=true&point[]=39.76036, -78.7812'
+              }
+            }
+          },
+          result: {
+            data: {
+              createSubscription: {
+                conceptId: 'SUB-12345'
+              }
+            }
+          }
+        }, {
+          request: {
+            query: SUBSCRIPTIONS,
+            variables: {
+              params: {
+                subscriberId: 'testuser',
+                type: 'collection'
+              }
+            }
+          },
+          result: {
+            data: {
+              subscriptions: {
+                items: [{
+                  collection: {
+                    conceptId: 'C123-PROV',
+                    title: 'Test Collection'
+                  },
+                  collectionConceptId: 'C123-PROV',
+                  conceptId: 'SUB-12345',
+                  creationDate: '2024-01-01T12:00:00Z',
+                  name: 'Dataset Search Subscription (Point)',
+                  nativeId: 'native-id-12345',
+                  query: 'has_granules_or_cwic=true&point[]=39.76036, -78.7812',
+                  revisionDate: '2024-01-01T12:00:00Z',
+                  type: 'collection'
+                }]
+              }
+            }
+          }
+        }]
+      })
+
+      const input = screen.getByRole('textbox')
+      await user.type(input, '{Enter}')
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledTimes(1)
+      })
+
       expect(addToast).toHaveBeenCalledWith('Subscription created', {
         appearance: 'success',
         autoDismiss: true
@@ -287,7 +384,10 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create New Subscription' })
         await user.click(button)
 
-        expect(addToast).toHaveBeenCalledTimes(1)
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledTimes(1)
+        })
+
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',
           autoDismiss: true
@@ -373,7 +473,10 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create Subscription' })
         await user.click(button)
 
-        expect(addToast).toHaveBeenCalledTimes(1)
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledTimes(1)
+        })
+
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',
           autoDismiss: true
@@ -475,7 +578,10 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create Subscription' })
         await user.click(button)
 
-        expect(addToast).toHaveBeenCalledTimes(1)
+        await waitFor(() => {
+          expect(addToast).toHaveBeenCalledTimes(1)
+        })
+
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',
           autoDismiss: true

--- a/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
+++ b/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
@@ -380,9 +380,7 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create New Subscription' })
         await user.click(button)
 
-        await waitFor(() => {
-          expect(addToast).toHaveBeenCalledTimes(1)
-        })
+        expect(addToast).toHaveBeenCalledTimes(1)
 
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',
@@ -469,9 +467,7 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create Subscription' })
         await user.click(button)
 
-        await waitFor(() => {
-          expect(addToast).toHaveBeenCalledTimes(1)
-        })
+        expect(addToast).toHaveBeenCalledTimes(1)
 
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',
@@ -574,9 +570,7 @@ describe('SubscriptionsBody component', () => {
         const button = screen.getByRole('button', { name: 'Create Subscription' })
         await user.click(button)
 
-        await waitFor(() => {
-          expect(addToast).toHaveBeenCalledTimes(1)
-        })
+        expect(addToast).toHaveBeenCalledTimes(1)
 
         expect(addToast).toHaveBeenCalledWith('Subscription created', {
           appearance: 'success',

--- a/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
+++ b/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
@@ -144,9 +144,7 @@ describe('SubscriptionsBody component', () => {
       const button = screen.getByRole('button', { name: 'Create Subscription' })
       await user.click(button)
 
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledTimes(1)
-      })
+      expect(addToast).toHaveBeenCalledTimes(1)
 
       expect(addToast).toHaveBeenCalledWith('Subscription created', {
         appearance: 'success',
@@ -238,9 +236,7 @@ describe('SubscriptionsBody component', () => {
       const input = screen.getByRole('textbox')
       await user.type(input, '{Enter}')
 
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledTimes(1)
-      })
+      expect(addToast).toHaveBeenCalledTimes(1)
 
       expect(addToast).toHaveBeenCalledWith('Subscription created', {
         appearance: 'success',


### PR DESCRIPTION
# Overview

### What is the feature?

Go to Granule Subscriptions. Under Name type in anything and press 'enter'. Or just press enter without typing anything. Notice you are redirected to the /search. This happens for collection subscriptions as well.

### What is the Solution?

Fixed so that pressing enter submits the form (regardless of whether a name as been entered or not) instead of redirecting

### What areas of the application does this impact?

SubscriptionsBody

# Testing

### Reproduction steps

1. Go to Granule Subscriptions. Under Name type in anything and press 'enter'. Should create the subscription.
2. Go to Granule Subscriptions. Don't type anything in the name field and press enter. Nothing should happen.
3. Go to Collection Subscriptions. Don't type anything in the name field and press enter. A new subscription should be created.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
