### PR TITLE
EDSC-4668: Wait for username to be loaded before fetching subscriptions

### DIFF
--- a/static/src/js/components/SubscriptionsList/SubscriptionsList.jsx
+++ b/static/src/js/components/SubscriptionsList/SubscriptionsList.jsx
@@ -21,6 +21,7 @@ const SubscriptionsList = () => {
   const username = useEdscStore(getUsername)
 
   const { data, loading } = useQuery(SUBSCRIPTIONS, {
+    skip: !username,
     variables: {
       params: {
         subscriberId: username
@@ -41,7 +42,7 @@ const SubscriptionsList = () => {
     <>
       <h2 className="route-wrapper__page-heading">Subscriptions</h2>
       {
-        (loading) && (
+        (loading || !username) && (
           <Spinner
             className="subscriptions-list__spinner"
             type="dots"

--- a/static/src/js/components/SubscriptionsList/__tests__/SubscriptionsList.test.jsx
+++ b/static/src/js/components/SubscriptionsList/__tests__/SubscriptionsList.test.jsx
@@ -117,4 +117,19 @@ describe('SubscriptionsList component', () => {
       }, {})
     })
   })
+
+  describe('when the username has not been loaded yet', () => {
+    it('should not fetch subscriptions', async () => {
+      setup({
+        overrideZustandState: {
+          user: {
+            username: null
+          }
+        }
+      })
+
+      expect(Spinner).toHaveBeenCalledTimes(1)
+      expect(SubscriptionsListTable).toHaveBeenCalledTimes(0)
+    })
+  })
 })


### PR DESCRIPTION
# Overview

### What is the feature?

When loading /subscriptions, we need to wait for the username to be available before fetching the subscriptions.

### What is the Solution?

Added `skip` to the `userQuery` to wait for the username, and added a username check to show the spinner when the username has not be loaded.

### What areas of the application does this impact?

The /subscriptions page

# Testing

### Reproduction steps

You can replicate this issue locally by first running `npm run build && npm run preview` in one terminal (this runs the production build), then after it is running run `npm start` in another terminal (this loads the api).

- Load http://localhost:8080/subscriptions
- - If you aren't logged in it will redirect you
- Once you are logged in, open your network tab in devtools and refresh the page, ensure only one call to api for the "Subscriptions" query is requested.

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings