### PR TITLE
EDSC-4671: Fix obdaac portal config

### DIFF
--- a/portals/obdaac/config.json
+++ b/portals/obdaac/config.json
@@ -36,8 +36,8 @@
     "secondary": "Ocean Biology Distributed Active Archive Center"
   },
   "ui": {
-    "showNonEosdisCheckbox": false,
-    "showOnlyGranulesCheckbox": false,
+    "showNonEosdisCheckbox": true,
+    "showOnlyGranulesCheckbox": true,
     "includeInactiveCollectionsCheckbox": true
   }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Flipped these by mistake in `EDSC-4318` reverting back I did check all the other ones as well this is the only one

### What is the Solution?

Just update the booleans in the portal configuration for the additional filters so they appear on the UI

### What areas of the application does this impact?

OBDAAC search portal

# Testing

### Reproduction steps

- **Environment for testing:*Any*
- **Collection to test with:*Any*

1. Navigate to OBDAAC portal from the landing page
2. Ensure that the additional filters are available and can be used
3. Make sure that in the network request that it contains the filters when clicked on

### Attachments

<img width="1925" height="1012" alt="image" src="https://github.com/user-attachments/assets/961160fd-baa5-4cf3-8798-91b3c2147b8b" />

# Checklist

- [NA] I have added automated tests that prove my fix is effective or that my feature works
- [NA] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-EOSDIS data visibility checkbox now available
  * Granules-only filtering checkbox now available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasa/earthdata-search/pull/2049)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->