### PR TITLE
EDSC-4712: EDSC not sending granule conceptIds to harmony

### DIFF
--- a/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
+++ b/static/src/js/zustand/slices/__tests__/createQuerySlice.test.ts
@@ -610,6 +610,38 @@ describe('createQuerySlice', () => {
         ...granuleQuery
       })
     })
+
+    test('preserves existing granule query values when re-initialized', () => {
+      const collectionId = 'collectionId'
+
+      useEdscStore.setState((state) => {
+        state.query.collection.byId.collectionId = {
+          granules: {
+            ...initialGranuleQuery,
+            readableGranuleName: ['Q2015155*']
+          }
+        }
+      })
+
+      const zustandState = useEdscStore.getState()
+      const { query } = zustandState
+      const { initializeGranuleQuery } = query
+      initializeGranuleQuery({
+        collectionId,
+        query: { sortKey: '-start_date' }
+      })
+
+      const updatedState = useEdscStore.getState()
+      const {
+        query: updatedQuery
+      } = updatedState
+
+      expect(updatedQuery.collection.byId.collectionId.granules).toEqual({
+        ...initialGranuleQuery,
+        readableGranuleName: ['Q2015155*'],
+        sortKey: '-start_date'
+      })
+    })
   })
 
   describe('removeSpatialFilter', () => {

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -187,7 +187,9 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
 
     initializeGranuleQuery: ({ collectionId, query }) => {
       set((state) => {
-        // Prevents existing query data from being overwritten.
+        // SetCollectionId calls this every time onChangePanel fires in ProjectPanels (ie. 'Back to Edit Options), not just when a granule query is initialized
+        // ExistingGranuleQuery is needed to prevent the wiping of existing data in the case of this being called outside of initialization
+        // TODO EDSC-4714: Skip re-initalization entirely when collectionId is already focused
         const {
           granules: existingGranuleQuery = {}
         } = state.query.collection.byId[collectionId] || {}

--- a/static/src/js/zustand/slices/createQuerySlice.ts
+++ b/static/src/js/zustand/slices/createQuerySlice.ts
@@ -187,8 +187,13 @@ const createQuerySlice: ImmerStateCreator<QuerySlice> = (set, get) => ({
 
     initializeGranuleQuery: ({ collectionId, query }) => {
       set((state) => {
+        // Prevents existing query data from being overwritten.
+        const {
+          granules: existingGranuleQuery = {}
+        } = state.query.collection.byId[collectionId] || {}
         state.query.collection.byId[collectionId] = {
           granules: {
+            ...existingGranuleQuery,
             ...initialGranuleQuery,
             ...query
           }


### PR DESCRIPTION
# Overview

### What is the feature?

Bug fix. The query parameter [id]=Q20152552* was getting wiped every time initializeGranuleQuery was called. 

### What is the Solution?

initializeGranuleQuery was replacing the granule query every time it was called. Now it merges the existing query with the new one.

### What areas of the application does this impact?

createQuerySlice

# Testing

### Reproduction steps

- **Environment for testing: any
- **Collection to test with: C2205121315-POCLOUD

1. Click on the collection and put Q20151552* in for the Granule Ids
2. Click 'Download All (2)'
3. Go to Customize Download >> Edit Variables >> Go back to Edit Options
4. You should see that your url still contains the parameter pg[1][id]=Q20151552* and the granule count underneath the collection name does not get updated after page refresh. 

### Attachments

N/A

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `npm audit fix` and made note of any changes in this PR
- [x] My changes generate no new warnings
