### PR TITLE
EDSC-4008: Reduce the size of database by aging out old retrievals

### DIFF
--- a/cdk/earthdata-search/lib/earthdata-search-functions.ts
+++ b/cdk/earthdata-search/lib/earthdata-search-functions.ts
@@ -122,6 +122,54 @@ export class Functions extends Construct {
     })
 
     /**
+     * Cleanup Old Retrievals Run once a month on the second day of the month at 2:00 AM
+     */
+    const cleanupOldRetrievalsNestedStack = new cdk.NestedStack(scope, 'CleanupOldRetrievalsNestedStack')
+    // eslint-disable-next-line no-new
+    new application.NodeJsFunction(cleanupOldRetrievalsNestedStack, 'CleanupOldRetrievalsLambda', {
+      ...defaultLambdaConfig,
+      description: 'Removes retrieval entries that are older than one year',
+      entry: '../../serverless/src/cleanupOldRetrievals/handler.js',
+      functionName: 'cleanupOldRetrievals',
+      functionNamePrefix,
+      schedules: [{
+        enabled: true,
+        schedule: events.Schedule.cron({
+          day: '2',
+          hour: '2',
+          minute: '0',
+          month: '*',
+          year: '*'
+        })
+      }],
+      timeout: cdk.Duration.minutes(5)
+    })
+
+    /**
+     * Cleanup Old Shapefiles Run once a month on the first day of the month at 2:00 AM
+     */
+    const cleanupOldShapefilesNestedStack = new cdk.NestedStack(scope, 'CleanupOldShapefilesNestedStack')
+    // eslint-disable-next-line no-new
+    new application.NodeJsFunction(cleanupOldShapefilesNestedStack, 'CleanupOldShapefilesLambda', {
+      ...defaultLambdaConfig,
+      description: 'Removes shapefile entries that are older than one year',
+      entry: '../../serverless/src/cleanupOldShapefiles/handler.js',
+      functionName: 'cleanupOldShapefiles',
+      functionNamePrefix,
+      schedules: [{
+        enabled: true,
+        schedule: events.Schedule.cron({
+          day: '1',
+          hour: '2',
+          minute: '0',
+          month: '*',
+          year: '*'
+        })
+      }],
+      timeout: cdk.Duration.minutes(5)
+    })
+
+    /**
      * Cloudfront To Cloudwatch
      */
     const cloudfrontToCloudwatchNestedStack = new cdk.NestedStack(scope, 'CloudfrontToCloudwatchNestedStack')
