### PR TITLE
EDSC-4660: Fixes issue with removing "Granule ID(s)" value, and changing other values when Granule ID(s) is present

### DIFF
--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/handleFormSubmit.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/handleFormSubmit.test.js
@@ -79,4 +79,40 @@ describe('handleFormSubmit', () => {
       expect(setSubmittingMock).toHaveBeenCalledWith(false)
     })
   })
+
+  describe('when readableGranuleName is defined with whitespace', () => {
+    test('splits the value on the comma and trims whitespace', () => {
+      useEdscStore.setState({
+        query: {
+          changeGranuleQuery: vi.fn()
+        }
+      })
+
+      const values = {
+        readableGranuleName: ' 1, 2 , 3 '
+      }
+
+      const config = {
+        props: {
+          collectionMetadata: {
+            conceptId: 'collectionId'
+          }
+        },
+        setSubmitting: setSubmittingMock
+      }
+
+      handleFormSubmit(values, config)
+
+      const zustandState = useEdscStore.getState()
+      const { query } = zustandState
+      expect(query.changeGranuleQuery).toHaveBeenCalledTimes(1)
+      expect(query.changeGranuleQuery).toHaveBeenCalledWith({
+        collectionId: 'collectionId',
+        query: { readableGranuleName: ['1', '2', '3'] }
+      })
+
+      expect(setSubmittingMock).toHaveBeenCalledTimes(1)
+      expect(setSubmittingMock).toHaveBeenCalledWith(false)
+    })
+  })
 })

