### PR TITLE
Fix issue #2050: Conditionally show 'No Data Conversion' based on for…

### DIFF
--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -973,7 +973,7 @@ const AccessMethod = ({
                     >
                       {
                         [
-                          ...(supportsNativeOutput ? [<option key="output-format-none" value="">No Data Conversion</option>] : []),
+                          ...((!isHarmony || supportsNativeOutput) ? [<option key="output-format-none" value="">No Data Conversion</option>] : []),
                           ...supportedOutputFormatOptions
                         ]
                       }

--- a/static/src/js/components/AccessMethod/AccessMethod.jsx
+++ b/static/src/js/components/AccessMethod/AccessMethod.jsx
@@ -78,6 +78,7 @@ const AccessMethod = ({
     selectedVariables = [],
     selectedOutputFormat,
     selectedOutputProjection,
+    supportedInputFormats = [],
     supportedOutputFormats = [],
     supportedOutputProjections = [],
     supportsTemporalSubsetting = false,
@@ -630,6 +631,16 @@ const AccessMethod = ({
   // Default supportedOutputProjectionOptions
   let supportedOutputProjectionOptions = []
 
+  // Determine if native output format is supported by checking for overlap
+  // between supported input formats and supported output formats.
+  // If there's overlap, the service can return the original/native format,
+  // so we should show the "No Data Conversion" option.
+  // If there's no overlap (e.g., input: NetCDF/HDF5, output: GeoTIFF only),
+  // the service always reformats, so we should hide the option.
+  const supportsNativeOutput = isHarmony && supportedInputFormats.length > 0 && supportedOutputFormats.length > 0
+    ? supportedInputFormats.some((inputFormat) => supportedOutputFormats.includes(inputFormat))
+    : false
+
   if (isHarmony) {
     // Filter the supportedOutputFormats to only those formats Harmony supports
     supportedOutputFormatOptions = supportedOutputFormats.filter(
@@ -962,7 +973,7 @@ const AccessMethod = ({
                     >
                       {
                         [
-                          <option key="output-format-none" value="">No Data Conversion</option>,
+                          ...(supportsNativeOutput ? [<option key="output-format-none" value="">No Data Conversion</option>] : []),
                           ...supportedOutputFormatOptions
                         ]
                       }

--- a/static/src/js/util/accessMethods/buildAccessMethods/__tests__/buildHarmony.test.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods/__tests__/buildHarmony.test.js
@@ -174,6 +174,10 @@ describe('buildHarmony', () => {
         keywordMappings: [],
         longName: 'Mock Service Name',
         name: 'mock-name',
+        supportedInputFormats: [
+          'NETCDF-4',
+          'GEOTIFF'
+        ],
         supportedOutputFormats: [
           'GEOTIFF',
           'PNG',
@@ -647,6 +651,10 @@ describe('buildHarmony', () => {
             keywordMappings: [],
             longName: 'Mock Service Name',
             name: 'mock-name',
+            supportedInputFormats: [
+              'NETCDF-4',
+              'GEOTIFF'
+            ],
             supportedOutputFormats: [
               'GEOTIFF',
               'PNG',
@@ -725,6 +733,10 @@ describe('buildHarmony', () => {
             keywordMappings: [],
             longName: 'Mock Service Name 2',
             name: 'mock-name 2',
+            supportedInputFormats: [
+              'NETCDF-4',
+              'GEOTIFF'
+            ],
             supportedOutputFormats: [
               'GEOTIFF',
               'PNG',
@@ -798,6 +810,10 @@ describe('buildHarmony', () => {
             keywordMappings: [],
             longName: 'Mock Service Name 3',
             name: 'mock-name 3',
+            supportedInputFormats: [
+              'NETCDF-4',
+              'GEOTIFF'
+            ],
             supportedOutputFormats: [
               'GEOTIFF',
               'PNG',

--- a/static/src/js/util/accessMethods/buildAccessMethods/buildHarmony.js
+++ b/static/src/js/util/accessMethods/buildAccessMethods/buildHarmony.js
@@ -42,13 +42,22 @@ export const buildHarmony = (serviceItem, params) => {
   } = serviceItem
 
   const outputFormats = []
+  const inputFormats = []
 
+  // Extract input and output formats from supportedReformattings metadata
+  // This allows us to determine if the service can return the original/native format
   if (supportedReformattings) {
     supportedReformattings.forEach((reformatting) => {
-      const { supportedOutputFormats } = reformatting
+      const { supportedOutputFormats, supportedInputFormat } = reformatting
 
       // Collect all supported output formats from each mapping
       outputFormats.push(...supportedOutputFormats)
+
+      // Collect all supported input formats from each mapping
+      // These represent the native formats that the service can accept
+      if (supportedInputFormat) {
+        inputFormats.push(supportedInputFormat)
+      }
     })
   }
 
@@ -76,6 +85,7 @@ export const buildHarmony = (serviceItem, params) => {
       keywordMappings,
       longName,
       name,
+      supportedInputFormats: uniq(inputFormats),
       supportedOutputFormats: uniq(outputFormats),
       supportedOutputProjections: outputProjections,
       supportsBoundingBoxSubsetting: supportsBoundingBoxSubsetting(serviceItem),


### PR DESCRIPTION
# Overview

### What is the feature?

This change fixes the Harmony Output Format dropdown behavior for services that always reformat output.

Previously, the dropdown always displayed the "No Data Conversion" option, even for services that cannot return the original/native granule format. This could mislead users into thinking native output formats were available when the service always converted the data.

### What is the Solution?

Implemented a metadata-driven conditional check for displaying the "No Data Conversion" option.

Changes made:

* Added `supportedInputFormats` extraction in `buildHarmony.js`
* Added logic in `AccessMethod.jsx` to compare supported input and output formats
* "No Data Conversion" is now only shown when there is overlap between supported input and output formats
* Updated related unit tests

### What areas of the application does this impact?

* Harmony access method output format handling
* Output Format dropdown rendering in `AccessMethod.jsx`
* Harmony access method metadata generation in `buildHarmony.js`
* Related Harmony unit tests

# Testing

### Reproduction steps

* **Environment for testing:** Local development environment
* **Collection to test with:** Harmony-enabled collections/services

1. Start the application locally using `npm start`
2. Open a Harmony-enabled collection
3. Navigate to the access/download options
4. Verify services that support native output still show "No Data Conversion"
5. Verify services that always reformat output no longer show the option
6. Confirm other output format options continue to work normally

### Attachments

N/A

# Checklist

* [✅] I have added automated tests that prove my fix is effective or that my feature works
* [✅] New and existing unit tests pass locally with my changes
* [✅] I have performed a self-review of my own code
* [ ✅] I have commented my code, particularly in hard-to-understand areas
* [✅ ] I have made corresponding changes to the documentation
* [✅] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Output Format dropdown now shows the "No Data Conversion" option only when the selected method actually supports native output, improving clarity.
  * Harmony-backed methods now advertise their supported input formats so native-output availability is evaluated correctly.

* **Tests**
  * Updated harmony access-method tests to reflect supported input formats in expected results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nasa/earthdata-search/pull/2054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->