@@ -658,30 +706,6 @@ export class Functions extends Construct {
       sqs: {
         queue: queues.userDataQueue
       },
-      timeout: cdk.Duration.minutes(5)
-    })
-
-    /**
-     * Cleanup Old Shapefiles Run once a month on the first day of the month at 2:00 AM
-     */
-    const cleanupOldShapefilesNestedStack = new cdk.NestedStack(scope, 'CleanupOldShapefilesNestedStack')
-    // eslint-disable-next-line no-new
-    new application.NodeJsFunction(cleanupOldShapefilesNestedStack, 'CleanupOldShapefilesLambda', {
-      ...defaultLambdaConfig,
-      description: 'Removes shapefile entries that are older than one year',
-      entry: '../../serverless/src/cleanupOldShapefiles/handler.js',
-      functionName: 'cleanupOldShapefiles',
-      functionNamePrefix,
-      schedules: [{
-        enabled: true,
-        schedule: events.Schedule.cron({
-          day: '1',
-          hour: '2',
-          minute: '0',
-          month: '*',
-          year: '*'
-        })
-      }],
       timeout: cdk.Duration.minutes(5)
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3630,17 +3630,6 @@
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3757,9 +3746,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -3776,14 +3765,13 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
+        "qs": "^6.15.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
+        "tunnel-agent": "^0.6.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -12771,6 +12759,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -12783,17 +12778,6 @@
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yup": {
       "version": "0.29.13",
@@ -13556,6 +13540,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -13664,40 +13649,17 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13768,9 +13730,9 @@
       }
     },
     "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
       "funding": [
         {
           "type": "github",
@@ -14110,16 +14072,6 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -14834,22 +14786,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bootstrap": {
       "version": "5.3.8",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
@@ -15060,16 +14996,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -15331,6 +15257,7 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -15460,28 +15387,32 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15491,21 +15422,38 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "@colors/colors": "1.5.0"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15599,6 +15547,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -15953,43 +15912,38 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.3.0.tgz",
-      "integrity": "sha512-rRfPl9Z0/CczuYybBEoLbDVuT1OGkhYaJ0+urRCshgiDRz6QnoA0KQIQnPx7MJ3zy+VCsbUU1pV74n+6cbJEdg==",
+      "version": "15.20.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.1.tgz",
+      "integrity": "sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.8",
+        "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
-        "arch": "^2.2.0",
+        "@types/tmp": "^0.2.3",
+        "arch": "^3.0.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
+        "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
         "ci-info": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.5",
+        "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
         "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
-        "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
+        "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "listr2": "^9.0.5",
+        "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -15997,27 +15951,27 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "systeminformation": "^5.31.1",
+        "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
-        "yauzl": "^2.10.0"
+        "yauzl": "^3.3.1"
       },
       "bin": {
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/cypress-real-events": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
-      "integrity": "sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.15.0.tgz",
+      "integrity": "sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==",
       "license": "MIT",
       "peerDependencies": {
-        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x"
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x"
       }
     },
     "node_modules/cypress/node_modules/execa": {
@@ -16076,19 +16030,6 @@
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/cypress/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/cypress/node_modules/supports-color": {
       "version": "8.1.1",
@@ -16764,33 +16705,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -16801,6 +16715,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -17829,6 +17756,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -17909,43 +17843,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -18193,16 +18090,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -18226,32 +18113,6 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -18751,6 +18612,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -18842,16 +18716,6 @@
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
       "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==",
       "license": "MIT"
-    },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "async": "^3.2.0"
-      }
     },
     "node_modules/getpass": {
       "version": "0.1.7",
@@ -19215,7 +19079,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
       "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-stream": "^2.0.0",
@@ -19232,7 +19095,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -19544,6 +19406,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21044,6 +20907,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "> 0.8"
@@ -21126,31 +20990,84 @@
       "license": "MIT"
     },
     "node_modules/listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loader-runner": {
@@ -21312,68 +21229,112 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loglevel": {
@@ -21725,6 +21686,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -22893,22 +22867,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -23943,12 +23901,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -25025,17 +24984,49 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/retry": {
@@ -25200,6 +25191,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -25938,18 +25930,49 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/snake-case": {
@@ -26500,12 +26523,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -26528,9 +26551,9 @@
       }
     },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -26666,6 +26689,33 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/systeminformation": {
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "peer": true,
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -26856,6 +26906,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tildify": {
@@ -29668,14 +29719,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
+++ b/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
@@ -1,0 +1,126 @@
+import knex from 'knex'
+import mockKnex from 'mock-knex'
+import MockDate from 'mockdate'
+
+import * as getDbConnection from '../../util/database/getDbConnection'
+
+import cleanupOldRetrievals from '../handler'
+
+let dbConnectionToMock
+let dbTracker
+
+beforeEach(() => {
+  // Mock the current date to a fixed date for consistent testing
+  MockDate.set('2024-01-15T10:00:00.000Z')
+
+  vi.spyOn(getDbConnection, 'getDbConnection').mockImplementationOnce(() => {
+    dbConnectionToMock = knex({
+      client: 'pg',
+      debug: false
+    })
+
+    // Mock the db connection
+    mockKnex.mock(dbConnectionToMock)
+
+    return dbConnectionToMock
+  })
+
+  dbTracker = mockKnex.getTracker()
+  dbTracker.install()
+})
+
+afterEach(() => {
+  dbTracker.uninstall()
+  MockDate.reset()
+})
+
+describe('cleanupOldRetrievals', () => {
+  test('successfully executes the correct SQL query and returns response', async () => {
+    const deletedCount = 5
+    const consoleMock = vi.spyOn(console, 'log').mockImplementation()
+
+    dbTracker.on('query', (query) => {
+      query.response(deletedCount)
+    })
+
+    const result = await cleanupOldRetrievals({}, {})
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+
+    // Verify bindings are Date objects with the correct date (one year ago)
+    const expectedDate = new Date('2023-01-15T10:00:00.000Z')
+
+    expect(queries[0].bindings).toEqual([expectedDate])
+
+    expect(result).toEqual({
+      body: '{"message":"Successfully deleted 5 retrieval(s)","deletedCount":5}',
+      statusCode: 200
+    })
+
+    expect(consoleMock).toHaveBeenCalledTimes(2)
+    expect(consoleMock).toHaveBeenNthCalledWith(1, 'Cleaning up retrievals older than 2023-01-15T10:00:00.000Z')
+    expect(consoleMock).toHaveBeenNthCalledWith(2, 'Successfully deleted 5 retrieval(s) 2023-01-15T10:00:00.000Z')
+  })
+
+  test('correctly handles no retrievals found and logs a message', async () => {
+    const deletedCount = 0
+    const consoleMock = vi.spyOn(console, 'log').mockImplementation()
+
+    dbTracker.on('query', (query) => {
+      query.response(deletedCount)
+    })
+
+    const result = await cleanupOldRetrievals({}, {})
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+
+    // Verify bindings are Date objects with the correct date (one year ago)
+    const expectedDate = new Date('2023-01-15T10:00:00.000Z')
+
+    expect(queries[0].bindings).toEqual([expectedDate])
+
+    expect(result).toEqual({
+      body: '{"message":"Successfully deleted 0 retrieval(s)","deletedCount":0}',
+      statusCode: 200
+    })
+
+    expect(consoleMock).toHaveBeenCalledTimes(2)
+    expect(consoleMock).toHaveBeenNthCalledWith(1, 'Cleaning up retrievals older than 2023-01-15T10:00:00.000Z')
+    expect(consoleMock).toHaveBeenNthCalledWith(2, 'No retrievals older than 2023-01-15T10:00:00.000Z found exiting cleanup process')
+  })
+
+  test.only('correctly handles database errors and logs them', async () => {
+    const consoleMock = vi.spyOn(console, 'log').mockImplementation()
+    const dbError = new Error('Database connection failed')
+
+    dbTracker.on('query', (query) => {
+      query.reject(dbError)
+    })
+
+    const result = await cleanupOldRetrievals({}, {})
+
+    expect(result.body).toContain('Database connection failed')
+    expect(result.statusCode).toEqual(500)
+
+    const { queries } = dbTracker.queries
+
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+
+    // Verify bindings are Date objects with the correct date (one year ago)
+    const expectedDate = new Date('2023-01-15T10:00:00.000Z')
+
+    // Even though both use the same date, Knex creates separate parameterized bindings:
+    // one for the main query and one for the subquery
+    expect(queries[0].bindings).toEqual([expectedDate])
+
+    // Verify error was logged
+    expect(consoleMock).toHaveBeenCalledWith(
+      'Error cleaning up old retrievals:',
+      dbError
+    )
+  })
+})

