### PR TITLE
EDSC-4731: add banner and tooltip to show data retention

### DIFF
--- a/serverless/src/graphQl/resolvers/__tests__/retrieval.test.js
+++ b/serverless/src/graphQl/resolvers/__tests__/retrieval.test.js
@@ -354,7 +354,7 @@ describe('Retrieval resolver', () => {
                 obfuscatedId: '4517239960',
                 portalId: 'edsc',
                 titles: ['title 1'],
-                updated_at: '2023-01-02T00:00:00Z'
+                updatedAt: '2023-01-02T00:00:00Z'
               }
             ],
             pageInfo: {

--- a/serverless/src/graphQl/resolvers/__tests__/retrieval.test.js
+++ b/serverless/src/graphQl/resolvers/__tests__/retrieval.test.js
@@ -324,7 +324,8 @@ describe('Retrieval resolver', () => {
             id: 1,
             portal_id: 'edsc',
             titles: ['title 1'],
-            total: 1
+            total: 1,
+            updated_at: '2023-01-02T00:00:00Z'
           }])
         }
 
@@ -352,7 +353,8 @@ describe('Retrieval resolver', () => {
                 id: 1,
                 obfuscatedId: '4517239960',
                 portalId: 'edsc',
-                titles: ['title 1']
+                titles: ['title 1'],
+                updated_at: '2023-01-02T00:00:00Z'
               }
             ],
             pageInfo: {

--- a/serverless/src/graphQl/types/retrieval.graphql
+++ b/serverless/src/graphQl/types/retrieval.graphql
@@ -40,6 +40,9 @@ type HistoryRetrieval {
 
   "The title of the retrieval"
   titles: [String]
+
+  "Timestamp of when the retrieval was last updated"
+  updatedAt: DateTime
 }
 
 type HistoryRetrievals {

--- a/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
+++ b/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
@@ -1359,7 +1359,7 @@ describe('DatabaseClient', () => {
 
       const { queries } = dbTracker.queries
 
-      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
+      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
 
       // When offset is 0, it is not included in variables
       expect(queries[0].bindings).toEqual([userId, limit])

--- a/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
+++ b/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
@@ -1334,6 +1334,7 @@ describe('DatabaseClient', () => {
           query.response([{
             id: 1,
             created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-02T00:00:00Z',
             portal_id: 'edsc',
             titles: ['title 1'],
             total: 1
@@ -1350,6 +1351,7 @@ describe('DatabaseClient', () => {
       expect(historyRetrievals).toEqual([{
         id: 1,
         created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-02T00:00:00Z',
         portal_id: 'edsc',
         titles: ['title 1'],
         total: 1

--- a/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
+++ b/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
@@ -1359,7 +1359,7 @@ describe('DatabaseClient', () => {
 
       const { queries } = dbTracker.queries
 
-      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
+      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
 
       // When offset is 0, it is not included in variables
       expect(queries[0].bindings).toEqual([userId, limit])

--- a/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
+++ b/serverless/src/graphQl/utils/__tests__/databaseClient.test.js
@@ -1380,7 +1380,7 @@ describe('DatabaseClient', () => {
 
       const { queries } = dbTracker.queries
 
-      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
+      expect(queries[0].sql).toEqual('select "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", (jsondata->\'portalId\') as portal_id, array_agg(retrieval_collections.collection_metadata->\'title\') as titles, count(*) OVER() as total from "retrievals" inner join "retrieval_collections" on "retrievals"."id" = "retrieval_collections"."retrieval_id" where "retrievals"."user_id" = $1 group by "retrievals"."id", "retrievals"."created_at", "retrievals"."updated_at", "retrievals"."jsondata" order by "retrievals"."created_at" desc limit $2')
       expect(queries[0].bindings).toEqual([1, 20])
 
       expect(consoleMock).toHaveBeenCalledTimes(1)

--- a/serverless/src/graphQl/utils/databaseClient.js
+++ b/serverless/src/graphQl/utils/databaseClient.js
@@ -565,9 +565,9 @@ export default class DatabaseClient {
         .join('retrieval_collections', { 'retrievals.id': 'retrieval_collections.retrieval_id' })
         // Filter results to only include retrievals for the specified user
         .where({ 'retrievals.user_id': userId })
-        // Group results by retrieval ID, creation date, and JSON data
+        // Group results by retrieval ID, creation/update date, and JSON data
         // in order to aggregate collection titles
-        .groupBy('retrievals.id', 'retrievals.created_at', 'retrievals.jsondata')
+        .groupBy('retrievals.id', 'retrievals.created_at', 'retrievals.updated_at', 'retrievals.jsondata')
         // Sort by most recent
         .orderBy('retrievals.created_at', 'desc')
 

--- a/serverless/src/graphQl/utils/databaseClient.js
+++ b/serverless/src/graphQl/utils/databaseClient.js
@@ -553,6 +553,7 @@ export default class DatabaseClient {
         .select(
           'retrievals.id',
           'retrievals.created_at',
+          'retrievals.updated_at',
           // Only request portal Id from the jsondata
           db.raw('(jsondata->\'portalId\') as portal_id'),
           // Aggregate all titles from related collections into an array.

--- a/static/src/js/components/DownloadHistory/DownloadHistory.scss
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.scss
@@ -2,6 +2,11 @@
 @use '../../../css/utils';
 
 .download-history {
+  &__retention-banner {
+    margin-top: calc(-1 * bootstrap.$spacer * 2);
+    margin-bottom: bootstrap.$spacer;
+  }
+
   &__spinner {
     margin: 0 auto;
   }
@@ -96,6 +101,12 @@
 .download-history-table {
   &__ago {
     white-space: nowrap;
+  }
+
+  &__expiration-warning {
+    display: inline-flex;
+    margin-left: calc(bootstrap.$spacer / 4);
+    vertical-align: middle;
   }
 
   &__actions,

--- a/static/src/js/components/DownloadHistory/DownloadHistory.tsx
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.tsx
@@ -58,7 +58,7 @@ export interface HistoryRetrieval {
   portalId: string
   /** The title of the retrieval */
   titles: string[]
-  //** The date the retrieval was las updated */
+  //* * The date the retrieval was las updated */
   updatedAt: string
 }
 interface HistoryRetrievalsQueryData {

--- a/static/src/js/components/DownloadHistory/DownloadHistory.tsx
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Table from 'react-bootstrap/Table'
+import { OverlayTrigger } from 'react-bootstrap'
 
 import { useMutation, useQuery } from '@apollo/client'
 // @ts-expect-error This file does not have types
@@ -8,12 +9,18 @@ import Pagination from 'rc-pagination'
 import localeInfo from 'rc-pagination/lib/locale/en_US'
 // @ts-expect-error This file does not have types
 import { Helmet } from 'react-helmet'
+import moment from 'moment'
 
 // @ts-expect-error This file does not have types
 import { XCircled } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
+// @ts-expect-error This file does not have types
+import { AlertMediumPriority } from '@edsc/earthdata-react-icons/horizon-design-system/earthdata/ui'
 
 import Button from '../Button/Button'
 import Spinner from '../Spinner/Spinner'
+import EDSCIcon from '../EDSCIcon/EDSCIcon'
+// @ts-expect-error This file does not have types
+import EDSCAlert from '../EDSCAlert/EDSCAlert'
 // @ts-expect-error This file does not have types
 import PortalLinkContainer from '../../containers/PortalLinkContainer/PortalLinkContainer'
 
@@ -33,7 +40,13 @@ import { getEarthdataEnvironment } from '../../zustand/selectors/earthdataEnviro
 
 import './DownloadHistory.scss'
 import 'rc-pagination/assets/index.css'
+import renderTooltip from '../../util/renderTooltip'
 
+// Downloads that have not been updated for this number of days are removed
+const RETENTION_PERIOD_DAYS = 365
+
+// Downloads within this number of days of removal are flagged as expiring soon
+const EXPIRATION_WARNING_THRESHOLD_DAYS = 30
 export interface HistoryRetrieval {
   /** The date the retrieval was created */
   createdAt: string
@@ -45,6 +58,8 @@ export interface HistoryRetrieval {
   portalId: string
   /** The title of the retrieval */
   titles: string[]
+  //* * The date the retrieval was las updated */
+  updatedAt: string
 }
 interface HistoryRetrievalsQueryData {
   historyRetrievals: {
@@ -126,6 +141,12 @@ export const DownloadHistory = () => {
     return `${titleList[0]} and ${titleList.length - 1} more`
   }
 
+  const isExpiringSoon = (updatedAt: string): boolean => {
+    const removalDate = moment(updatedAt).add(RETENTION_PERIOD_DAYS, 'days')
+
+    return removalDate.diff(moment(), 'days') <= EXPIRATION_WARNING_THRESHOLD_DAYS
+  }
+
   return (
     <div className="download-history">
       <Helmet>
@@ -137,6 +158,13 @@ export const DownloadHistory = () => {
       <h2 className="route-wrapper__page-heading">
         Download Status & History
       </h2>
+      <EDSCAlert
+        className="download-history__retention-banner"
+        bootstrapVariant="warning"
+        icon={AlertMediumPriority}
+      >
+        Downloads that have not been updated in over a year will be removed.
+      </EDSCAlert>
       {
         loading && (
           <Spinner
@@ -161,10 +189,11 @@ export const DownloadHistory = () => {
                 {
                   historyRetrievalsList.map((retrieval) => {
                     const {
-                      id, createdAt, obfuscatedId, portalId, titles
+                      id, createdAt, obfuscatedId, portalId, titles, updatedAt
                     } = retrieval
 
                     const titleDisplay = formatTitleDisplay(titles)
+                    const expiringSoon = isExpiringSoon(updatedAt)
 
                     return (
                       <tr key={id}>
@@ -183,6 +212,27 @@ export const DownloadHistory = () => {
                         </td>
                         <td className="download-history-table__ago">
                           <TimeAgo date={createdAt} />
+                          {
+                            expiringSoon && (
+                              <OverlayTrigger
+                                placement="top"
+                                overlay={
+                                  (tooltipPros) => renderTooltip({
+                                    children: 'Download will be removed soon if not updated.',
+                                    id: `tooltip__download-history-expiration__${id}`,
+                                    ...tooltipPros
+                                  })
+                                }
+                              >
+                                <span className="download-history-table__expiration-warning">
+                                  <EDSCIcon
+                                    icon={AlertMediumPriority}
+                                    ariaLabel="Download expiring soon"
+                                  />
+                                </span>
+                              </OverlayTrigger>
+                            )
+                          }
                         </td>
                         <td className="download-history-table__actions">
                           <Button

--- a/static/src/js/components/DownloadHistory/DownloadHistory.tsx
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.tsx
@@ -34,13 +34,13 @@ import { routes } from '../../constants/routes'
 import { stringify } from '../../util/url/url'
 // @ts-expect-error This file does not have types
 import addToast from '../../util/addToast'
+import renderTooltip from '../../util/renderTooltip'
 
 import useEdscStore from '../../zustand/useEdscStore'
 import { getEarthdataEnvironment } from '../../zustand/selectors/earthdataEnvironment'
 
 import './DownloadHistory.scss'
 import 'rc-pagination/assets/index.css'
-import renderTooltip from '../../util/renderTooltip'
 
 // Downloads that have not been updated for this number of days are removed
 const RETENTION_PERIOD_DAYS = 365
@@ -163,7 +163,7 @@ export const DownloadHistory = () => {
         bootstrapVariant="warning"
         icon={AlertMediumPriority}
       >
-        Downloads that have not been updated in over a year will be removed.
+        Downloads older than one year are automatically removed.
       </EDSCAlert>
       {
         loading && (
@@ -218,7 +218,7 @@ export const DownloadHistory = () => {
                                 placement="top"
                                 overlay={
                                   (tooltipPros) => renderTooltip({
-                                    children: 'Download will be removed soon if not updated.',
+                                    children: 'Download will be removed soon.',
                                     id: `tooltip__download-history-expiration__${id}`,
                                     ...tooltipPros
                                   })

--- a/static/src/js/components/DownloadHistory/DownloadHistory.tsx
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.tsx
@@ -58,7 +58,7 @@ export interface HistoryRetrieval {
   portalId: string
   /** The title of the retrieval */
   titles: string[]
-  //* * The date the retrieval was las updated */
+  /** The date the retrieval was las updated */
   updatedAt: string
 }
 interface HistoryRetrievalsQueryData {

--- a/static/src/js/components/DownloadHistory/DownloadHistory.tsx
+++ b/static/src/js/components/DownloadHistory/DownloadHistory.tsx
@@ -58,7 +58,7 @@ export interface HistoryRetrieval {
   portalId: string
   /** The title of the retrieval */
   titles: string[]
-  //* * The date the retrieval was las updated */
+  //** The date the retrieval was las updated */
   updatedAt: string
 }
 interface HistoryRetrievalsQueryData {

--- a/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
+++ b/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
@@ -86,7 +86,8 @@ describe('DownloadHistorys component', () => {
         id: 1,
         obfuscatedId: '8069076',
         portalId: 'edsc',
-        titles: ['title 1']
+        titles: ['title 1'],
+        updatedAt: '2019-09-09T11:58:14.390Z'
       }
 
       setup({
@@ -137,7 +138,8 @@ describe('DownloadHistorys component', () => {
         id: 1,
         obfuscatedId: '8069076',
         portalId: 'edsc',
-        titles: ['title 1', 'title 2', 'title 3']
+        titles: ['title 1', 'title 2', 'title 3'],
+        updatedAt: '2019-09-09T11:58:14.390Z'
       }
 
       setup({
@@ -180,6 +182,137 @@ describe('DownloadHistorys component', () => {
         }),
         {}
       )
+    })
+  })
+
+  test('renders a banner about a download retention', async () => {
+    const historyRetrieval = {
+      createdAt: '2019-08-25T11:58:14.390Z',
+      id: 1,
+      obfuscatedId: '8069076',
+      portalId: 'edsc',
+      titles: ['title 1'],
+      updatedAt: '2019-09-09T11:58:14.390Z'
+    }
+
+    setup({
+      overrideApolloClientMocks: [{
+        request: {
+          query: HISTORY_RETRIEVALS,
+          variables: {
+            limit: 20,
+            offset: 0
+          }
+        },
+        result: {
+          data: {
+            historyRetrievals: {
+              historyRetrievals: [historyRetrieval],
+              count: 1,
+              pageInfo: {
+                currentPage: 1,
+                hasNextPage: false,
+                hasPreviousPage: false,
+                pageCount: 1
+              }
+            }
+          }
+        }
+      }]
+    })
+
+    expect(await screen.findByText('Downloads that have not been updated in over a year will be removed')).toBeInTheDocument()
+  })
+
+  describe('when a retrieval is close to its removal date', () => {
+    test('displays a removal warning tooltip on hover', async () => {
+      const almostExipredDate = new Date()
+      almostExipredDate.setDate(almostExipredDate.getDate() - 360)
+
+      const historyRetrieval = {
+        createdAt: '2019-08-25T11:58:14.390Z',
+        id: 1,
+        obfuscatedId: '8069076',
+        portalId: 'edsc',
+        titles: ['title 1'],
+        updatedAt: almostExipredDate.toISOString()
+      }
+
+      const { user } = setup({
+        overrideApolloClientMocks: [{
+          request: {
+            query: HISTORY_RETRIEVALS,
+            variables: {
+              limit: 20,
+              offset: 0
+            }
+          },
+          result: {
+            data: {
+              historyRetrievals: {
+                historyRetrievals: [historyRetrieval],
+                count: 1,
+                pageInfo: {
+                  currentPage: 1,
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  pageCount: 1
+                }
+              }
+            }
+          }
+        }]
+      })
+
+      const icon = await screen.findByLabelText('Download Expiring Soon')
+
+      await user.hover(icon)
+
+      const tooltip = await screen.findByRole('tooltip')
+      expect(tooltip).toHaveTextContent('Download will be removed soon if not updated.')
+    })
+  })
+
+  describe('when a retrieval is not close to its removal date', () => {
+    test('does not display a removal warning', async () => {
+      const historyRetrieval = {
+        createdAt: '2019-08-25T11:58:14.390Z',
+        id: 1,
+        obfuscatedId: '8069076',
+        portalId: 'edsc',
+        titles: ['title 1'],
+        updatedAt: new Date().toISOString()
+      }
+
+      setup({
+        overrideApolloClientMocks: [{
+          request: {
+            query: HISTORY_RETRIEVALS,
+            variables: {
+              limit: 20,
+              offset: 0
+            }
+          },
+          result: {
+            data: {
+              historyRetrievals: {
+                historyRetrievals: [historyRetrieval],
+                count: 1,
+                pageInfo: {
+                  currentPage: 1,
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  pageCount: 1
+                }
+              }
+            }
+          }
+        }]
+      })
+
+      await screen.findByRole('link', { name: 'title 1' })
+
+      expect(screen.queryByLabelText('Download expiring soon')).not.toBeInTheDocument()
     })
   })
 

--- a/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
+++ b/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
@@ -221,7 +221,7 @@ describe('DownloadHistorys component', () => {
       }]
     })
 
-    expect(await screen.findByText('Downloads that have not been updated in over a year will be removed')).toBeInTheDocument()
+    expect(await screen.findByText('Downloads that have not been updated in over a year will be removed.')).toBeInTheDocument()
   })
 
   describe('when a retrieval is close to its removal date', () => {
@@ -264,7 +264,7 @@ describe('DownloadHistorys component', () => {
         }]
       })
 
-      const icon = await screen.findByLabelText('Download Expiring Soon')
+      const icon = await screen.findByLabelText('Download expiring soon')
 
       await user.hover(icon)
 

--- a/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
+++ b/static/src/js/components/DownloadHistory/__tests__/DownloadHistory.test.tsx
@@ -221,7 +221,7 @@ describe('DownloadHistorys component', () => {
       }]
     })
 
-    expect(await screen.findByText('Downloads that have not been updated in over a year will be removed.')).toBeInTheDocument()
+    expect(await screen.findByText('Downloads older than one year are automatically removed.')).toBeInTheDocument()
   })
 
   describe('when a retrieval is close to its removal date', () => {
@@ -269,7 +269,7 @@ describe('DownloadHistorys component', () => {
       await user.hover(icon)
 
       const tooltip = await screen.findByRole('tooltip')
-      expect(tooltip).toHaveTextContent('Download will be removed soon if not updated.')
+      expect(tooltip).toHaveTextContent('Download will be removed soon.')
     })
   })
 

--- a/static/src/js/operations/queries/historyRetrievals.ts
+++ b/static/src/js/operations/queries/historyRetrievals.ts
@@ -10,6 +10,7 @@ const HISTORY_RETRIEVALS = gql`
         obfuscatedId
         portalId
         titles
+        updatedAt
       }
       pageInfo {
         hasNextPage


### PR DESCRIPTION
# Overview

### What is the feature?

This adds an always-on banner to the `/downloads` route that notifies users that downloads will be removed after 1 year.  It also shows an icon and tooltip in the downloads table for any item that is within 30 days of deletion.

### What is the Solution?
added a 

### What areas of the application does this impact?

#### backend

- added `updatedAt` to the `HistoryRetrieval` GraphQL type
- updated `getHistoryRetrievals` in `databaseClient.js` to select and group by `retrievals.updated_at` so it is available for the resolver

#### frontend

- request that new `updatedAt` in the `HISTORY_RETRIEVALS`
- on /downloads:  show Alert banner notifying user of deletion after one year
- on /downloads: calculate "isExpiringSoon" and show icon & tooltip if item is within 30 days of expiration


# Testing


### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

<img width="1727" height="650" alt="Screenshot 2026-09-09 at 4 11 41 PM" src="https://github.com/user-attachments/assets/d85c51f5-23be-49fe-bc18-50fc804510a4" />
<img width="1725" height="610" alt="Screenshot 2026-09-09 at 4 11 09 PM" src="https://github.com/user-attachments/assets/4da78d36-f2af-4719-9226-985313e378cd" />
# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm audit fix` and made note of any changes in this PR
- [x] My changes generate no new warnings
