### PR TITLE
EDSC-4681: clarify temporal prompt based on manual testing

### DIFF
--- a/serverless/src/nlpSearch/handler.js
+++ b/serverless/src/nlpSearch/handler.js
@@ -143,6 +143,7 @@ export const convertTemporalToolExecute = async (
   - For Winter: Because Northern Hemisphere winter crosses calendar years, default to Dec 1st of the previous year through the last day of February of the current year (accounting for leap years). Spring, Summer, and Fall remain entirely within the current year.
   - For relative terms like "past 5 years", calculate the start date exactly that many years prior to the current date, and use the current date as the end date.
   - For relative terms like "since [Year]", use Jan 1st of that year as the start date, and the current date as the end date.
+  - For relative terms like "since [Month]", use the first day of of that month as the start date, and the current date as the end date.
   - Always use the current date of ${new Date().toISOString()} as the reference point for relative time expressions.
 
   Input: "${temporal}"`,

--- a/serverless/src/nlpSearch/handler.js
+++ b/serverless/src/nlpSearch/handler.js
@@ -136,10 +136,13 @@ export const convertTemporalToolExecute = async (
   - For "last year", use Jan 1 to Dec 31 of the year before the current year.
   - For "this year", use Jan 1 to Dec 31 of the current year.
   - For specific years, use Jan 1 to Dec 31 of that year.
+  - For decades (e.g., "1990s"), use Jan 1 of the first year to Dec 31 of the last year (e.g., 1990-1999).
   - For "last month", use the first to the last day of the previous month.
   - For "this month", use the first to the last day of the current month.
-  - For seasons, use their typical date ranges within the current year unless a specific year is mentioned.
-  - For relative terms like "past 5 years", calculate based on the current date.
+  - For seasons, use their most recent meteorological date ranges unless a specific year is provided. (Note: Invert these months if the spatial query is in the Southern Hemisphere).
+  - For Winter: Because Northern Hemisphere winter crosses calendar years, default to Dec 1st of the previous year through the last day of February of the current year (accounting for leap years). Spring, Summer, and Fall remain entirely within the current year.
+  - For relative terms like "past 5 years", calculate the start date exactly that many years prior to the current date, and use the current date as the end date.
+  - For relative terms like "since [Year]", use Jan 1st of that year as the start date, and the current date as the end date.
   - Always use the current date of ${new Date().toISOString()} as the reference point for relative time expressions.
 
   Input: "${temporal}"`,


### PR DESCRIPTION
# Overview

As part of EDSC-4681 of testing promps, there were a few cases where the /nlp response was inconsistent in parsing temporal information:
1. Sometimes searching with “since _ " date goes through 12/31 of the current year and other times through current date.
2. Seasons, (e.g. summer) have variable start/end dates.   Sometimes 6/1-8/31 sometimes 6/1 - 9/23.  That appears to be meteorological summer vs astronomical summer.  Also,  “winter” gets various responses because of wrapping a year.

## Summarize what you changed.

I added to the temporal prompt to clarify the expected results for these cases

List impacted areas.

# Testing

### Reproduction steps

Validate consistent dates with prompts:
- `droughts in Sub-Saharan Africa since 2000`
- `surface temperatures in alaska in 1990s`
- `permafrost melt in Svalbard during winter`
- `rainfall in eastern North Ireland during spring of 1990`
- `Vegetation change in chad, nigeria, and sudan over the last 20 years`

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm audit fix` and made note of any changes in this PR
- [ x] My changes generate no new warnings
