### PR TITLE
Decode shapefileId with decodeString

### DIFF
--- a/static/src/js/util/url/__tests__/changePath.test.ts
+++ b/static/src/js/util/url/__tests__/changePath.test.ts
@@ -99,7 +99,7 @@ describe('changePath', () => {
           }
         },
         shapefile: {
-          shapefileId: ''
+          shapefileId: undefined
         }
       })
     )
@@ -167,7 +167,7 @@ describe('changePath', () => {
         }
       },
       shapefile: {
-        shapefileId: ''
+        shapefileId: undefined
       }
     }), '/search')
 

--- a/static/src/js/util/url/__tests__/url.mocks.js
+++ b/static/src/js/util/url/__tests__/url.mocks.js
@@ -42,7 +42,7 @@ export const emptyDecodedResult = {
   selectedRegion: undefined,
   shapefile: {
     selectedFeatures: undefined,
-    shapefileId: ''
+    shapefileId: undefined
   },
   timeline: undefined
 }

--- a/static/src/js/util/url/url.js
+++ b/static/src/js/util/url/url.js
@@ -146,7 +146,7 @@ const urlDefs = {
   shapefileId: {
     shortKey: 'sf',
     encode: encodeString,
-    decode: encodeString
+    decode: decodeString
   },
   selectedFeatures: {
     shortKey: 'sfs',


### PR DESCRIPTION
Fixes #2076.

`shapefileId` is the only entry in `urlDefs` whose `decode` slot holds an encoder. `encodeString` returns `''` for a missing value where `decodeString` returns it unchanged, so a URL without `sf` decodes `shapefileId` to `''` while every sibling decodes to `undefined`.

`updateStore` merges decoded params with lodash `merge`, and the comment above that call says the merge exists so the initial state can serve as a fallback for `undefined` decoded values. `merge` skips `undefined` but overwrites with `''`, so `shapefileId` alone cannot fall back. The result splits one object: `selectedFeatures` keeps its stored value while `shapefileId` is cleared.

The store treats `undefined` as the absent value (`createShapefileSlice` initialises it that way and the type is optional), so three test expectations that recorded `''` are updated to match.

I do not have an EDSC number for the commit prefix, so please let me know if you would like the commit reworded once one is assigned.