--- a/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
+++ b/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
@@ -55,7 +55,7 @@ describe('cleanupOldRetrievals', () => {
 
     const { queries } = dbTracker.queries
 
-    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "updated_at" < $1')
 
     // Verify bindings are Date objects with the correct date (one year ago)
     const expectedDate = new Date('2023-01-15T10:00:00.000Z')
@@ -93,7 +93,7 @@ describe('cleanupOldRetrievals', () => {
 
     const { queries } = dbTracker.queries
 
-    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "updated_at" < $1')
 
     // Verify bindings are Date objects with the correct date (one year ago)
     const expectedDate = new Date('2023-01-15T10:00:00.000Z')
@@ -126,7 +126,7 @@ describe('cleanupOldRetrievals', () => {
 
     const { queries } = dbTracker.queries
 
-    expect(queries[0].sql).toEqual('delete from "retrievals" where "created_at" < $1')
+    expect(queries[0].sql).toEqual('delete from "retrievals" where "updated_at" < $1')
 
     // Verify bindings are Date objects with the correct date (one year ago)
     const expectedDate = new Date('2023-01-15T10:00:00.000Z')

--- a/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
+++ b/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
@@ -39,8 +39,16 @@ describe('cleanupOldRetrievals', () => {
     const deletedCount = 5
     const consoleMock = vi.spyOn(console, 'log').mockImplementation()
 
-    dbTracker.on('query', (query) => {
-      query.response(deletedCount)
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        // First query: deleting old retrievals
+        query.response(deletedCount)
+      } else if (step === 2) {
+        // Second query: deleting orphaned retrieval collections
+        query.response(0)
+      } else {
+        query.response(0)
+      }
     })
 
     const result = await cleanupOldRetrievals({}, {})
@@ -55,21 +63,30 @@ describe('cleanupOldRetrievals', () => {
     expect(queries[0].bindings).toEqual([expectedDate])
 
     expect(result).toEqual({
-      body: '{"message":"Successfully deleted 5 retrieval(s)","deletedCount":5}',
+      body: '{"message":"Cleanup complete. Deleted 5 retrieval(s) and 0 orphaned retrieval collection(s).","deletedRetrievals":5,"deletedOrphanedRetrievalCollections":0}',
       statusCode: 200
     })
 
-    expect(consoleMock).toHaveBeenCalledTimes(2)
+    expect(consoleMock).toHaveBeenCalledTimes(3)
     expect(consoleMock).toHaveBeenNthCalledWith(1, 'Cleaning up retrievals older than 2023-01-15T10:00:00.000Z')
     expect(consoleMock).toHaveBeenNthCalledWith(2, 'Successfully deleted 5 retrieval(s) 2023-01-15T10:00:00.000Z')
+    expect(consoleMock).toHaveBeenNthCalledWith(3, 'No orphaned retrievals found in exiting cleanup process')
   })
 
   test('correctly handles no retrievals found and logs a message', async () => {
     const deletedCount = 0
     const consoleMock = vi.spyOn(console, 'log').mockImplementation()
 
-    dbTracker.on('query', (query) => {
-      query.response(deletedCount)
+    dbTracker.on('query', (query, step) => {
+      if (step === 1) {
+        // First query: deleting old retrievals
+        query.response(deletedCount)
+      } else if (step === 2) {
+        // Second query: deleting orphaned collections
+        query.response(0)
+      } else {
+        query.response(0)
+      }
     })
 
     const result = await cleanupOldRetrievals({}, {})
@@ -84,16 +101,17 @@ describe('cleanupOldRetrievals', () => {
     expect(queries[0].bindings).toEqual([expectedDate])
 
     expect(result).toEqual({
-      body: '{"message":"Successfully deleted 0 retrieval(s)","deletedCount":0}',
+      body: '{"message":"Cleanup complete. Deleted 0 retrieval(s) and 0 orphaned retrieval collection(s).","deletedRetrievals":0,"deletedOrphanedRetrievalCollections":0}',
       statusCode: 200
     })
 
-    expect(consoleMock).toHaveBeenCalledTimes(2)
+    expect(consoleMock).toHaveBeenCalledTimes(3)
     expect(consoleMock).toHaveBeenNthCalledWith(1, 'Cleaning up retrievals older than 2023-01-15T10:00:00.000Z')
     expect(consoleMock).toHaveBeenNthCalledWith(2, 'No retrievals older than 2023-01-15T10:00:00.000Z found exiting cleanup process')
+    expect(consoleMock).toHaveBeenNthCalledWith(3, 'No orphaned retrievals found in exiting cleanup process')
   })
 
-  test.only('correctly handles database errors and logs them', async () => {
+  test('correctly handles database errors and logs them', async () => {
     const consoleMock = vi.spyOn(console, 'log').mockImplementation()
     const dbError = new Error('Database connection failed')
 

--- a/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
+++ b/serverless/src/cleanupOldRetrievals/__tests__/handler.test.js
@@ -36,16 +36,17 @@ afterEach(() => {
 
 describe('cleanupOldRetrievals', () => {
   test('successfully executes the correct SQL query and returns response', async () => {
-    const deletedCount = 5
+    const deletedRetrieval = 5
+    const deletedOrphanedRetrievalCollections = 3
     const consoleMock = vi.spyOn(console, 'log').mockImplementation()
 
     dbTracker.on('query', (query, step) => {
       if (step === 1) {
         // First query: deleting old retrievals
-        query.response(deletedCount)
+        query.response(deletedRetrieval)
       } else if (step === 2) {
         // Second query: deleting orphaned retrieval collections
-        query.response(0)
+        query.response(deletedOrphanedRetrievalCollections)
       } else {
         query.response(0)
       }
@@ -63,14 +64,14 @@ describe('cleanupOldRetrievals', () => {
     expect(queries[0].bindings).toEqual([expectedDate])
 
     expect(result).toEqual({
-      body: '{"message":"Cleanup complete. Deleted 5 retrieval(s) and 0 orphaned retrieval collection(s).","deletedRetrievals":5,"deletedOrphanedRetrievalCollections":0}',
+      body: '{"message":"Cleanup complete. Deleted 5 retrieval(s) and 3 orphaned retrieval collection(s).","deletedRetrievals":5,"deletedOrphanedRetrievalCollections":3}',
       statusCode: 200
     })
 
     expect(consoleMock).toHaveBeenCalledTimes(3)
     expect(consoleMock).toHaveBeenNthCalledWith(1, 'Cleaning up retrievals older than 2023-01-15T10:00:00.000Z')
     expect(consoleMock).toHaveBeenNthCalledWith(2, 'Successfully deleted 5 retrieval(s) 2023-01-15T10:00:00.000Z')
-    expect(consoleMock).toHaveBeenNthCalledWith(3, 'No orphaned retrievals found in exiting cleanup process')
+    expect(consoleMock).toHaveBeenNthCalledWith(3, 'Successfully deleted 3 orphaned retrieval(s)')
   })
 
   test('correctly handles no retrievals found and logs a message', async () => {

--- a/serverless/src/cleanupOldRetrievals/handler.js
+++ b/serverless/src/cleanupOldRetrievals/handler.js
@@ -1,0 +1,58 @@
+import 'pg'
+
+import { getDbConnection } from '../util/database/getDbConnection'
+
+/**
+ * Removes retrieval entries that are older than one year. Deleting a retrieval cascades
+ * (via ON DELETE CASCADE foreign keys) to its retrieval_collections and retrieval_orders if applicable.
+ * @param {Object} event EventBridge event (scheduled event)
+ * @param {Object} context Methods and properties that provide information about the invocation, function, and execution environment
+ */
+const cleanupOldRetrievals = async (event, context) => {
+  // https://stackoverflow.com/questions/49347210/why-aws-lambda-keeps-timing-out-when-using-knex-js
+  // eslint-disable-next-line no-param-reassign
+  context.callbackWaitsForEmptyEventLoop = false
+
+  // Retrieve a connection to the database
+  const dbConnection = await getDbConnection()
+
+  try {
+    // Calculate the date one year ago
+    const oneYearAgo = new Date()
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+    console.log(`Cleaning up retrievals older than ${oneYearAgo.toISOString()}`)
+
+    // Delete retrievals older than one year. Foreign keys on retrieval_collections and
+    // retrieval_orders are ON DELETE CASCADE, so their related rows are removed automatically
+    const deletedCount = await dbConnection('retrievals')
+      .where('created_at', '<', oneYearAgo)
+      .delete()
+
+    console.log(deletedCount > 0
+      ? `Successfully deleted ${deletedCount} retrieval(s) ${oneYearAgo.toISOString()}`
+      : `No retrievals older than ${oneYearAgo.toISOString()} found exiting cleanup process`)
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: `Successfully deleted ${deletedCount} retrieval(s)`,
+        deletedCount
+      })
+    }
+  } catch (error) {
+    console.log('Error cleaning up old retrievals:', error)
+
+    // Event Bridge will retry the function if an uncaught error is thrown
+    // so we are catching an error and returning a 500 status code
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: 'Error cleaning up old retrievals',
+        error: error.message
+      })
+    }
+  }
+}
+
+export default cleanupOldRetrievals

--- a/serverless/src/cleanupOldRetrievals/handler.js
+++ b/serverless/src/cleanupOldRetrievals/handler.js
@@ -26,7 +26,7 @@ const cleanupOldRetrievals = async (event, context) => {
     // Delete retrievals older than one year. Foreign keys on retrieval_collections and
     // retrieval_orders are ON DELETE CASCADE, so their related rows are removed automatically
     const deletedCount = await dbConnection('retrievals')
-      .where('created_at', '<', oneYearAgo)
+      .where('updated_at', '<', oneYearAgo)
       .delete()
 
     // Also remove orphaned retrieval_collections with no parent retrieval

--- a/serverless/src/cleanupOldRetrievals/handler.js
+++ b/serverless/src/cleanupOldRetrievals/handler.js
@@ -29,15 +29,25 @@ const cleanupOldRetrievals = async (event, context) => {
       .where('created_at', '<', oneYearAgo)
       .delete()
 
+    // Also remove orphaned retrieval_collections with no parent retrieval
+    const orphanedRetrievalCollectionsDeletedCount = await dbConnection('retrieval_collections')
+      .whereNull('retrieval_id')
+      .delete()
+
     console.log(deletedCount > 0
       ? `Successfully deleted ${deletedCount} retrieval(s) ${oneYearAgo.toISOString()}`
       : `No retrievals older than ${oneYearAgo.toISOString()} found exiting cleanup process`)
 
+    console.log(orphanedRetrievalCollectionsDeletedCount > 0
+      ? `Successfully deleted ${orphanedRetrievalCollectionsDeletedCount} orphaned retrieval(s)`
+      : 'No orphaned retrievals found in exiting cleanup process')
+
     return {
       statusCode: 200,
       body: JSON.stringify({
-        message: `Successfully deleted ${deletedCount} retrieval(s)`,
-        deletedCount
+        message: `Cleanup complete. Deleted ${deletedCount} retrieval(s) and ${orphanedRetrievalCollectionsDeletedCount} orphaned retrieval collection(s).`,
+        deletedRetrievals: deletedCount,
+        deletedOrphanedRetrievalCollections: orphanedRetrievalCollectionsDeletedCount
       })
     }
   } catch (error) {


### PR DESCRIPTION
# Overview

### What is the feature?

retrieval_collections takes up a lot of space in the database. Our goal was to cleanup the retrieval_collections by removing any that were updated_at over a year ago. Since the roadmap goes retrievals > retrieval_collections > retrieval_orders, this tickets removes all retrievals that are older than a year and that triggers a cascade effect down to retrieval_collections and retrieval orders

### What is the Solution?

delete retrievals where updated_at is > 1 year ago. Add that handler function to cdk/lib/earthdata-search-functions.
Also found orphaned retrieval collections with NULL foreign keys. The initial function did not reach these and they would forever stay in the database unless specifically addressed here.

npm audit fix brought vulnerabilities down from 21 to 16. 

### What areas of the application does this impact?

cdk/lib/earthdata-search-functions
cleanupOldRetrievals

# Testing

### Reproduction steps

1. Get PRE-CLEANUP-SS.dump from Mandy over teams
2. load that into your edsc_dev database via pg_restore command found here: https://wiki.earthdata.nasa.gov/spaces/EDSC/pages/194448934/EDSC+Database+Backup+and+Restore+in+NGAP
3. Spin up your postgres db for local SQL queries
4. `SELECT COUNT(*) FROM retrievals;`, `SELECT COUNT(*) FROM retrieval_collections;`, `SELECT COUNT(*) FROM retrieval_orders;` (Should get 7333, 7492, and 7334)
5. `npm run invoke-local cleanupOldRetrievals`
6. Run those SQL queries again. You should get 543, 547, and 506. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `npm audit fix` and made note of any changes in this PR
- [x] My changes generate no new warnings
