### PR TITLE
EDSC-4654: Split bounding boxes that cross the anti-meridian to draw correctly on the map

### DIFF
--- a/static/src/js/util/map/__tests__/normalizeSpatial.test.ts
+++ b/static/src/js/util/map/__tests__/normalizeSpatial.test.ts
@@ -116,6 +116,43 @@ describe('normalizeSpatial', () => {
         })
       })
     })
+
+    describe('when the box crosses the antimeridian', () => {
+      test('returns a geojson multi polygon', () => {
+        const granule = {
+          boxes: ['51.37013 178.36708 52.38609 -179.99104']
+        }
+
+        const response = normalizeSpatial(granule)
+
+        expect(response).toEqual({
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: [
+              [
+                [
+                  [180, 52.38615173370995],
+                  [178.36708, 52.38609],
+                  [178.36708, 51.37013],
+                  [178.36708, 51.37013],
+                  [180, 51.37019227207734]
+                ]
+              ],
+              [
+                [
+                  [-180, 51.37019227207734],
+                  [-179.99104, 51.37013],
+                  [-179.99104, 52.38609],
+                  [-180, 52.38615173370995]
+                ]
+              ]
+            ]
+          }
+        })
+      })
+    })
   })
 
   describe('when the granule has a line', () => {

--- a/static/src/js/util/map/normalizeSpatial.ts
+++ b/static/src/js/util/map/normalizeSpatial.ts
@@ -266,10 +266,27 @@ const normalizeSpatial = (metadata: {
         [swLon, swLat]
       ])
 
-      // Interpolate the polygon to add points between each point
-      const interpolatedPolygon = interpolateBoxPolygon(polygonCoordinates, 250, 6)
+      // Divide the polygon if it crosses the antimeridian
+      const { interiors: dividedCoordinates } = dividePolygon(polygonCoordinates.map(
+        ([lng, lat]: number[]) => ({
+          lng,
+          lat
+        })
+      ))
 
-      multiPolygons.push(interpolatedPolygon)
+      // Add each divided polygon to the multi-polygon array
+      dividedCoordinates.forEach((dividedPolygon: { lat: number, lng: number }[]) => {
+        const dividedPolygonCoordinates = dividedPolygon.map((point) => [point.lng, point.lat])
+
+        // Interpolate the polygon to add points between each point
+        const interpolatedPolygon = interpolateBoxPolygon(
+          dividedPolygonCoordinates,
+          250,
+          6
+        )
+
+        multiPolygons.push(interpolatedPolygon)
+      })
     })
 
     // Return the bounding box as GeoJSON MultiPolygon


### PR DESCRIPTION
# Overview

### What is the feature?

We already split polygons and lines across the anti-meridian, but we don't split bounding boxes, so they do not show up correctly when drawn on our map.

### What is the Solution?

Spilt bounding boxes that cross the anti-meridian

### What areas of the application does this impact?

Drawing granules on the map

# Testing

This UAT granule crosses with bounding box spatial. It should be drawn as two bounding boxes instead of one crossing the whole globe

http://localhost:8080/search/granules?p=C1275699127-ASF&pg[0][v]=f&pg[0][id]=OPERA_L3_DIST-ALERT-S1_T60UXC_20250123T182734Z_20260331T123639Z_S1A_30_v0.1&pg[0][gsk]=-start_date&ee=uat&q=OPERA_L3_DIST-ALERT-S1_V1


### Attachments

Incorrect:
<img width="1086" height="277" alt="Screenshot 2026-05-12 at 4 38 11 PM" src="https://github.com/user-attachments/assets/fc56ec11-f1ee-4854-9421-5ab33b7b542b" />

Correct:
<img width="218" height="152" alt="Screenshot 2026-05-12 at 4 38 26 PM" src="https://github.com/user-attachments/assets/f5d6e1db-6de3-42bf-a98e-4ad27b891057" />
<img width="95" height="114" alt="Screenshot 2026-05-12 at 4 38 20 PM" src="https://github.com/user-attachments/assets/346f480b-f11a-44c0-b826-fb7906fab685" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test covering bounding boxes that cross the antimeridian to validate normalized GeoJSON output.

* **Bug Fixes**
  * Improved spatial normalization for antimeridian-crossing regions by splitting affected boxes and producing correct MultiPolygon coordinate sets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasa/earthdata-search/pull/2048)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->