### PR TITLE
EDSC-4695: Drops user_tokens table

### DIFF
--- a/migrations/1787246652011_drop-user-tokens.js
+++ b/migrations/1787246652011_drop-user-tokens.js
@@ -1,0 +1,43 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.dropTable('user_tokens')
+}
+
+exports.down = (pgm) => {
+  pgm.createTable('user_tokens', {
+    id: 'id',
+    user_id: {
+      type: 'integer',
+      references: 'users'
+    },
+    environment: {
+      type: 'varchar(100)',
+      notNull: true
+    },
+    access_token: {
+      type: 'varchar(100)',
+      notNull: true
+    },
+    refresh_token: {
+      type: 'varchar(100)',
+      notNull: true
+    },
+    expires_at: {
+      type: 'timestamp',
+      notNull: true
+    },
+    updated_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('current_timestamp')
+    },
+    created_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('current_timestamp')
+    }
+  })
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Drops user_tokens table

# Testing

Locally run `npm run invoke-local migrateDatabase` and ensure table was removed

### Attachments

<img width="1247" height="585" alt="Screenshot 2026-08-20 at 1 26 56 PM" src="https://github.com/user-attachments/assets/a4c7f390-3574-4e1a-93a1-13abaea5c19e" />


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm audit fix` and made note of any changes in this PR
- [x] My changes generate no new warnings