--- a/static/src/js/containers/GranuleFiltersContainer/__tests__/mapPropsToValues.test.js
+++ b/static/src/js/containers/GranuleFiltersContainer/__tests__/mapPropsToValues.test.js
@@ -1,0 +1,156 @@
+import useEdscStore from '../../../zustand/useEdscStore'
+import mapPropsToValues from '../mapPropsToValues'
+
+describe('mapPropsToValues', () => {
+  describe('when there are no granule query values', () => {
+    test('should return the expected values', () => {
+      const expected = {
+        browseOnly: false,
+        cloudCover: {
+          max: '',
+          min: ''
+        },
+        dayNightFlag: '',
+        equatorCrossingDate: {
+          endDate: '',
+          startDate: ''
+        },
+        equatorCrossingLongitude: {
+          max: '',
+          min: ''
+        },
+        gridCoords: '',
+        onlineOnly: false,
+        orbitNumber: {
+          max: '',
+          min: ''
+        },
+        readableGranuleName: '',
+        temporal: {
+          endDate: '',
+          isRecurring: false,
+          recurringDayEnd: '',
+          recurringDayStart: '',
+          startDate: ''
+        },
+        tilingSystem: ''
+      }
+
+      const actual = mapPropsToValues()
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('when there are granule query values', () => {
+    test('should return the expected values', () => {
+      useEdscStore.setState({
+        collection: {
+          collectionId: 'collectionId'
+        },
+        query: {
+          collection: {
+            byId: {
+              collectionId: {
+                granules: {
+                  browseOnly: true,
+                  cloudCover: {
+                    max: '100',
+                    min: '0'
+                  },
+                  dayNightFlag: 'DAY',
+                  equatorCrossingDate: {
+                    endDate: '2020-01-01T00:00:00Z',
+                    startDate: '2020-01-01T00:00:00Z'
+                  },
+                  equatorCrossingLongitude: {
+                    max: '100',
+                    min: '0'
+                  },
+                  gridCoords: 'gridCoords',
+                  onlineOnly: true,
+                  orbitNumber: {
+                    max: '100',
+                    min: '0'
+                  },
+                  readableGranuleName: 'readableGranuleName',
+                  temporal: {
+                    endDate: '2020-01-01T00:00:00Z',
+                    isRecurring: true,
+                    recurringDayEnd: '10',
+                    recurringDayStart: '1',
+                    startDate: '2020-01-01T00:00:00Z'
+                  },
+                  tilingSystem: 'tilingSystem'
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const expected = {
+        browseOnly: true,
+        cloudCover: {
+          max: '100',
+          min: '0'
+        },
+        dayNightFlag: 'DAY',
+        equatorCrossingDate: {
+          endDate: '2020-01-01T00:00:00Z',
+          startDate: '2020-01-01T00:00:00Z'
+        },
+        equatorCrossingLongitude: {
+          max: '100',
+          min: '0'
+        },
+        gridCoords: 'gridCoords',
+        onlineOnly: true,
+        orbitNumber: {
+          max: '100',
+          min: '0'
+        },
+        readableGranuleName: 'readableGranuleName',
+        temporal: {
+          endDate: '2020-01-01T00:00:00Z',
+          isRecurring: true,
+          recurringDayEnd: '10',
+          recurringDayStart: '1',
+          startDate: '2020-01-01T00:00:00Z'
+        },
+        tilingSystem: 'tilingSystem'
+      }
+
+      const actual = mapPropsToValues()
+
+      expect(actual).toEqual(expected)
+    })
+
+    describe('when readableGranuleName is an array', () => {
+      test('should join the array values with a comma', () => {
+        useEdscStore.setState({
+          collection: {
+            collectionId: 'collectionId'
+          },
+          query: {
+            collection: {
+              byId: {
+                collectionId: {
+                  granules: {
+                    readableGranuleName: ['readableGranuleName1', 'readableGranuleName2']
+                  }
+                }
+              }
+            }
+          }
+        })
+
+        const expected = 'readableGranuleName1,readableGranuleName2'
+
+        const actual = mapPropsToValues().readableGranuleName
+
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+})

--- a/static/src/js/containers/GranuleFiltersContainer/handleFormSubmit.js
+++ b/static/src/js/containers/GranuleFiltersContainer/handleFormSubmit.js
@@ -7,11 +7,11 @@ export const handleFormSubmit = (values, { props, setSubmitting }) => {
 
   let granuleFilters = { ...values }
 
-  // `readableGranuleName` needs to be sent as an array, split on the ','
+  // `readableGranuleName` needs to be sent as an array, split on the ',' and trim any whitespace
   if (readableGranuleName) {
     granuleFilters = {
       ...granuleFilters,
-      readableGranuleName: readableGranuleName.split(',')
+      readableGranuleName: readableGranuleName.split(',').map((name) => name.trim())
     }
   }
 

--- a/static/src/js/containers/GranuleFiltersContainer/mapPropsToValues.js
+++ b/static/src/js/containers/GranuleFiltersContainer/mapPropsToValues.js
@@ -75,7 +75,9 @@ export const mapPropsToValues = () => {
       recurringDayEnd: temporalRecurringDayEnd || '',
       isRecurring: temporalIsRecurring || false
     },
-    readableGranuleName: readableGranuleName || ''
+    readableGranuleName: Array.isArray(readableGranuleName)
+      ? readableGranuleName.join(',')
+      : readableGranuleName || ''
   }
 }
 

--- a/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
@@ -368,6 +368,7 @@ describe('createQuerySlice', () => {
           state.query.collection.byId.collectionId = {
             granules: {
               ...initialGranuleQuery,
+              readableGranuleName: ['granuleName'],
               pageNum: 2
             }
           }
@@ -390,6 +391,7 @@ describe('createQuerySlice', () => {
 
         expect(updatedQuery.collection.byId.collectionId.granules).toEqual({
           ...initialGranuleQuery,
+          readableGranuleName: ['granuleName'],
           pageNum: 3
         })
 

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -105,16 +105,22 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
           }
         }
 
-        const prunedQuery = pruneFilters(query)
-
-        if (isEmpty(prunedQuery)) {
+        if (isEmpty(query)) {
           state.query.collection.byId[collectionId].granules = {
             ...initialGranuleQuery
           }
         } else {
+          const currentGranuleQuery = state.query.collection.byId[collectionId]?.granules || {}
+
+          const mergedQuery = {
+            ...currentGranuleQuery,
+            ...query
+          }
+
+          const prunedQuery = pruneFilters(mergedQuery)
+
           state.query.collection.byId[collectionId].granules = {
             ...initialGranuleQuery,
-            ...state.query.collection.byId[collectionId]?.granules,
             ...prunedQuery
           }
         }


### PR DESCRIPTION
# Overview

### What is the feature?

1) After applying a granule id (readableGranuleName), you are unable to remove that field by deleting the text.
2) Also after applying a granule id you are unable to edit other fields in the form, like checking the "Find only granules that have browse images" checkbox.

### What is the Solution?

1) To fix not being able to remove the granule id, the fix is in changeGranuleQuery in the query slice. We need to take into account the current granule query before merging with the incoming query and pruning of empty fields.

2) To fix applying other filters, the fix was in mapPropsToValues, where we needed to correctly map an array `readableGranuleName` to a string to keep Formik from breaking and not being able to submit the form correctly when another field was changed.

### What areas of the application does this impact?

Granule filters

# Testing

### Reproduction steps

1)
- Load any collection's granules
- Apply a Granule ID(s) filter (type value and tab/enter)
- Ensure filter is applied (granules refresh and `granules.json` network request has correct filter)
- Delete Granule ID(s) text and tab/enter
- Ensure filter is removed (granules refresh and `granules.json` network request removed the filter)

2)
- Load any collection's granules
- Apply a Granule ID(s) filter (type value and tab/enter)
- Check the "Find only granules that have browse images" checkbox
- Ensure both filters are applied (granules refresh and `granules.json` network request has correct filters)


### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
