### PR TITLE
EDSC-4405: Search Results Subscriptions and dataset subscriptions should have different text when empty

### DIFF
--- a/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
+++ b/static/src/js/components/Subscriptions/SubscriptionsBody.jsx
@@ -213,6 +213,10 @@ export const SubscriptionsBody = ({
     subscriptionType
   ).length
 
+  const emptyStateMessage = subscriptionType === 'collection'
+    ? 'You have not created any dataset search subscriptions. Use filters to define your dataset query and '
+    : 'You have not created any subscriptions for this collection. Use filters to define your query for this collection and '
+
   return (
     <div className="subscriptions-body">
       <div className="subscriptions-body__content">
@@ -348,7 +352,7 @@ export const SubscriptionsBody = ({
             {
               subscriptionItems.length === 0 && (
                 <EmptyListItem>
-                  {'No subscriptions exist for this collection. Use filters to define your query and '}
+                  {emptyStateMessage}
                   <Button
                     className="subscriptions-body__empty-list-item"
                     disabled={displayWarning}

--- a/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
+++ b/static/src/js/components/Subscriptions/__tests__/SubscriptionsBody.test.jsx
@@ -59,6 +59,50 @@ describe('SubscriptionsBody component', () => {
     expect(screen.getByText('Subscribe to be notified by email when new data matching your search query becomes available.')).toBeInTheDocument()
   })
 
+  describe('when no subscritptions exist', () => {
+    test('shows dataset search empty-state message for collection subscriptions', () => {
+      setup()
+
+      expect(screen.getByText(/You have not created any dataset search subscriptions/i)).toBeInTheDocument()
+      expect(screen.getByText(/Use filters to define your dataset query/i)).toBeInTheDocument()
+    })
+
+    test('shows collection specific empty-state message for granuale subscriptions', () => {
+      setup({
+        overrideProps: {
+          subscriptionType: 'granule'
+        },
+        overrideZustandState: {
+          collection: {
+            collectionId: 'C123-PROV'
+          }
+        },
+        overrideApolloClientMocks: [{
+          request: {
+            query: SUBSCRIPTIONS,
+            variables: {
+              params: {
+                collectionConceptId: 'C123-PROV',
+                subscriberId: 'testuser',
+                type: 'granule'
+              }
+            }
+          },
+          result: {
+            data: {
+              subscriptions: {
+                items: []
+              }
+            }
+          }
+        }]
+      })
+
+      expect(screen.getByText(/You have not created any subscriptions for this collection/i)).toBeInTheDocument()
+      expect(screen.getByText(/Use filters to define your query for this collection/i)).toBeInTheDocument()
+    })
+  })
+
   describe('when creating a subscription', () => {
     test('calls addToast', async () => {
       const { user } = setup({


### PR DESCRIPTION

# Overview

### What is the feature?

The collection search subscriptions panel was showing the text that was meant for a focused collection subscription panel.  The empty state text now will be specific for the subscription type.

### What is the Solution?

We already passed the subscriptionType to the subscriptionBody component, so I added a conditional and showed the desired empty state message

### What areas of the application does this impact?

`//search/granules/subscriptions?` and `/search/subscriptions`
# Testing

### Reproduction steps
Log into the app

1. Make a search and click on the subscriptions link at the bottom of the dateset results.  verify that the new empty state message is specific for datasets.

2. Click into a collection Search result.  click on the subscriptions link at the bottom. Verify that the new empty state message is specific for granules.

### Attachments
<img width="1028" height="746" alt="Screenshot 2026-08-13 at 4 38 27 PM" src="https://github.com/user-attachments/assets/3adbcfaa-6818-4cc9-9871-75d9901b6938" />
<img width="892" height="678" alt="Screenshot 2026-08-13 at 4 37 57 PM" src="https://github.com/user-attachments/assets/b8b05b2a-5eca-4dac-b789-0008f4148fe4" />


# Checklist

- [ x] I have added automated tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm audit fix` and made note of any changes in this PR
- [ x] My changes generate no new warnings
